### PR TITLE
perf(ios): improve codeblock

### DIFF
--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
@@ -161,7 +161,7 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 }
 #endif
 
-- (void)setAttributedCode:(NSAttributedString *)attributedCode
+- (void)setAttributedCode:(nullable NSAttributedString *)attributedCode
 {
   _attributedCode = attributedCode;
   if (attributedCode.length == 0) {

--- a/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/views/ENRMCodeBlockContainerView.m
@@ -67,17 +67,32 @@ static NSAttributedString *ENRMCodeBlockPlainAttributedCode(NSString *code, Styl
   return attributed;
 }
 
-// Unwrapped code extent: width feeds the horizontal scroll, height the box
-// measurement. Width-independent since lines never wrap.
-static CGSize ENRMCodeBlockCodeSize(NSAttributedString *attributedCode)
+// Per-line height applied to the code text (see ENRMApplyCodeBlockTextAttributes):
+// when a code block line height is configured every line fragment is exactly that
+// tall; otherwise the font's natural line height is used.
+static CGFloat ENRMCodeBlockPerLineHeight(StyleConfig *config)
 {
-  if (attributedCode.length == 0) {
-    return CGSizeZero;
+  CGFloat lineHeight = [config codeBlockLineHeight];
+  return lineHeight > 0 ? lineHeight : ceil([config codeBlockFont].lineHeight);
+}
+
+// Analytic code height: lines never wrap and each fragment is a fixed height, so
+// the laid-out height is simply lineCount * perLineHeight. No text layout needed,
+// which is what boundingRectWithSize used to do on the whole block.
+static CGFloat ENRMCodeBlockCodeHeight(NSString *code, StyleConfig *config)
+{
+  if (code.length == 0) {
+    return 0;
   }
-  CGRect bounds = [attributedCode boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)
-                                               options:NSStringDrawingUsesLineFragmentOrigin
-                                               context:nil];
-  return CGSizeMake(ceil(bounds.size.width), ceil(bounds.size.height));
+  __block NSUInteger lineCount = 0;
+  [code enumerateSubstringsInRange:NSMakeRange(0, code.length)
+                           options:NSStringEnumerationByLines | NSStringEnumerationSubstringNotRequired
+                        usingBlock:^(NSString *_Nullable substring, NSRange substringRange, NSRange enclosingRange,
+                                     BOOL *stop) { lineCount++; }];
+  if (lineCount == 0) {
+    lineCount = 1;
+  }
+  return ceil(lineCount * ENRMCodeBlockPerLineHeight(config));
 }
 
 // Used only to pick the scroll indicator style for the code pane, so the
@@ -109,15 +124,30 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 
 // Scrollable code pane content. Draws the attributed code unwrapped at a
 // fixed origin; the hosting ENRMCodeBlockContainerView draws everything else.
+//
+// The TextKit stack (storage/layout manager/container) is built and laid out
+// once, when attributedCode is set, then cached: drawRect: only paints the
+// already-computed glyphs, so scrolling and redraws never re-lay-out. This is
+// the same rendering path drawAtPoint used internally, so output is identical,
+// but the layout is no longer thrown away on every draw. The container is
+// unbounded (lines never wrap) with zero line-fragment padding and font leading
+// disabled, matching the NSStringDrawing origin the block used before.
 @interface ENRMCodeBlockContentView : RCTUIView
 @property (nonatomic, strong, nullable) NSAttributedString *attributedCode;
 @property (nonatomic, assign) CGPoint textOrigin;
+// Laid-out content width, for the horizontal scroll extent. Free once the
+// cached stack exists; no separate measurement pass.
+@property (nonatomic, readonly) CGFloat usedWidth;
 #if TARGET_OS_OSX
 @property (nonatomic, copy, nullable) NSMenu * (^menuProvider)(void);
 #endif
 @end
 
-@implementation ENRMCodeBlockContentView
+@implementation ENRMCodeBlockContentView {
+  NSTextStorage *_textStorage;
+  NSLayoutManager *_layoutManager;
+  NSTextContainer *_textContainer;
+}
 
 #if TARGET_OS_OSX
 - (BOOL)isFlipped
@@ -131,11 +161,44 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 }
 #endif
 
+- (void)setAttributedCode:(NSAttributedString *)attributedCode
+{
+  _attributedCode = attributedCode;
+  if (attributedCode.length == 0) {
+    _textStorage = nil;
+    _layoutManager = nil;
+    _textContainer = nil;
+    return;
+  }
+  _textStorage = [[NSTextStorage alloc] initWithAttributedString:attributedCode];
+  _layoutManager = [[NSLayoutManager alloc] init];
+  _layoutManager.usesFontLeading = NO;
+  _textContainer = [[NSTextContainer alloc] initWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)];
+  _textContainer.lineFragmentPadding = 0;
+  _textContainer.maximumNumberOfLines = 0;
+  [_layoutManager addTextContainer:_textContainer];
+  [_textStorage addLayoutManager:_layoutManager];
+  [_layoutManager ensureLayoutForTextContainer:_textContainer];
+}
+
+- (CGFloat)usedWidth
+{
+  if (!_layoutManager) {
+    return 0;
+  }
+  return ceil([_layoutManager usedRectForTextContainer:_textContainer].size.width);
+}
+
 - (void)drawRect:(CGRect)rect
 {
-  if (self.attributedCode.length > 0) {
-    [self.attributedCode drawAtPoint:self.textOrigin];
+  if (!_layoutManager) {
+    return;
   }
+  // Only paint the glyphs intersecting the dirty rect; tall blocks skip their
+  // off-screen lines. The rect is in view space, the layout in container space.
+  CGRect boundingRect = CGRectOffset(rect, -self.textOrigin.x, -self.textOrigin.y);
+  NSRange glyphRange = [_layoutManager glyphRangeForBoundingRect:boundingRect inTextContainer:_textContainer];
+  [_layoutManager drawGlyphsForGlyphRange:glyphRange atPoint:self.textOrigin];
 }
 
 @end
@@ -346,8 +409,10 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
   NSAttributedString *highlighted =
       _pending ? nil : ENRMHighlightedAttributedCode(plainCode, _cachedCode, _cachedLanguage, _config);
   _attributedCode = highlighted ?: plainCode;
-  _codeSize = ENRMCodeBlockCodeSize(_attributedCode);
+  // Setting attributedCode builds and lays out the cached TextKit stack once;
+  // width then reads out of that layout, and height stays analytic.
   _codeContentView.attributedCode = _attributedCode;
+  _codeSize = CGSizeMake(_codeContentView.usedWidth, ENRMCodeBlockCodeHeight(_cachedCode, _config));
 }
 
 - (void)applyCodeBlockNode:(MarkdownASTNode *)node
