### PR TITLE
feat(web): add a block store for the web input

### DIFF
--- a/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
@@ -8,6 +8,7 @@ import {
 } from '../model/blocks';
 import { adjustRangesForEdit } from './RangeEditAdjustment';
 import { sortedInsertionIndex } from './rangeStoreUtils';
+import { clamp } from '../utils';
 import type { RangeBounds } from '../model/rangeBounds';
 
 // Expands a selection to cover whole lines (line-scoped block boundaries).
@@ -20,8 +21,8 @@ export function paragraphBounds(
     return { start: 0, end: 0 };
   }
 
-  const clampedStart = Math.min(Math.max(rangeStart, 0), text.length);
-  const clampedEnd = Math.min(Math.max(rangeEnd, clampedStart), text.length);
+  const clampedStart = clamp(rangeStart, 0, text.length);
+  const clampedEnd = clamp(rangeEnd, clampedStart, text.length);
 
   let start = clampedStart;
   while (start > 0 && text[start - 1] !== '\n') {

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
@@ -4,6 +4,7 @@ import {
   type BlockRange,
   type BlockType,
 } from '../model/blocks';
+import { adjustRangesForEdit } from './RangeEditAdjustment';
 import { sortedInsertionIndex } from './rangeStoreUtils';
 import type { RangeBounds } from '../model/rangeBounds';
 
@@ -69,11 +70,8 @@ export class BlockStore {
     if (end < start || (end === start && !ANCHORED_BLOCK_TYPES.has(type))) {
       return;
     }
-    this.ranges.splice(
-      sortedInsertionIndex(this.ranges, start),
-      0,
-      createBlockRange(type, start, end, level)
-    );
+    const block = createBlockRange(type, start, end, level);
+    this.ranges.splice(sortedInsertionIndex(this.ranges, start), 0, block);
   }
 
   // Clears any block on the paragraphs the given range touches, reverting
@@ -100,6 +98,71 @@ export class BlockStore {
             block.start <= end)
         )
     );
+  }
+
+  // Shifts/clips block ranges to follow a text edit, with anchored-block
+  // persistence layered on top: a block deleted exactly to its end collapses
+  // to a zero-length anchor at the edit location (its line survives), and
+  // existing anchors shift/keep/drop with their line.
+  adjustForEdit(
+    editLocation: number,
+    deletedLength: number,
+    insertedLength: number
+  ): void {
+    if (deletedLength === 0 && insertedLength === 0) {
+      return;
+    }
+
+    const deleteEnd = editLocation + deletedLength;
+    const delta = insertedLength - deletedLength;
+
+    const anchors = this.ranges.filter(
+      (b) => b.end === b.start && ANCHORED_BLOCK_TYPES.has(b.type)
+    );
+    let ranges = this.ranges.filter((b) => b.end !== b.start);
+
+    // At most one range can end exactly at deleteEnd (blocks never overlap),
+    // so this restores at most one collapsed block.
+    const collapsed =
+      ranges.find(
+        (b) =>
+          ANCHORED_BLOCK_TYPES.has(b.type) &&
+          b.start >= editLocation &&
+          b.end === deleteEnd
+      ) ?? null;
+
+    ranges = adjustRangesForEdit(
+      ranges,
+      editLocation,
+      deletedLength,
+      insertedLength,
+      () => true,
+      () => true
+    );
+
+    for (const anchor of anchors) {
+      if (anchor.start <= editLocation) {
+        // Keeps its position.
+      } else if (anchor.start >= deleteEnd) {
+        anchor.start += delta;
+        anchor.end = anchor.start;
+      } else {
+        continue; // The anchor's line was deleted.
+      }
+      ranges.splice(sortedInsertionIndex(ranges, anchor.start), 0, anchor);
+    }
+
+    if (collapsed !== null && !ranges.includes(collapsed)) {
+      const anchor = createBlockRange(
+        collapsed.type,
+        editLocation,
+        editLocation,
+        collapsed.level
+      );
+      ranges.splice(sortedInsertionIndex(ranges, editLocation), 0, anchor);
+    }
+
+    this.ranges = ranges;
   }
 
   // Starts are unique (one block per paragraph), so a binary search finds the

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
@@ -87,6 +87,39 @@ export class BlockStore {
     this.removeBlocksOverlapping(start, end);
   }
 
