### PR TITLE
fix(ios): accessibility path follows correct position in scroll view

### DIFF
--- a/packages/react-native-enriched-markdown/ios/utils/MarkdownAccessibilityElementBuilder.m
+++ b/packages/react-native-enriched-markdown/ios/utils/MarkdownAccessibilityElementBuilder.m
@@ -161,12 +161,7 @@ static const CGFloat kFocusRectPadding = 2.0;
   if (text.length > 0)
     element.accessibilityLabel = text;
 
-  UIBezierPath *path = [self accessibilityPathForRange:range inTextView:textView];
-  if (path) {
-    element.accessibilityPath = path;
-  } else {
-    element.accessibilityFrameInContainerSpace = [self frameForRange:range inTextView:textView container:container];
-  }
+  element.accessibilityFrameInContainerSpace = [self frameForRange:range inTextView:textView container:container];
 
   if (type == ElementTypeImage) {
     element.accessibilityTraits =
@@ -227,60 +222,6 @@ static const CGFloat kFocusRectPadding = 2.0;
   if (text.length == 0 || range.location >= text.length)
     return NSMakeRange(NSNotFound, 0);
   return NSMakeRange(range.location, MIN(range.length, text.length - range.location));
-}
-
-+ (NSArray<NSValue *> *)perLineRectsForGlyphRange:(NSRange)glyphRange inTextView:(UITextView *)textView
-{
-  NSLayoutManager *layoutManager = textView.layoutManager;
-  UIEdgeInsets insets = textView.textContainerInset;
-  NSMutableArray<NSValue *> *rects = [NSMutableArray array];
-
-  [layoutManager
-      enumerateLineFragmentsForGlyphRange:glyphRange
-                               usingBlock:^(CGRect lineRect, CGRect usedRect, NSTextContainer *textContainer,
-                                            NSRange lineGlyphRange, BOOL *stop) {
-                                 NSRange overlap = NSIntersectionRange(glyphRange, lineGlyphRange);
-                                 if (overlap.length == 0)
-                                   return;
-
-                                 CGFloat left = [layoutManager locationForGlyphAtIndex:overlap.location].x;
-                                 BOOL extendsToLineEnd = (NSMaxRange(overlap) == NSMaxRange(lineGlyphRange));
-                                 CGFloat right = extendsToLineEnd
-                                                     ? CGRectGetMaxX(usedRect)
-                                                     : [layoutManager locationForGlyphAtIndex:NSMaxRange(overlap)].x;
-
-                                 CGRect rect =
-                                     CGRectMake(left, CGRectGetMinY(usedRect), right - left, CGRectGetHeight(usedRect));
-                                 rect = CGRectInset(rect, -kFocusRectPadding, -kFocusRectPadding);
-                                 rect = CGRectOffset(rect, insets.left, insets.top);
-                                 [rects addObject:[NSValue valueWithCGRect:rect]];
-                               }];
-
-  return rects;
-}
-
-+ (UIBezierPath *)accessibilityPathForRange:(NSRange)range inTextView:(UITextView *)textView
-{
-  NSRange clamped = [self clampedRange:range forText:textView.attributedText.string];
-  if (clamped.location == NSNotFound)
-    return nil;
-
-  NSRange glyphRange = [textView.layoutManager glyphRangeForCharacterRange:clamped actualCharacterRange:NULL];
-  NSArray<NSValue *> *lineRects = [self perLineRectsForGlyphRange:glyphRange inTextView:textView];
-  if (lineRects.count <= 1)
-    return nil;
-
-  UIWindow *window = textView.window;
-  if (!window)
-    return nil;
-
-  id<UICoordinateSpace> screenSpace = window.screen.coordinateSpace;
-  UIBezierPath *path = [UIBezierPath bezierPath];
-  for (NSValue *value in lineRects) {
-    CGRect screenRect = [textView convertRect:CGRectIntegral(value.CGRectValue) toCoordinateSpace:screenSpace];
-    [path appendPath:[UIBezierPath bezierPathWithRect:screenRect]];
-  }
-  return path;
 }
 
 + (CGRect)frameForRange:(NSRange)range inTextView:(UITextView *)textView container:(id)container


### PR DESCRIPTION
### What/Why?
Fixes #696.

On iOS, VoiceOver drew the focus ring for EnrichedMarkdownText text at the wrong position (and failed to scroll to it) when the component was inside a ScrollView - e.g. a chat feed that appends messages.

Multi-line text ranges described their focus ring with an accessibilityPath in absolute screen coordinates, computed once and cached. Screen coordinates go stale the moment the ScrollView scrolls, so the ring pointed at the text's old position. This drops the screen-space path and describes every accessibility element with `accessibilityFrameInContainerSpace`, which UIKit re-projects to the screen on every query, so the geometry stays correct under scroll. (This matches the fix the reporter proposed.)

> Note: because of this change we changed paragraphs to be one block instead of block per line.

### Testing
- Ran the example app's Text screen (EnrichedMarkdownText inside a ScrollView with long, multi-line content) on iOS. With VoiceOver / Accessibility Inspector, scrolled the content and navigated between paragraphs: the focus ring now sits on the visible text and VoiceOver scrolls each element into view. Verified single-line paragraphs, links, images, and headings still focus correctly.

#### Screenshots

##### Before
https://github.com/user-attachments/assets/d9dce0ee-3453-42f8-86f5-d2dd6a62094a

##### After 
https://github.com/user-attachments/assets/c1d9dea9-d95c-41d0-8980-5125887cfc72

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

