### PR TITLE
feat(web): serialize the input model to markdown

### DIFF
--- a/packages/react-native-enriched-markdown/src/web/input/formatting/MarkdownSerializer.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/MarkdownSerializer.ts
@@ -1,0 +1,226 @@
+import { clamp, isWhitespace } from '../utils';
+import { LIST_ITEM_BLOCK_TYPES, type BlockRange } from '../model/blocks';
+import type { FormattingRange, InputStyleType } from '../model/inlineStyles';
+
+// Zero-width space used by the editor to anchor an empty bullet line; it is an
+// internal editing aid and must never appear in serialized markdown.
+export const ZWSP = '\u200B';
+// Single choke point for scrubbing the empty-line ZWSP anchor out of anything
+// bound for JS. Route new output paths through this rather than scattering
+// replace calls, so the anchor can never leak because one path forgot to strip.
+export function stripZwsp(text: string): string {
+  return text.replaceAll(ZWSP, '');
+}
+
+const OPENING_DELIMITERS: Record<InputStyleType, string> = {
+  strong: '**',
+  em: '*',
+  underline: '_',
+  strikethrough: '~~',
+  link: '[',
+  spoiler: '||',
+};
+
+function closingDelimiter(
+  type: InputStyleType,
+  url: string | undefined
+): string {
+  if (type === 'link') {
+    return `](${url ?? ''})`;
+  }
+  return OPENING_DELIMITERS[type];
+}
+
+// Lower value = outermost wrapper. Font styles wrap around structural styles.
+const NESTING_PRIORITY: Record<InputStyleType, number> = {
+  em: 0,
+  strong: 1,
+  underline: 2,
+  strikethrough: 3,
+  spoiler: 4,
+  link: 5,
+};
+
+interface BoundaryEvent {
+  position: number;
+  isOpening: boolean;
+  type: InputStyleType;
+  url: string | undefined;
+}
+
+function compareBoundaryEvents(a: BoundaryEvent, b: BoundaryEvent): number {
+  if (a.position !== b.position) {
+    return a.position - b.position;
+  }
+  // Closing events before opening events at the same position.
+  if (a.isOpening !== b.isOpening) {
+    return a.isOpening ? 1 : -1;
+  }
+  // Among openings: outer first (lower priority emitted first).
+  // Among closings: inner first (higher priority emitted first) — LIFO order.
+  return a.isOpening
+    ? NESTING_PRIORITY[a.type] - NESTING_PRIORITY[b.type]
+    : NESTING_PRIORITY[b.type] - NESTING_PRIORITY[a.type];
+}
+
+export function serializeInline(
+  text: string,
+  ranges: readonly FormattingRange[]
+): string {
+  if (ranges.length === 0) {
+    return text;
+  }
+
+  const events: BoundaryEvent[] = [];
+  for (const range of ranges) {
+    let start = clamp(range.start, 0, text.length);
+    let end = clamp(range.end, 0, text.length);
+    if (start >= end) {
+      continue;
+    }
+
+    // Trim leading/trailing whitespace so delimiters hug non-whitespace content.
+    while (start < end && isWhitespace(text.charAt(start))) {
+      start++;
+    }
+    while (end > start && isWhitespace(text.charAt(end - 1))) {
+      end--;
+    }
+    if (start >= end) {
+      continue;
+    }
+
+    events.push({
+      position: start,
+      isOpening: true,
+      type: range.type,
+      url: range.url,
+    });
+    events.push({
+      position: end,
+      isOpening: false,
+      type: range.type,
+      url: range.url,
+    });
+  }
+
+  events.sort(compareBoundaryEvents);
+
+  const markdown: string[] = [];
+  let lastPosition = 0;
+  for (const event of events) {
+    const position = Math.min(event.position, text.length);
+    if (position > lastPosition) {
+      markdown.push(text.slice(lastPosition, position));
+      lastPosition = position;
+    }
+    markdown.push(
+      event.isOpening
+        ? OPENING_DELIMITERS[event.type]
+        : closingDelimiter(event.type, event.url)
+    );
+  }
+  if (lastPosition < text.length) {
+    markdown.push(text.slice(lastPosition));
+  }
+
+  return markdown.join('');
+}
+
+// Block-aware serialization: serializes inline styles exactly as
+// serializeInline, then prepends each line's block prefix.
+// `blockPrefixProvider` is asked, per block range, for the markdown line
+// marker (e.g. "# ", "- "); returning "" leaves the line unprefixed. Any ZWSP
+// empty-line anchor is stripped so an empty bullet still serializes to a bare
+// line rather than "- \u200B".
+export function serialize(
+  text: string,
+  ranges: readonly FormattingRange[],
+  blockRanges: readonly BlockRange[],
+  blockPrefixProvider: (block: BlockRange) => string
+): string {
+  return stripZwsp(
+    serializeWithAnchors(text, ranges, blockRanges, blockPrefixProvider)
+  );
+}
+
+function serializeWithAnchors(
+  text: string,
+  ranges: readonly FormattingRange[],
+  blockRanges: readonly BlockRange[],
+  blockPrefixProvider: (block: BlockRange) => string
+): string {
+  const inlineMarkdown = serializeInline(text, ranges);
+  if (blockRanges.length === 0) {
+    return inlineMarkdown;
+  }
+
+  // Block prefixes attach per line. Inline serialization only inserts inline
+  // delimiters (never newlines), so the serialized output has the same line
+  // count as the plain text — we map a block's plain-text range to line
+  // indices and prefix the corresponding serialized lines. If the invariant
+  // ever breaks, prefixes would land on the wrong lines: log and fall back to
+  // inline-only output — a library must not crash the host app over lost
+  // block prefixes.
+  const plainLines = text.split('\n');
+  const markdownLines = inlineMarkdown.split('\n');
+  if (plainLines.length !== markdownLines.length) {
+    console.error(
+      `[MarkdownSerializer] Block serialization line-count invariant violated: plain=${plainLines.length} markdown=${markdownLines.length}`
+    );
+    return inlineMarkdown;
+  }
+
+  // Plain-text character offset at the start of each line.
+  const lineStartOffsets: number[] = [];
+  let runningOffset = 0;
+  for (const line of plainLines) {
+    lineStartOffsets.push(runningOffset);
+    runningOffset += line.length + 1; // +1 for the '\n' separator
+  }
+
+  for (const block of blockRanges) {
+    const prefix = blockPrefixProvider(block);
+    if (prefix === '') {
+      continue;
+    }
+
+    const isZeroLength = block.end === block.start;
+    const isListItem = LIST_ITEM_BLOCK_TYPES.has(block.type);
+    for (let lineIndex = 0; lineIndex < plainLines.length; lineIndex++) {
+      const lineStart = lineStartOffsets[lineIndex]!;
+      const lineEnd = lineStart + plainLines[lineIndex]!.length;
+      const overlaps = isZeroLength
+        ? lineStart === block.start
+        : lineEnd >= block.start && lineStart < block.end;
+      if (!overlaps) {
+        continue;
+      }
+      // A marker-only list line ("- " with no content) re-parses as a setext
+      // underline for the previous line; emit an empty list line bare. An
+      // empty "# " heading is valid ATX and keeps its prefix.
+      if (isListItem && stripZwsp(plainLines[lineIndex]!) === '') {
+        continue;
+      }
+      markdownLines[lineIndex] = prefix + markdownLines[lineIndex]!;
+    }
+  }
+
+  return markdownLines.join('\n');
+}
+
+// Default per-line markdown marker for a block, gathered from the native
+// block handlers. The three-space list indent is wide enough for ordered
+// markers; paragraphs carry no marker.
+export function markdownLinePrefix(block: BlockRange): string {
+  switch (block.type) {
+    case 'paragraph':
+      return '';
+    case 'unordered-list-item':
+      return '   '.repeat(Math.max(block.level, 0)) + '- ';
+    case 'ordered-list-item':
+      return '   '.repeat(Math.max(block.level, 0)) + `${block.ordinal}. `;
+    default:
+      return '#'.repeat(clamp(block.level, 1, 6)) + ' ';
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/MarkdownSerializer.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/MarkdownSerializer.ts
@@ -1,4 +1,4 @@
-import { clamp, isWhitespace } from '../utils';
+import { clamp, firstIndexReachingTarget, isWhitespace } from '../utils';
 import { LIST_ITEM_BLOCK_TYPES, type BlockRange } from '../model/blocks';
 import type { FormattingRange, InputStyleType } from '../model/inlineStyles';
 
@@ -171,11 +171,12 @@ function serializeWithAnchors(
     return inlineMarkdown;
   }
 
-  // Plain-text character offset at the start of each line.
   const lineStartOffsets: number[] = [];
+  const lineEndOffsets: number[] = [];
   let runningOffset = 0;
   for (const line of plainLines) {
     lineStartOffsets.push(runningOffset);
+    lineEndOffsets.push(runningOffset + line.length);
     runningOffset += line.length + 1; // +1 for the '\n' separator
   }
 
@@ -187,14 +188,21 @@ function serializeWithAnchors(
 
     const isZeroLength = block.end === block.start;
     const isListItem = LIST_ITEM_BLOCK_TYPES.has(block.type);
-    for (let lineIndex = 0; lineIndex < plainLines.length; lineIndex++) {
+    for (
+      let lineIndex = firstIndexReachingTarget(
+        block.start,
+        lineEndOffsets.length,
+        (index) => lineEndOffsets[index]!
+      );
+      lineIndex < plainLines.length;
+      lineIndex++
+    ) {
       const lineStart = lineStartOffsets[lineIndex]!;
-      const lineEnd = lineStart + plainLines[lineIndex]!.length;
       const overlaps = isZeroLength
         ? lineStart === block.start
-        : lineEnd >= block.start && lineStart < block.end;
+        : lineStart < block.end;
       if (!overlaps) {
-        continue;
+        break;
       }
       // A marker-only list line ("- " with no content) re-parses as a setext
       // underline for the previous line; emit an empty list line bare. An

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/MarkdownSerializer.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/__tests__/MarkdownSerializer.test.ts
@@ -1,0 +1,122 @@
+import {
+  markdownLinePrefix,
+  serialize,
+  serializeInline,
+  ZWSP,
+} from '../MarkdownSerializer';
+import { createBlockRange } from '../../model/blocks';
+import { createFormattingRange as range } from '../../model/inlineStyles';
+
+describe('serializeInline', () => {
+  it('wraps each style in its dialect delimiters', () => {
+    const text = 'The world is big';
+
+    expect(serializeInline(text, [range('strong', 4, 9)])).toBe(
+      'The **world** is big'
+    );
+    expect(serializeInline(text, [range('em', 4, 9)])).toBe(
+      'The *world* is big'
+    );
+    expect(serializeInline(text, [range('underline', 4, 9)])).toBe(
+      'The _world_ is big'
+    );
+    expect(serializeInline(text, [range('strikethrough', 4, 9)])).toBe(
+      'The ~~world~~ is big'
+    );
+    expect(serializeInline(text, [range('spoiler', 4, 9)])).toBe(
+      'The ||world|| is big'
+    );
+    expect(
+      serializeInline(text, [range('link', 4, 9, 'https://a.example')])
+    ).toBe('The [world](https://a.example) is big');
+  });
+
+  it('nests overlapping styles by priority, font styles outermost', () => {
+    const text = 'The world is big';
+
+    expect(
+      serializeInline(text, [range('spoiler', 4, 9), range('em', 4, 9)])
+    ).toBe('The *||world||* is big');
+    expect(
+      serializeInline(text, [
+        range('link', 4, 9, 'https://a.example'),
+        range('strong', 4, 9),
+      ])
+    ).toBe('The **[world](https://a.example)** is big');
+  });
+
+  it('trims delimiters to hug non-whitespace content', () => {
+    // The range covers " world " including both spaces.
+    expect(serializeInline('The world is big', [range('strong', 3, 10)])).toBe(
+      'The **world** is big'
+    );
+    // A whitespace-only range serializes no delimiters at all.
+    expect(serializeInline('a b', [range('strong', 1, 2)])).toBe('a b');
+  });
+
+  it('closes before opening at a shared boundary instead of nesting', () => {
+    // "ab" with bold on "a" and underline on "b" — adjacent, not nested.
+    expect(
+      serializeInline('ab', [range('strong', 0, 1), range('underline', 1, 2)])
+    ).toBe('**a**_b_');
+  });
+});
+
+const prefix = markdownLinePrefix;
+
+describe('serialize', () => {
+  const text = 'Rebase\nfetch\nmerge';
+
+  it('prefixes each block line with its marker', () => {
+    const blocks = [
+      createBlockRange('h2', 0, 6, 2),
+      createBlockRange('ordered-list-item', 7, 12),
+      { ...createBlockRange('ordered-list-item', 13, 18), ordinal: 2 },
+    ];
+
+    expect(serialize(text, [], blocks, prefix)).toBe(
+      '## Rebase\n1. fetch\n2. merge'
+    );
+  });
+
+  it('combines block prefixes with inline delimiters', () => {
+    const blocks = [createBlockRange('ordered-list-item', 7, 12)];
+    const bold = [{ type: 'strong' as const, start: 7, end: 12 }];
+
+    expect(serialize(text, bold, blocks, prefix)).toBe(
+      'Rebase\n1. **fetch**\nmerge'
+    );
+  });
+
+  it('prefixes an empty heading anchor but leaves an empty list item bare', () => {
+    const anchorText = `a\n${ZWSP}\nb`;
+
+    expect(
+      serialize(anchorText, [], [createBlockRange('h1', 2, 3, 1)], prefix)
+    ).toBe('a\n# \nb');
+    expect(
+      serialize(
+        anchorText,
+        [],
+        [createBlockRange('unordered-list-item', 2, 3)],
+        prefix
+      )
+    ).toBe('a\n\nb');
+  });
+});
+
+describe('markdownLinePrefix', () => {
+  it('builds heading, bullet and numbered markers with three-space nesting', () => {
+    expect(markdownLinePrefix(createBlockRange('h3', 0, 5, 3))).toBe('### ');
+    expect(markdownLinePrefix(createBlockRange('paragraph', 0, 5))).toBe('');
+    expect(
+      markdownLinePrefix(createBlockRange('unordered-list-item', 0, 5, 1))
+    ).toBe('   - ');
+    expect(
+      markdownLinePrefix({
+        ...createBlockRange('ordered-list-item', 0, 5, 2),
+        ordinal: 3,
+      })
+    ).toBe('      3. ');
+  });
+});

--- a/packages/react-native-enriched-markdown/src/web/input/utils.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/utils.ts
@@ -2,6 +2,24 @@ export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
+export function firstIndexReachingTarget(
+  target: number,
+  size: number,
+  valueAt: (index: number) => number
+): number {
+  let low = 0;
+  let high = size;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (valueAt(mid) < target) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+}
+
 export function isWhitespace(char: string): boolean {
   return /\s/.test(char);
 }

--- a/packages/react-native-enriched-markdown/src/web/input/utils.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/utils.ts
@@ -1,4 +1,7 @@
-// Kotlin's coerceIn: clamps `value` into [min, max].
 export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
+}
+
+export function isWhitespace(char: string): boolean {
+  return /\s/.test(char);
 }


### PR DESCRIPTION
Third layer of the web `EnrichedMarkdownTextInput`. Model to markdown export, ported from Kotlin `MarkdownSerializer.kt`.

- `serializeInline`: delimiters from sorted boundary events, fixed nesting priorities, whitespace trimming
- `serialize`: per-line block prefixes with a line-count invariant fallback
- empty list items serialize bare (setext hazard), ZWSP anchors stripped at one choke point

Tested with Jest. Stacked on #715.