+  // Snaps every stored range to the line bounds of its start position.
+  // Absorbs edge-typed chars, clips split ranges to their first line, drops
+  // duplicates. On an empty line an anchored block persists as a zero-length
+  // anchor; any other collapsed range is dropped. Call after adjustForEdit
+  // once `text` is final. Idempotent.
+  normalizeToLineBounds(text: string): void {
+    if (this.ranges.length === 0) {
+      return;
+    }
+
+    let previousEnd = -1;
+    this.ranges = this.ranges.filter((range) => {
+      const line = paragraphBounds(range.start, range.start, text);
+      const isEmptyLine = line.end === line.start;
+      if (
+        (isEmptyLine && !ANCHORED_BLOCK_TYPES.has(range.type)) ||
+        line.start <= previousEnd
+      ) {
+        // Dedup: drop a range that resolves to an already-claimed paragraph.
+        // This is a legitimate self-heal path (a heading anchor and the block
+        // it merges into can briefly share a start after a line-join), so it
+        // is deliberately silent.
+        return false;
+      }
+      range.start = line.start;
+      range.end = line.end;
+      previousEnd = line.end;
+      return true;
+    });
+
+    this.recomputeListMetadata();
+  }
+
   // Clamps list depths to valid ancestry (an item nests at most one level
   // under the previous adjacent list item — CommonMark cannot represent
   // orphan nesting) and renumbers ordered items among their adjacent

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
@@ -1,6 +1,8 @@
 import {
   ANCHORED_BLOCK_TYPES,
   createBlockRange,
+  LIST_ITEM_BLOCK_TYPES,
+  MAX_LIST_DEPTH,
   type BlockRange,
   type BlockType,
 } from '../model/blocks';