@@ -413,8 +478,8 @@ static BOOL ENRMColorIsDark(RCTUIColor *color)
 {
   CGFloat inset = ENRMCodeBlockContentInset(config);
   CGFloat headerH = inset + ENRMCodeBlockHeaderLabelLineHeight(ENRMCodeBlockHeaderFont(config));
-  NSAttributedString *code = ENRMCodeBlockPlainAttributedCode(ENRMCodeBlockExtractCode(node), config);
-  return ENRMCodeBlockCodeSize(code).height + inset * 2 + headerH;
+  CGFloat codeHeight = ENRMCodeBlockCodeHeight(ENRMCodeBlockExtractCode(node), config);
+  return codeHeight + inset * 2 + headerH;
 }
 
 - (void)drawRect:(CGRect)rect


### PR DESCRIPTION
### What/Why?

Speeds up iOS code block rendering. Each fenced code block was being laid out from scratch multiple times per render: `boundingRectWithSize` for measurement and `drawAtPoint` for drawing each spin up a throwaway TextKit stack, lay out the whole block, then tear it down again on every `drawRect:` (scroll, redraw, streaming). tree-sitter parsing was never the bottleneck; the redundant layout was.

Two changes, both in `ENRMCodeBlockContainerView.m`:
1. **Analytic height.** Code never wraps and every line fragment is a fixed height (`codeBlockLineHeight`, or the font's natural line height), so the laid-out height is exactly `lineCount * perLineHeight`. This replaces `measureHeightForCodeBlockNode:` (height only) becomes essentially free.
2. **Cached TextKit stack, paint-only draw.** The content view builds and lays out its `NSTextStorage`/`NSLayoutManager`/`NSTextContainer` once, when the attributed code changes, then caches them. `drawRect:` only calls `drawGlyphsForGlyphRange:atPoint:` on the already-computed layout, clipped to the dirty rect so off-screen lines are skipped. Scroll/redraw/streaming no longer re-lay-out. Scroll content width falls out of `usedRectForTextContainer` for free, removing the separate width measurement pass. Same rendering engine `drawAtPoint` used internally, so output is pixel-identical.

**Measured gains** (iOS simulator; 4 code blocks ~15 lines each — js/python/ts/go - with text between, whole document remounted 10x; per-render = total phase time per full document render):

| phase              | baseline (ms) | after (ms) | change |
| -------------- | ------------- | ---------- | ------ |
| parse                | 3.72          | 2.66       | untouched (noise) |
| apply          | 0.20          | 0.17       | untouched (noise) |
| measure        | 7.41          | 1.72       | -77%   |
| draw           | 7.06          | 1.31       | -81%   |
| **measure+draw** | **14.47**   | **3.03**   | **-79%** |
| **total**      | **18.40**     | **5.87**   | **-68%** |

Additionaly the perf win should be even greater while streaming

### Testing

- Example app, code block screens: blocks render identically to before — same height, no vertical shift, long lines still scroll fully (checked the tab-indented Go block specifically, since width now comes from CoreText/TextKit layout rather than a full bounding-rect pass).
- Streaming: code blocks still render per-keystroke while open and pick up syntax highlighting on close.

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android 
- [ ] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)