### PR TITLE
ci(ios): run the package sync workflow only on manual dispatch

### DIFF
--- a/.github/workflows/sync-release-ios-package.yml
+++ b/.github/workflows/sync-release-ios-package.yml
@@ -1,14 +1,6 @@
 name: Sync and release iOS package
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'packages/enriched-markdown-ios/**'
-      - 'packages/core/cpp/md4c/**'
-      - 'packages/core/cpp/parser/**'
-      - '.gitignore'
-      - 'LICENSE'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Drop the push trigger from sync-release-ios-package.yml so the standalone repo is no longer synced automatically on every main push that touches the package; workflow_dispatch remains the only way to run it.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

