### PR TITLE
fix(android): remove the accessibility layout listener on detach

### DIFF
--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/accessibility/AccessibleMarkdownTextView.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/accessibility/AccessibleMarkdownTextView.kt
@@ -30,4 +30,14 @@ abstract class AccessibleMarkdownTextView
       super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
       accessibilityHelper.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
     }
+
+    override fun onDetachedFromWindow() {
+      // Before super, and here rather than in a ViewManager's
+      // onDropViewInstance: getViewTreeObserver() returns the WINDOW's observer
+      // only while the view is attached. Once detached it hands back the view's
+      // own floating observer, so a removal then would target the wrong
+      // observer and leave the listener on the window.
+      accessibilityHelper.cleanup()
+      super.onDetachedFromWindow()
+    }
   }

--- a/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper.kt
+++ b/packages/android-enriched-markdown/ui/src/main/java/com/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper.kt
@@ -83,6 +83,17 @@ class MarkdownAccessibilityHelper(
     observer.addOnGlobalLayoutListener(listener)
   }
 
+  /**
+   * Drops the pending global-layout listener, if any is still registered.
+   *
+   * Must run while the view is attached: `textView.viewTreeObserver` returns
+   * the window's observer only until detach, and the listener was merged into
+   * it from the view's floating observer when the view attached.
+   */
+  fun cleanup() {
+    removePendingLayoutListener()
+  }
+
   private fun removePendingLayoutListener() {
     val listener = pendingLayoutListener ?: return
     pendingLayoutListener = null

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/accessibility/AccessibleMarkdownTextView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/accessibility/AccessibleMarkdownTextView.kt
@@ -30,4 +30,14 @@ abstract class AccessibleMarkdownTextView
       super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
       accessibilityHelper.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
     }
+
+    override fun onDetachedFromWindow() {
+      // Before super, and here rather than in a ViewManager's
+      // onDropViewInstance: getViewTreeObserver() returns the WINDOW's observer
+      // only while the view is attached. Once detached it hands back the view's
+      // own floating observer, so a removal then would target the wrong
+      // observer and leave the listener on the window.
+      accessibilityHelper.cleanup()
+      super.onDetachedFromWindow()
+    }
   }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper.kt
@@ -91,6 +91,17 @@ class MarkdownAccessibilityHelper(
     observer.addOnGlobalLayoutListener(listener)
   }
 
+  /**
+   * Drops the pending global-layout listener, if any is still registered.
+   *
+   * Must run while the view is attached: `textView.viewTreeObserver` returns
+   * the window's observer only until detach, and the listener was merged into
+   * it from the view's floating observer when the view attached.
+   */
+  fun cleanup() {
+    removePendingLayoutListener()
+  }
+
   private fun removePendingLayoutListener() {
     val listener = pendingLayoutListener ?: return
     pendingLayoutListener = null


### PR DESCRIPTION
### What/Why?

Fixes #730.

On Android, an `EnrichedMarkdownText` that is mounted and later unmounted retains its **entire
enclosing view hierarchy**, permanently. `MarkdownAccessibilityHelper` defers its TalkBack item
rebuild by registering a `ViewTreeObserver.OnGlobalLayoutListener`, and that listener is only ever
removed by its own callback:

https://github.com/software-mansion/enriched-markdown/blob/00423aa8110a7a69b26b0debb1844b3f7fa60541/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/accessibility/MarkdownAccessibilityHelper.kt#L78-L101

Three things make that leak once per instance:

1. **The deferred branch is the normal path.** The JS wrapper always sends resolved
   `accessibilityLabels`, so the `labels` setter calls `invalidateAccessibilityItems()` at
   prop-set time, when `textView.layout` is still `null`. Every instance registers a listener.
2. **The listener ends up on the window's observer.** At prop-set time the view is not attached,
   so `textView.viewTreeObserver` is the view's own *floating* observer;
   `View.dispatchAttachedToWindow` then merges it into `AttachInfo.mTreeObserver`, which belongs
   to `ViewRootImpl` and outlives every screen.
3. **Nothing else removes it.** `removePendingLayoutListener()` has exactly one caller, inside the
   listener. The immediate branch of `invalidateAccessibilityItems()` never clears a listener
   registered earlier, and neither detach nor `onDropViewInstance` does.

Result: `ViewRootImpl.mTreeObserver -> listener -> helper -> TextView -> mParent -> the whole
screen`.

`onDetachedFromWindow` is the right place for the removal specifically because
`getViewTreeObserver()` returns the window's observer only while the view is attached. Doing it
from `onDropViewInstance` would silently remove from the view's floating observer and leave the
leak untouched.

The cleanup goes in `AccessibleMarkdownTextView` rather than in `EnrichedMarkdownText`, because
that is where the helper is created, so `EnrichedMarkdownInternalText` (and with it the
`EnrichedMarkdown` component) is covered by the same change.

### Testing

Measured in a production app, on a **release** build with R8 enabled: Pixel 11 Pro, Android 16,
React Native 0.86.2 on the New Architecture, expo-router / react-native-screens navigation.
Six push/pop cycles of one screen, `Views` and `WebViews` read from `dumpsys meminfo`'s Objects
block after forcing a GC by backgrounding the app, two samples per reading:

| Six push/pop cycles | Views | WebViews |
| - | - | - |
| Before | 327 -> 1907 (+225/cycle) | 0 -> 7 |
| After | 327 -> **327** | 0 -> **0** |

The `WebViews` column is not a typo: an unrelated `WebView` elsewhere on the same screen was being
retained through the same chain, which is what makes this expensive rather than merely untidy. At
about 23 MB PSS per retained screen, this was the whole of a leak we had been chasing for two
weeks.

Two A/Bs isolate it to this component and this mechanism, same install and same content:

- Replacing the markdown component with a plain `<Text>` returns to baseline exactly.
- A component rendered with `markdown=""`, which returns from `setMarkdownContent` before
  `scheduleRender` and never parses or renders anything, leaks at the **identical** rate. That
  rules out the parser, the spans, `MeasurementStore` and the render executor, and points at
  construction and prop-set, which is where the listener is registered.

One incidental observation while measuring: the per-view `Executors.newSingleThreadExecutor()` in
`EnrichedMarkdownText` climbed about 4 threads per screen open before this change and goes flat
after it. That is a symptom rather than a second bug (the pool's `finalize()` shuts it down once
the view is collectable), but it does mean a retained view also costs a live thread.

### PR Checklist

- [ ] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

Being straight about the unticked boxes: the change is Kotlin-only and Android-only, and it was
built, run and measured in a real release app rather than in this repo's example app, so I have
not run the Maestro suites or an iOS build. I did not add an E2E test because the behaviour is not
user-visible - it is an object count in `dumpsys meminfo`, which Maestro cannot assert. Happy to
adjust the shape of this if you would rather the cleanup lived somewhere else, and happy to put
together a standalone reproduction repo if that would help.