@@ -46,7 +48,7 @@ export class BlockStore {
   // parser owns that invariant.
   setRanges(newRanges: BlockRange[]): void {
     this.ranges = [...newRanges].sort((a, b) => a.start - b.start);
-    // TODO: recomputeListMetadata() once ported.
+    this.recomputeListMetadata();
   }
 
   clearAll(): void {
@@ -83,6 +85,53 @@ export class BlockStore {
   ): void {
     const { start, end } = paragraphBounds(paragraphStart, paragraphEnd, text);
     this.removeBlocksOverlapping(start, end);
+  }
+
+  // Clamps list depths to valid ancestry (an item nests at most one level
+  // under the previous adjacent list item — CommonMark cannot represent
+  // orphan nesting) and renumbers ordered items among their adjacent
+  // same-depth, same-type run.
+  private recomputeListMetadata(): void {
+    let prevEnd = -2;
+    let prevDepth = -1;
+    const counters = new Array<number>(MAX_LIST_DEPTH + 2).fill(0);
+    const counterTypes = new Array<BlockType | null>(MAX_LIST_DEPTH + 2).fill(
+      null
+    );
+
+    for (const range of this.ranges) {
+      if (!LIST_ITEM_BLOCK_TYPES.has(range.type)) {
+        prevDepth = -1;
+        continue;
+      }
+      const adjacent = prevDepth >= 0 && range.start === prevEnd + 1;
+      if (!adjacent) {
+        counters.fill(0);
+        counterTypes.fill(null);
+      }
+      // Coerce into [0, MAX_LIST_DEPTH] before ancestry-clamping: this pass
+      // indexes the counter arrays by depth, so an out-of-bounds level must
+      // never survive it.
+      const maxDepth = Math.min(adjacent ? prevDepth + 1 : 0, MAX_LIST_DEPTH);
+      if (range.level > maxDepth) {
+        range.level = maxDepth;
+      } else if (range.level < 0) {
+        range.level = 0;
+      }
+      const depth = range.level;
+      for (let i = depth + 1; i <= MAX_LIST_DEPTH + 1; i++) {
+        counters[i] = 0;
+        counterTypes[i] = null;
+      }
+      if (counterTypes[depth] !== range.type) {
+        counters[depth] = 0;
+        counterTypes[depth] = range.type;
+      }
+      counters[depth] = counters[depth]! + 1;
+      range.ordinal = counters[depth]!;
+      prevEnd = range.end;
+      prevDepth = range.level;
+    }
   }
 
   // Blocks never partially overlap, so a touched block is removed wholesale; a

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
@@ -1,0 +1,123 @@
+import {
+  ANCHORED_BLOCK_TYPES,
+  createBlockRange,
+  type BlockRange,
+  type BlockType,
+} from '../model/blocks';
+import { sortedInsertionIndex } from './rangeStoreUtils';
+import type { RangeBounds } from '../model/rangeBounds';
+
+// Expands a selection to cover whole lines (line-scoped block boundaries).
+export function paragraphBounds(
+  rangeStart: number,
+  rangeEnd: number,
+  text: string
+): RangeBounds {
+  if (text.length === 0) {
+    return { start: 0, end: 0 };
+  }
+
+  const clampedStart = Math.min(Math.max(rangeStart, 0), text.length);
+  const clampedEnd = Math.min(Math.max(rangeEnd, clampedStart), text.length);
+
+  let start = clampedStart;
+  while (start > 0 && text[start - 1] !== '\n') {
+    start--;
+  }
+  let end = clampedEnd;
+  while (end < text.length && text[end] !== '\n') {
+    end++;
+  }
+  return { start, end };
+}
+
+// Stores the block-level (line-scoped) ranges for the editor, mirroring
+// FormattingStore. Block ranges never overlap: at most one block covers any
+// paragraph, and ranges stay normalized to whole-line boundaries.
+export class BlockStore {
+  private ranges: BlockRange[] = [];
+
+  get allRanges(): BlockRange[] {
+    return [...this.ranges];
+  }
+
+  // Incoming ranges are trusted to be non-overlapping and line-scoped — the
+  // parser owns that invariant.
+  setRanges(newRanges: BlockRange[]): void {
+    this.ranges = [...newRanges].sort((a, b) => a.start - b.start);
+    // TODO: recomputeListMetadata() once ported.
+  }
+
+  clearAll(): void {
+    this.ranges = [];
+  }
+
+  // Sets/replaces the block on every paragraph the given range touches,
+  // expanding to whole-line boundaries. Removes any block previously covering
+  // those paragraphs.
+  setBlock(
+    type: BlockType,
+    level: number,
+    paragraphStart: number,
+    paragraphEnd: number,
+    text: string
+  ): void {
+    const { start, end } = paragraphBounds(paragraphStart, paragraphEnd, text);
+    this.removeBlocksOverlapping(start, end);
+    // An anchored block (heading, list item) on an empty line is kept as a
+    // zero-length anchor; other blocks need real content.
+    if (end < start || (end === start && !ANCHORED_BLOCK_TYPES.has(type))) {
+      return;
+    }
+    this.ranges.splice(
+      sortedInsertionIndex(this.ranges, start),
+      0,
+      createBlockRange(type, start, end, level)
+    );
+  }
+
+  // Clears any block on the paragraphs the given range touches, reverting
+  // them to the implicit paragraph default.
+  removeBlock(
+    paragraphStart: number,
+    paragraphEnd: number,
+    text: string
+  ): void {
+    const { start, end } = paragraphBounds(paragraphStart, paragraphEnd, text);
+    this.removeBlocksOverlapping(start, end);
+  }
+
+  // Blocks never partially overlap, so a touched block is removed wholesale; a
+  // zero-length anchor is dropped when it sits within the bounds (so
+  // toggle-off clears an empty line).
+  private removeBlocksOverlapping(start: number, end: number): void {
+    this.ranges = this.ranges.filter(
+      (block) =>
+        !(
+          (block.end > start && block.start < end) ||
+          (block.end === block.start &&
+            block.start >= start &&
+            block.start <= end)
+        )
+    );
+  }
+
+  // Starts are unique (one block per paragraph), so a binary search finds the
+  // block whose paragraph starts exactly at `lineStart`.
+  blockStartingAt(lineStart: number): BlockRange | null {
+    let lo = 0;
+    let hi = this.ranges.length - 1;
+    while (lo <= hi) {
+      const mid = Math.floor((lo + hi) / 2);
+      const start = this.ranges[mid]!.start;
+      if (start < lineStart) {
+        lo = mid + 1;
+      } else if (start > lineStart) {
+        hi = mid - 1;
+      } else {
+        return this.ranges[mid]!;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/BlockStore.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/BlockStore.test.ts
@@ -162,6 +162,57 @@ describe('BlockStore', () => {
     ]);
   });
 
+  it('numbers adjacent ordered items and restarts after a gap', () => {
+    // Lines are adjacent when the next start is prevEnd + 1 (the newline).
+    store.setRanges([
+      block('ordered-list-item', 0, 5),
+      block('ordered-list-item', 6, 11),
+      block('ordered-list-item', 13, 18), // gap: not adjacent
+    ]);
+
+    expect(store.allRanges.map((r) => r.ordinal)).toEqual([1, 2, 1]);
+  });
+
+  it('clamps depths to one level below the previous adjacent item', () => {
+    store.setRanges([
+      { ...block('ordered-list-item', 0, 5), level: 3 },
+      { ...block('ordered-list-item', 6, 11), level: 2 },
+      { ...block('ordered-list-item', 12, 17), level: 1 },
+    ]);
+
+    expect(store.allRanges.map((r) => r.level)).toEqual([0, 1, 1]);
+    expect(store.allRanges.map((r) => r.ordinal)).toEqual([1, 1, 2]);
+  });
+
+  it('restarts numbering on list-type change and after a non-list block', () => {
+    store.setRanges([
+      block('ordered-list-item', 0, 5),
+      block('unordered-list-item', 6, 11),
+      block('unordered-list-item', 12, 17),
+      block('ordered-list-item', 18, 23),
+    ]);
+    expect(store.allRanges.map((r) => r.ordinal)).toEqual([1, 1, 2, 1]);
+
+    store.setRanges([
+      block('ordered-list-item', 0, 5),
+      block('h1', 6, 11),
+      block('ordered-list-item', 12, 17),
+    ]);
+    expect(store.allRanges.map((r) => r.ordinal)).toEqual([1, 1, 1]);
+  });
+
+  it('resets deeper counters when the list returns to a shallower depth', () => {
+    store.setRanges([
+      { ...block('ordered-list-item', 0, 5), level: 0 },
+      { ...block('ordered-list-item', 6, 11), level: 1 },
+      { ...block('ordered-list-item', 12, 17), level: 0 },
+      { ...block('ordered-list-item', 18, 23), level: 1 },
+    ]);
+
+    // The second depth-1 run starts over at 1.
+    expect(store.allRanges.map((r) => r.ordinal)).toEqual([1, 1, 2, 1]);
+  });
+
   it('setRanges sorts incoming blocks by start', () => {
     store.setRanges([block('paragraph', 6, 11), block('h1', 0, 5)]);
 

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/BlockStore.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/BlockStore.test.ts
@@ -1,0 +1,113 @@
+import { BlockStore, paragraphBounds } from '../BlockStore';
+import { createBlockRange as block } from '../../model/blocks';
+
+// "The world\nis big\n\nend"
+//  0-8 line 1 | 10-15 line 2 | 17 empty | 18-20 line 3
+const text = 'The world\nis big\n\nend';
+
+describe('paragraphBounds', () => {
+  it('expands a position inside a line to the whole line', () => {
+    expect(paragraphBounds(4, 4, text)).toEqual({ start: 0, end: 9 });
+    expect(paragraphBounds(12, 14, text)).toEqual({ start: 10, end: 16 });
+  });
+
+  it('expands a selection spanning lines to both line bounds', () => {
+    expect(paragraphBounds(4, 12, text)).toEqual({ start: 0, end: 16 });
+  });
+
+  it('keeps line terminators outside the bounds', () => {
+    // A selection ending on the newline still resolves to line 1 only —
+    // the terminator belongs to no line.
+    expect(paragraphBounds(0, 9, text)).toEqual({ start: 0, end: 9 });
+  });
+
+  it('resolves an empty line to a zero-length range', () => {
+    expect(paragraphBounds(17, 17, text)).toEqual({ start: 17, end: 17 });
+  });
+
+  it('clamps out-of-range positions and handles empty text', () => {
+    expect(paragraphBounds(-5, 999, text)).toEqual({ start: 0, end: 21 });
+    expect(paragraphBounds(3, 3, '')).toEqual({ start: 0, end: 0 });
+  });
+});
+
+describe('BlockStore', () => {
+  let store: BlockStore;
+
+  beforeEach(() => {
+    store = new BlockStore();
+  });
+
+  it('blockStartingAt finds the block by its exact line start', () => {
+    store.setRanges([
+      block('h1', 0, 5),
+      block('paragraph', 6, 11),
+      block('unordered-list-item', 12, 17),
+    ]);
+
+    expect(store.blockStartingAt(6)).toEqual(block('paragraph', 6, 11));
+    expect(store.blockStartingAt(12)).toEqual(
+      block('unordered-list-item', 12, 17)
+    );
+    // Positions inside a line do not match — only exact starts do.
+    expect(store.blockStartingAt(7)).toBeNull();
+    expect(store.blockStartingAt(99)).toBeNull();
+  });
+
+  it('setBlock claims the whole line from a caret position', () => {
+    store.setBlock('h2', 2, 4, 4, text);
+
+    expect(store.allRanges).toEqual([{ ...block('h2', 0, 9), level: 2 }]);
+  });
+
+  it('setBlock replaces whatever block covered those lines', () => {
+    store.setRanges([block('h1', 0, 9), block('unordered-list-item', 10, 16)]);
+
+    store.setBlock('ordered-list-item', 0, 12, 12, text);
+
+    expect(store.allRanges).toEqual([
+      block('h1', 0, 9),
+      block('ordered-list-item', 10, 16),
+    ]);
+  });
+
+  it('setBlock on an empty line creates an anchor only for anchored types', () => {
+    store.setBlock('h1', 1, 17, 17, text);
+    expect(store.allRanges).toEqual([{ ...block('h1', 17, 17), level: 1 }]);
+
+    store.clearAll();
+    store.setBlock('paragraph', 0, 17, 17, text);
+    expect(store.allRanges).toEqual([]);
+  });
+
+  it('removeBlock clears blocks on every touched line, leaving neighbors', () => {
+    store.setRanges([
+      block('h1', 0, 9),
+      block('unordered-list-item', 10, 16),
+      block('h2', 18, 21),
+    ]);
+
+    // Caret in the middle of line 1 represents the whole line.
+    store.removeBlock(4, 4, text);
+
+    expect(store.allRanges).toEqual([
+      block('unordered-list-item', 10, 16),
+      block('h2', 18, 21),
+    ]);
+  });
+
+  it('removeBlock clears a zero-length anchor on an empty line', () => {
+    // Toggle-off on an empty heading: only the anchor exists there.
+    store.setRanges([block('h1', 0, 9), block('h2', 17, 17)]);
+
+    store.removeBlock(17, 17, text);
+
+    expect(store.allRanges).toEqual([block('h1', 0, 9)]);
+  });
+
+  it('setRanges sorts incoming blocks by start', () => {
+    store.setRanges([block('paragraph', 6, 11), block('h1', 0, 5)]);
+
+    expect(store.allRanges.map((r) => r.start)).toEqual([0, 6]);
+  });
+});

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/BlockStore.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/BlockStore.test.ts
@@ -105,6 +105,63 @@ describe('BlockStore', () => {
     expect(store.allRanges).toEqual([block('h1', 0, 9)]);
   });
 
+  it('adjustForEdit grows the edited block and shifts the following ones', () => {
+    store.setRanges([block('h2', 0, 6), block('ordered-list-item', 7, 12)]);
+
+    // Two chars typed inside the heading.
+    store.adjustForEdit(3, 0, 2);
+
+    expect(store.allRanges).toEqual([
+      block('h2', 0, 8),
+      block('ordered-list-item', 9, 14),
+    ]);
+  });
+
+  it('adjustForEdit absorbs a char typed at the line start into its block', () => {
+    store.setRanges([block('h2', 0, 6)]);
+
+    store.adjustForEdit(0, 0, 1);
+
+    expect(store.allRanges).toEqual([block('h2', 0, 7)]);
+  });
+
+  it('adjustForEdit keeps the block through a replacement of its content', () => {
+    // Autocorrect swaps the whole heading text for a same-length word.
+    store.setRanges([block('h2', 0, 6)]);
+
+    store.adjustForEdit(0, 6, 6);
+
+    expect(store.allRanges).toEqual([block('h2', 0, 6)]);
+  });
+
+  it('adjustForEdit collapses a block emptied exactly to its end into an anchor', () => {
+    store.setRanges([block('h2', 0, 6), block('ordered-list-item', 7, 12)]);
+
+    // The whole list item content deleted; its line (the newline) survives.
+    store.adjustForEdit(7, 5, 0);
+
+    expect(store.allRanges).toEqual([
+      block('h2', 0, 6),
+      block('ordered-list-item', 7, 7),
+    ]);
+  });
+
+  it('adjustForEdit keeps, shifts or drops anchors around the edit', () => {
+    store.setRanges([
+      block('h1', 0, 0),
+      block('unordered-list-item', 10, 10),
+      block('ordered-list-item', 20, 20),
+    ]);
+
+    // Replace chars 8-15 with two chars (delta -5).
+    store.adjustForEdit(8, 7, 2);
+
+    expect(store.allRanges).toEqual([
+      block('h1', 0, 0),
+      block('ordered-list-item', 15, 15),
+    ]);
+  });
+
   it('setRanges sorts incoming blocks by start', () => {
     store.setRanges([block('paragraph', 6, 11), block('h1', 0, 5)]);
 

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/BlockStore.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/BlockStore.test.ts
@@ -162,6 +162,41 @@ describe('BlockStore', () => {
     ]);
   });
 
+  it('normalizeToLineBounds snaps ranges to their full lines', () => {
+    // Math left the heading covering only part of line 1 and leaking a char.
+    store.setRanges([{ ...block('h2', 1, 5), level: 2 }]);
+
+    store.normalizeToLineBounds(text);
+
+    expect(store.allRanges).toEqual([{ ...block('h2', 0, 9), level: 2 }]);
+  });
+
+  it('normalizeToLineBounds clips a block split by a newline to its first line', () => {
+    // An Enter typed inside the heading stretched its range across two lines.
+    store.setRanges([block('h1', 0, 14)]);
+
+    store.normalizeToLineBounds(text);
+
+    expect(store.allRanges).toEqual([block('h1', 0, 9)]);
+  });
+
+  it('normalizeToLineBounds drops the duplicate after a line join', () => {
+    // Backspace joined two heading lines: both ranges resolve to line 1.
+    store.setRanges([block('h1', 0, 4), block('h2', 5, 9)]);
+
+    store.normalizeToLineBounds(text);
+
+    expect(store.allRanges).toEqual([block('h1', 0, 9)]);
+  });
+
+  it('normalizeToLineBounds keeps anchored empties and drops the rest', () => {
+    store.setRanges([block('h1', 17, 17), block('paragraph', 17, 17)]);
+
+    store.normalizeToLineBounds(text);
+
+    expect(store.allRanges).toEqual([block('h1', 17, 17)]);
+  });
+
   it('numbers adjacent ordered items and restarts after a gap', () => {
     // Lines are adjacent when the next start is prevEnd + 1 (the newline).
     store.setRanges([

--- a/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
@@ -1,0 +1,52 @@
+import type { RangeBounds } from './rangeBounds';
+
+// Block-level (line-scoped) element types. A block covers whole lines, unlike
+// inline styles which cover character ranges. Every line is a paragraph until
+// a block handler claims it.
+export type BlockType =
+  | 'paragraph'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'unordered-list-item'
+  | 'ordered-list-item';
+
+export const HEADING_BLOCK_TYPES = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+] as const;
+
+export const LIST_ITEM_BLOCK_TYPES: ReadonlySet<BlockType> = new Set([
+  'unordered-list-item',
+  'ordered-list-item',
+]);
+
+// Block types whose emptied line persists as a zero-length anchor (an emptied
+// heading stays a heading, an emptied list item keeps its marker).
+export const ANCHORED_BLOCK_TYPES: ReadonlySet<BlockType> = new Set([
+  ...HEADING_BLOCK_TYPES,
+  ...LIST_ITEM_BLOCK_TYPES,
+]);
+
+export function blockTypeForHeadingLevel(level: number): BlockType | null {
+  return HEADING_BLOCK_TYPES[level - 1] ?? null;
+}
+
+// Maximum bullet-list nesting depth (0-based), so indent can't run away.
+export const MAX_LIST_DEPTH = 5;
+
+// `level` is a generic payload: headings keep the H-level (1-6), list items
+// their nesting depth. `ordinal` is the 1-based position of an ordered list
+// item among adjacent siblings at the same depth, recomputed by the store.
+export interface BlockRange extends RangeBounds {
+  type: BlockType;
+  level: number;
+  ordinal: number;
+}

--- a/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
@@ -50,3 +50,12 @@ export interface BlockRange extends RangeBounds {
   level: number;
   ordinal: number;
 }
+
+export function createBlockRange(
+  type: BlockType,
+  start: number,
+  end: number,
+  level = 0
+): BlockRange {
+  return { type, start, end, level, ordinal: 1 };
+}

--- a/packages/react-native-enriched-markdown/src/web/input/utils.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/utils.ts
@@ -1,0 +1,4 @@
+// Kotlin's coerceIn: clamps `value` into [min, max].
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}


### PR DESCRIPTION
Second layer of the web `EnrichedMarkdownTextInput`. Line-scoped block ranges for headings and list items, ported from Kotlin `BlockStore.kt` and cross-checked against iOS.

- `paragraphBounds`, `setBlock`, `removeBlock`: caret expands to whole lines
- `adjustForEdit`: shared range math plus zero-length anchors on emptied lines
- `normalizeToLineBounds`: re-snaps ranges to lines after edits
- `recomputeListMetadata`: clamps list depths, renumbers ordinals (with iOS-only guards)

Tested with Jest. Stacked on #718.