### PR TITLE
feat(web): render the input model into the editable dom

### DIFF
--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownStyle.web.ts
@@ -33,7 +33,7 @@ const baseHeader: {
   textAlign: 'auto',
 };
 
-const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
+export const DEFAULT_NORMALIZED_STYLE: MarkdownStyleInternal = Object.freeze({
   paragraph: {
     fontSize: 16,
     fontFamily: SYSTEM_FONT,

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownTextInputStyle.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownTextInputStyle.ts
@@ -53,10 +53,10 @@ interface MarkdownTextInputStyleInternal {
   };
 }
 
-const DEFAULT_LINK_COLOR = '#2563EB';
+export const DEFAULT_LINK_COLOR = '#2563EB';
 const DEFAULT_LINK_BG_COLOR = 'transparent';
-const DEFAULT_SPOILER_COLOR = '#374151';
-const DEFAULT_SPOILER_BG_COLOR = '#E5E7EB';
+export const DEFAULT_SPOILER_COLOR = '#374151';
+export const DEFAULT_SPOILER_BG_COLOR = '#E5E7EB';
 
 // Defaults shared with the read-only renderer via headingDefaults; consumers
 // override per level via markdownStyle h1..h6.

--- a/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
@@ -42,6 +42,10 @@ export function blockTypeForHeadingLevel(level: number): BlockType | null {
 // Maximum bullet-list nesting depth (0-based), so indent can't run away.
 export const MAX_LIST_DEPTH = 5;
 
+// A list line at depth d is indented (d + 1) * LIST_INDENT_PER_DEPTH px and
+// its marker draws in the last slot (mirrors kENRMListIndentPerDepth).
+export const LIST_INDENT_PER_DEPTH = 18;
+
 // `level` is a generic payload: headings keep the H-level (1-6), list items
 // their nesting depth. `ordinal` is the 1-based position of an ordered list
 // item among adjacent siblings at the same depth, recomputed by the store.

--- a/packages/react-native-enriched-markdown/src/web/input/render/DomRenderer.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/DomRenderer.ts
@@ -1,0 +1,228 @@
+import { LIST_ITEM_BLOCK_TYPES } from '../model/blocks';
+import type { ParagraphProjection, StyleRun } from './InputProjection';
+
+// Writes the projection into the contentEditable DOM. The caret and IME sit
+// in these nodes, so existing nodes are mutated rather than replaced; nodes
+// are added or removed only when the paragraph/run structure changes.
+export class DomRenderer {
+  private readonly root: HTMLElement;
+  private renderedText = '';
+  private renderedParagraphs: readonly ParagraphProjection[] = [];
+
+  constructor(root: HTMLElement) {
+    this.root = root;
+    // A fresh renderer has rendered nothing; the root must reflect that.
+    this.root.replaceChildren();
+  }
+
+  render(text: string, paragraphs: readonly ParagraphProjection[]): void {
+    const document = this.root.ownerDocument;
+    const { start, stalePairs, freshPairs } = changedWindow(
+      this.renderedText,
+      this.renderedParagraphs,
+      text,
+      paragraphs
+    );
+    const patched = Math.min(stalePairs, freshPairs);
+    const removed = stalePairs - patched;
+    const inserted = freshPairs - patched;
+
+    for (let i = 0; i < patched; i++) {
+      patchParagraph(
+        document,
+        this.root.childNodes[start + i] as HTMLElement,
+        text,
+        paragraphs[start + i]!
+      );
+    }
+    for (let i = 0; i < removed; i++) {
+      this.root.childNodes[start + patched]!.remove();
+    }
+    const suffixAnchor = this.root.childNodes[start + patched] ?? null;
+    for (let i = 0; i < inserted; i++) {
+      this.root.insertBefore(
+        createParagraph(document, text, paragraphs[start + patched + i]!),
+        suffixAnchor
+      );
+    }
+
+    this.renderedText = text;
+    this.renderedParagraphs = [...paragraphs];
+  }
+}
+
+// An edit changes one contiguous window of paragraphs. Pairs the shared
+// prefix and suffix (by content, not offsets) and returns the window between
+// them: where it starts and how many old/new paragraphs fall inside.
+function changedWindow(
+  previousText: string,
+  previous: readonly ParagraphProjection[],
+  text: string,
+  next: readonly ParagraphProjection[]
+): { start: number; stalePairs: number; freshPairs: number } {
+  const maxShared = Math.min(previous.length, next.length);
+
+  let prefix = 0;
+  while (
+    prefix < maxShared &&
+    sameParagraph(previousText, previous[prefix]!, text, next[prefix]!)
+  ) {
+    prefix++;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < maxShared - prefix &&
+    sameParagraph(
+      previousText,
+      previous[previous.length - 1 - suffix]!,
+      text,
+      next[next.length - 1 - suffix]!
+    )
+  ) {
+    suffix++;
+  }
+
+  return {
+    start: prefix,
+    stalePairs: previous.length - prefix - suffix,
+    freshPairs: next.length - prefix - suffix,
+  };
+}
+
+function sameParagraph(
+  previousText: string,
+  previous: ParagraphProjection,
+  text: string,
+  next: ParagraphProjection
+): boolean {
+  return (
+    previous.blockType === next.blockType &&
+    previous.level === next.level &&
+    previous.ordinal === next.ordinal &&
+    previous.runs.length === next.runs.length &&
+    previous.runs.every((run, i) =>
+      sameRun(previousText, run, text, next.runs[i]!)
+    )
+  );
+}
+
+function sameRun(
+  previousText: string,
+  previous: StyleRun,
+  text: string,
+  next: StyleRun
+): boolean {
+  return (
+    classNameFor(previous.styles) === classNameFor(next.styles) &&
+    previous.url === next.url &&
+    previousText.slice(previous.start, previous.end) ===
+      text.slice(next.start, next.end)
+  );
+}
+
+function classNameFor(styles: StyleRun['styles']): string {
+  return styles.map((style) => `enrm-${style}`).join(' ');
+}
+
+function createParagraph(
+  document: Document,
+  text: string,
+  paragraph: ParagraphProjection
+): HTMLElement {
+  const element = document.createElement('div');
+  patchParagraph(document, element, text, paragraph);
+  return element;
+}
+
+function patchParagraph(
+  document: Document,
+  element: HTMLElement,
+  text: string,
+  paragraph: ParagraphProjection
+): void {
+  patchBlockAttributes(element, paragraph);
+
+  if (paragraph.runs.length === 0) {
+    // The <br> gives an empty paragraph height and a caret spot.
+    if (
+      element.childNodes.length !== 1 ||
+      element.firstChild!.nodeName !== 'BR'
+    ) {
+      element.replaceChildren(document.createElement('br'));
+    }
+    return;
+  }
+
+  if (element.firstChild?.nodeName === 'BR') {
+    element.firstChild.remove();
+  }
+  while (element.childNodes.length > paragraph.runs.length) {
+    element.lastChild!.remove();
+  }
+  paragraph.runs.forEach((run, index) => {
+    const existing = element.childNodes[index];
+    if (existing === undefined) {
+      element.appendChild(createRun(document, text, run));
+    } else {
+      patchRun(existing as HTMLElement, text, run);
+    }
+  });
+}
+
+function patchBlockAttributes(
+  element: HTMLElement,
+  paragraph: ParagraphProjection
+): void {
+  const isListItem = LIST_ITEM_BLOCK_TYPES.has(paragraph.blockType);
+  setData(
+    element,
+    'block',
+    paragraph.blockType === 'paragraph' ? undefined : paragraph.blockType
+  );
+  setData(element, 'depth', isListItem ? String(paragraph.level) : undefined);
+  setData(
+    element,
+    'ordinal',
+    paragraph.blockType === 'ordered-list-item'
+      ? String(paragraph.ordinal)
+      : undefined
+  );
+}
+
+function setData(
+  element: HTMLElement,
+  key: string,
+  value: string | undefined
+): void {
+  if (value === undefined) {
+    if (element.dataset[key] !== undefined) delete element.dataset[key];
+  } else if (element.dataset[key] !== value) {
+    element.dataset[key] = value;
+  }
+}
+
+function createRun(
+  document: Document,
+  text: string,
+  run: StyleRun
+): HTMLElement {
+  const span = document.createElement('span');
+  span.appendChild(document.createTextNode(''));
+  patchRun(span, text, run);
+  return span;
+}
+
+function patchRun(span: HTMLElement, text: string, run: StyleRun): void {
+  const className = classNameFor(run.styles);
+  if (span.className !== className) {
+    span.className = className;
+  }
+  setData(span, 'url', run.url);
+
+  const content = text.slice(run.start, run.end);
+  const textNode = span.firstChild as Text;
+  if (textNode.nodeValue !== content) {
+    textNode.nodeValue = content;
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/render/InputProjection.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/InputProjection.ts
@@ -1,0 +1,127 @@
+import type { FormattingRange, InputStyleType } from '../model/inlineStyles';
+import type { RangeBounds } from '../model/rangeBounds';
+import { clamp } from '../utils';
+
+// Canonical order for a run's style list, so equal style sets compare equal.
+const STYLE_ORDER: readonly InputStyleType[] = [
+  'strong',
+  'em',
+  'underline',
+  'strikethrough',
+  'link',
+  'spoiler',
+];
+
+// A maximal segment of text with one constant style set; renders as one
+// DOM element.
+export interface StyleRun extends RangeBounds {
+  styles: InputStyleType[];
+  url?: string;
+}
+
+function sameRunStyle(run: StyleRun, styles: InputStyleType[], url?: string) {
+  return (
+    run.url === url &&
+    run.styles.length === styles.length &&
+    run.styles.every((style, i) => style === styles[i])
+  );
+}
+
+interface BoundaryEvent {
+  position: number;
+  isOpening: boolean;
+  type: InputStyleType;
+  url: string | undefined;
+}
+
+function compareBoundaryEvents(a: BoundaryEvent, b: BoundaryEvent): number {
+  if (a.position !== b.position) {
+    return a.position - b.position;
+  }
+  // Closings before openings at the same position.
+  if (a.isOpening !== b.isOpening) {
+    return a.isOpening ? 1 : -1;
+  }
+  return 0;
+}
+
+// Flattens overlapping formatting ranges over [start, end) into disjoint
+// runs — DOM elements cannot partially overlap.
+export function computeStyleRuns(
+  ranges: readonly FormattingRange[],
+  start: number,
+  end: number
+): StyleRun[] {
+  if (end <= start) return [];
+
+  const events: BoundaryEvent[] = [];
+  for (const range of ranges) {
+    const rangeStart = clamp(range.start, start, end);
+    const rangeEnd = clamp(range.end, start, end);
+    if (rangeStart >= rangeEnd) continue;
+
+    events.push({
+      position: rangeStart,
+      isOpening: true,
+      type: range.type,
+      url: range.url,
+    });
+    events.push({
+      position: rangeEnd,
+      isOpening: false,
+      type: range.type,
+      url: range.url,
+    });
+  }
+  if (events.length === 0) {
+    return [{ start, end, styles: [] }];
+  }
+
+  events.sort(compareBoundaryEvents);
+
+  // Counts, not booleans: overlapping ranges of one type stay active until
+  // all close.
+  const activeCounts = new Map<InputStyleType, number>();
+  const activeLinkUrls: (string | undefined)[] = [];
+  const runs: StyleRun[] = [];
+  let segmentStart = start;
+
+  const emitRunUpTo = (segmentEnd: number) => {
+    if (segmentEnd <= segmentStart) return;
+
+    const styles = STYLE_ORDER.filter(
+      (style) => (activeCounts.get(style) ?? 0) > 0
+    );
+    const url = activeLinkUrls[0];
+
+    const previous = runs[runs.length - 1];
+    if (previous && sameRunStyle(previous, styles, url)) {
+      previous.end = segmentEnd;
+    } else {
+      runs.push(
+        url === undefined
+          ? { start: segmentStart, end: segmentEnd, styles }
+          : { start: segmentStart, end: segmentEnd, styles, url }
+      );
+    }
+    segmentStart = segmentEnd;
+  };
+
+  for (const event of events) {
+    // Emit before applying: the current state styles the text up to here.
+    emitRunUpTo(event.position);
+
+    const count = activeCounts.get(event.type) ?? 0;
+    activeCounts.set(event.type, count + (event.isOpening ? 1 : -1));
+    if (event.type === 'link') {
+      if (event.isOpening) {
+        activeLinkUrls.push(event.url);
+      } else {
+        activeLinkUrls.splice(activeLinkUrls.indexOf(event.url), 1);
+      }
+    }
+  }
+  emitRunUpTo(end);
+
+  return runs;
+}

--- a/packages/react-native-enriched-markdown/src/web/input/render/InputProjection.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/InputProjection.ts
@@ -1,3 +1,4 @@
+import type { BlockRange, BlockType } from '../model/blocks';
 import type { FormattingRange, InputStyleType } from '../model/inlineStyles';
 import type { RangeBounds } from '../model/rangeBounds';
 import { clamp } from '../utils';
@@ -124,4 +125,74 @@ export function computeStyleRuns(
   emitRunUpTo(end);
 
   return runs;
+}
+
+// One buffer line with its block metadata and style runs.
+export interface ParagraphProjection extends RangeBounds {
+  blockType: BlockType;
+  level: number;
+  ordinal: number;
+  runs: StyleRun[];
+}
+
+// An emptied heading or list item keeps its block as a zero-length range
+// pinned to the line start.
+function isEmptyAnchor(block: BlockRange): boolean {
+  return block.start === block.end;
+}
+
+function blockEndsBeforeLine(block: BlockRange, lineStart: number): boolean {
+  return isEmptyAnchor(block)
+    ? block.start < lineStart
+    : block.end <= lineStart;
+}
+
+function blockCoversLine(
+  block: BlockRange,
+  lineStart: number,
+  lineEnd: number
+): boolean {
+  return isEmptyAnchor(block)
+    ? block.start === lineStart
+    : lineEnd >= block.start && lineStart < block.end;
+}
+
+// Splits the buffer into per-line paragraphs. Expects block ranges sorted
+// and line-normalized, as the store keeps them.
+export function projectParagraphs(
+  text: string,
+  formattingRanges: readonly FormattingRange[],
+  blockRanges: readonly BlockRange[]
+): ParagraphProjection[] {
+  const paragraphs: ParagraphProjection[] = [];
+  let blockIndex = 0;
+  let lineStart = 0;
+  for (const line of text.split('\n')) {
+    const lineEnd = lineStart + line.length;
+
+    // Both advance left to right, so one pointer suffices.
+    while (
+      blockIndex < blockRanges.length &&
+      blockEndsBeforeLine(blockRanges[blockIndex]!, lineStart)
+    ) {
+      blockIndex++;
+    }
+
+    const candidate = blockRanges[blockIndex];
+    const block =
+      candidate && blockCoversLine(candidate, lineStart, lineEnd)
+        ? candidate
+        : undefined;
+
+    paragraphs.push({
+      start: lineStart,
+      end: lineEnd,
+      blockType: block?.type ?? 'paragraph',
+      level: block?.level ?? 0,
+      ordinal: block?.ordinal ?? 1,
+      runs: computeStyleRuns(formattingRanges, lineStart, lineEnd),
+    });
+    lineStart = lineEnd + 1;
+  }
+  return paragraphs;
 }

--- a/packages/react-native-enriched-markdown/src/web/input/render/InputProjection.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/InputProjection.ts
@@ -166,6 +166,8 @@ export function projectParagraphs(
 ): ParagraphProjection[] {
   const paragraphs: ParagraphProjection[] = [];
   let blockIndex = 0;
+  let nextRange = 0;
+  let activeRanges: FormattingRange[] = [];
   let lineStart = 0;
   for (const line of text.split('\n')) {
     const lineEnd = lineStart + line.length;
@@ -176,6 +178,14 @@ export function projectParagraphs(
       blockEndsBeforeLine(blockRanges[blockIndex]!, lineStart)
     ) {
       blockIndex++;
+    }
+    activeRanges = activeRanges.filter((range) => range.end > lineStart);
+    while (
+      nextRange < formattingRanges.length &&
+      formattingRanges[nextRange]!.start < lineEnd
+    ) {
+      activeRanges.push(formattingRanges[nextRange]!);
+      nextRange++;
     }
 
     const candidate = blockRanges[blockIndex];
@@ -190,7 +200,7 @@ export function projectParagraphs(
       blockType: block?.type ?? 'paragraph',
       level: block?.level ?? 0,
       ordinal: block?.ordinal ?? 1,
-      runs: computeStyleRuns(formattingRanges, lineStart, lineEnd),
+      runs: computeStyleRuns(activeRanges, lineStart, lineEnd),
     });
     lineStart = lineEnd + 1;
   }

--- a/packages/react-native-enriched-markdown/src/web/input/render/__tests__/InputProjection.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/__tests__/InputProjection.test.ts
@@ -1,0 +1,75 @@
+import { computeStyleRuns } from '../InputProjection';
+import { createFormattingRange as range } from '../../model/inlineStyles';
+
+describe('computeStyleRuns', () => {
+  it('returns a single plain run when no ranges overlap the segment', () => {
+    expect(computeStyleRuns([], 0, 5)).toEqual([
+      { start: 0, end: 5, styles: [] },
+    ]);
+    expect(computeStyleRuns([range('strong', 10, 14)], 0, 5)).toEqual([
+      { start: 0, end: 5, styles: [] },
+    ]);
+  });
+
+  it('returns no runs for an empty segment', () => {
+    expect(computeStyleRuns([range('strong', 0, 4)], 3, 3)).toEqual([]);
+  });
+
+  it('cuts the text at every range boundary', () => {
+    // "the world is big": bold over "world is big", italic over "is".
+    const runs = computeStyleRuns(
+      [range('strong', 4, 16), range('em', 10, 12)],
+      0,
+      16
+    );
+    expect(runs).toEqual([
+      { start: 0, end: 4, styles: [] },
+      { start: 4, end: 10, styles: ['strong'] },
+      { start: 10, end: 12, styles: ['strong', 'em'] },
+      { start: 12, end: 16, styles: ['strong'] },
+    ]);
+  });
+
+  it('orders a run’s styles canonically regardless of range order', () => {
+    const runs = computeStyleRuns(
+      [range('em', 0, 4), range('strong', 0, 4)],
+      0,
+      4
+    );
+    expect(runs).toEqual([{ start: 0, end: 4, styles: ['strong', 'em'] }]);
+  });
+
+  it('merges adjacent runs with identical styles', () => {
+    const runs = computeStyleRuns(
+      [range('strong', 0, 3), range('strong', 3, 6)],
+      0,
+      6
+    );
+    expect(runs).toEqual([{ start: 0, end: 6, styles: ['strong'] }]);
+  });
+
+  it('keeps adjacent links with different urls as separate runs', () => {
+    const runs = computeStyleRuns(
+      [
+        range('link', 0, 3, 'https://a.dev'),
+        range('link', 3, 6, 'https://b.dev'),
+      ],
+      0,
+      6
+    );
+    expect(runs).toEqual([
+      { start: 0, end: 3, styles: ['link'], url: 'https://a.dev' },
+      { start: 3, end: 6, styles: ['link'], url: 'https://b.dev' },
+    ]);
+  });
+
+  it('clips ranges to the segment bounds', () => {
+    const runs = computeStyleRuns([range('strong', 0, 20)], 5, 10);
+    expect(runs).toEqual([{ start: 5, end: 10, styles: ['strong'] }]);
+  });
+
+  it('ignores zero-length ranges', () => {
+    const runs = computeStyleRuns([range('strong', 2, 2)], 0, 5);
+    expect(runs).toEqual([{ start: 0, end: 5, styles: [] }]);
+  });
+});

--- a/packages/react-native-enriched-markdown/src/web/input/render/__tests__/InputProjection.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/__tests__/InputProjection.test.ts
@@ -1,5 +1,6 @@
-import { computeStyleRuns } from '../InputProjection';
+import { computeStyleRuns, projectParagraphs } from '../InputProjection';
 import { createFormattingRange as range } from '../../model/inlineStyles';
+import { createBlockRange as block } from '../../model/blocks';
 
 describe('computeStyleRuns', () => {
   it('returns a single plain run when no ranges overlap the segment', () => {
@@ -71,5 +72,94 @@ describe('computeStyleRuns', () => {
   it('ignores zero-length ranges', () => {
     const runs = computeStyleRuns([range('strong', 2, 2)], 0, 5);
     expect(runs).toEqual([{ start: 0, end: 5, styles: [] }]);
+  });
+});
+
+describe('projectParagraphs', () => {
+  it('projects an empty document as a single empty paragraph', () => {
+    expect(projectParagraphs('', [], [])).toEqual([
+      {
+        start: 0,
+        end: 0,
+        blockType: 'paragraph',
+        level: 0,
+        ordinal: 1,
+        runs: [],
+      },
+    ]);
+  });
+
+  it('defaults unclaimed lines to paragraphs with plain runs', () => {
+    // "The world\nis big"
+    const paragraphs = projectParagraphs('The world\nis big', [], []);
+    expect(paragraphs).toEqual([
+      {
+        start: 0,
+        end: 9,
+        blockType: 'paragraph',
+        level: 0,
+        ordinal: 1,
+        runs: [{ start: 0, end: 9, styles: [] }],
+      },
+      {
+        start: 10,
+        end: 16,
+        blockType: 'paragraph',
+        level: 0,
+        ordinal: 1,
+        runs: [{ start: 10, end: 16, styles: [] }],
+      },
+    ]);
+  });
+
+  it('keeps the empty trailing paragraph after a final newline', () => {
+    const paragraphs = projectParagraphs('end\n', [], []);
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[1]).toEqual({
+      start: 4,
+      end: 4,
+      blockType: 'paragraph',
+      level: 0,
+      ordinal: 1,
+      runs: [],
+    });
+  });
+
+  it('resolves block metadata for claimed lines', () => {
+    // "Rebase\n- fetch\n- merge" with h1 + two list items.
+    const text = 'Rebase\nfetch\nmerge';
+    const blocks = [
+      block('h1', 0, 6, 1),
+      block('unordered-list-item', 7, 12, 0),
+      { ...block('ordered-list-item', 13, 18, 1), ordinal: 3 },
+    ];
+    const paragraphs = projectParagraphs(text, [], blocks);
+    expect(paragraphs.map((p) => [p.blockType, p.level, p.ordinal])).toEqual([
+      ['h1', 1, 1],
+      ['unordered-list-item', 0, 1],
+      ['ordered-list-item', 1, 3],
+    ]);
+  });
+
+  it('lets a zero-length anchor claim its empty line', () => {
+    // Emptied heading between two paragraphs.
+    const paragraphs = projectParagraphs('a\n\nb', [], [block('h2', 2, 2, 2)]);
+    expect(paragraphs.map((p) => p.blockType)).toEqual([
+      'paragraph',
+      'h2',
+      'paragraph',
+    ]);
+  });
+
+  it('computes runs per line, clipping ranges that span the newline', () => {
+    const paragraphs = projectParagraphs('ab\ncd', [range('strong', 1, 4)], []);
+    expect(paragraphs[0]!.runs).toEqual([
+      { start: 0, end: 1, styles: [] },
+      { start: 1, end: 2, styles: ['strong'] },
+    ]);
+    expect(paragraphs[1]!.runs).toEqual([
+      { start: 3, end: 4, styles: ['strong'] },
+      { start: 4, end: 5, styles: [] },
+    ]);
   });
 });

--- a/packages/react-native-enriched-markdown/src/web/input/render/inputStyles.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/inputStyles.ts
@@ -1,0 +1,92 @@
+import { DEFAULT_NORMALIZED_STYLE } from '../../../normalizeMarkdownStyle.web';
+import {
+  DEFAULT_LINK_COLOR,
+  DEFAULT_SPOILER_BG_COLOR,
+  DEFAULT_SPOILER_COLOR,
+} from '../../../normalizeMarkdownTextInputStyle';
+import { injectStyleOnce } from '../../injectStyle';
+import {
+  HEADING_BLOCK_TYPES,
+  LIST_INDENT_PER_DEPTH,
+  MAX_LIST_DEPTH,
+} from '../model/blocks';
+
+export const ENRM_INPUT_CLASS = 'enrm-input';
+
+const defaults = DEFAULT_NORMALIZED_STYLE;
+
+function headingRules(): string {
+  return HEADING_BLOCK_TYPES.map((level) => {
+    const { fontSize, lineHeight, color, fontWeight } = defaults[level];
+    return `.${ENRM_INPUT_CLASS} [data-block="${level}"] { font-size: ${fontSize}px; line-height: ${lineHeight}px; color: ${color}; font-weight: ${fontWeight}; }`;
+  }).join('\n');
+}
+
+function bulletShape(depth: number): string {
+  switch (depth % 3) {
+    case 0:
+      return 'background: currentColor; border-radius: 50%;';
+    case 1:
+      return 'border: 1px solid currentColor; border-radius: 50%;';
+    default:
+      return 'background: currentColor;';
+  }
+}
+
+function listRules(): string {
+  const rules: string[] = [];
+  for (let depth = 0; depth <= MAX_LIST_DEPTH; depth++) {
+    const indent = (depth + 1) * LIST_INDENT_PER_DEPTH;
+    const markerLeft = depth * LIST_INDENT_PER_DEPTH;
+    rules.push(
+      `.${ENRM_INPUT_CLASS} [data-depth="${depth}"] { padding-left: ${indent}px; }`,
+      `.${ENRM_INPUT_CLASS} [data-block="unordered-list-item"][data-depth="${depth}"]::before { left: ${markerLeft + 4}px; ${bulletShape(depth)} }`,
+      `.${ENRM_INPUT_CLASS} [data-block="ordered-list-item"][data-depth="${depth}"]::before { left: ${markerLeft}px; }`
+    );
+  }
+  return rules.join('\n');
+}
+
+const INPUT_CSS = `
+.${ENRM_INPUT_CLASS} {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  font-family: ${defaults.paragraph.fontFamily};
+  font-size: ${defaults.paragraph.fontSize}px;
+  line-height: ${defaults.paragraph.lineHeight}px;
+  color: ${defaults.paragraph.color};
+}
+.${ENRM_INPUT_CLASS} [data-block] {
+  position: relative;
+}
+.${ENRM_INPUT_CLASS} [data-block="unordered-list-item"]::before {
+  content: '';
+  position: absolute;
+  top: ${defaults.list.lineHeight / 2 - 3}px;
+  width: 6px;
+  height: 6px;
+  color: ${defaults.list.markerColor};
+}
+.${ENRM_INPUT_CLASS} [data-block="ordered-list-item"]::before {
+  content: attr(data-ordinal) '.';
+  position: absolute;
+  width: 14px;
+  text-align: right;
+  white-space: nowrap;
+  color: ${defaults.list.markerColor};
+  font-weight: ${defaults.list.markerFontWeight};
+}
+${headingRules()}
+${listRules()}
+.${ENRM_INPUT_CLASS} .enrm-strong { font-weight: bold; }
+.${ENRM_INPUT_CLASS} .enrm-em { font-style: italic; }
+.${ENRM_INPUT_CLASS} .enrm-underline { text-decoration: underline; }
+.${ENRM_INPUT_CLASS} .enrm-strikethrough { color: ${defaults.strikethrough.color}; text-decoration: line-through; }
+.${ENRM_INPUT_CLASS} .enrm-underline.enrm-strikethrough { text-decoration: underline line-through; }
+.${ENRM_INPUT_CLASS} .enrm-link { color: ${DEFAULT_LINK_COLOR}; text-decoration: underline; }
+.${ENRM_INPUT_CLASS} .enrm-spoiler { color: ${DEFAULT_SPOILER_COLOR}; background: ${DEFAULT_SPOILER_BG_COLOR}; border-radius: 4px; }
+`;
+
+export function injectInputStyles(): void {
+  injectStyleOnce('enrm-input-style', INPUT_CSS);
+}


### PR DESCRIPTION
Adds the renderer layer of the web input: the model (plain-text buffer + formatting and block ranges) is projected into paragraphs with style runs and written into the editable DOM with a minimal diff.

- `InputProjection`: `computeStyleRuns` flattens overlapping formatting ranges into disjoint runs (boundary-event sweep, same idiom as the serializer); `projectParagraphs` splits the buffer into per-line paragraphs with block metadata, with zero-length anchors claiming their line.
- `DomRenderer`: canonical DOM shape (one div per paragraph, one span per run, `<br>` in empty lines, links as spans with `data-url`). Updates mutate existing nodes in place (`nodeValue`, `className`) so the caret and IME are never disturbed, and a prefix/suffix window diff keeps a single edit down to a single DOM mutation.
- `inputStyles`: stylesheet generated from the shared defaults (`DEFAULT_NORMALIZED_STYLE`, the input style normalizer, heading and list constants from the model). List markers are drawn via `::before` from `data-depth`/`data-ordinal`, mirroring the native marker drawer. Base typography is a temporary stand-in until the `style` prop arrives with the JS API layer.

Jest unit tests cover the projection; the renderer will be exercised end to end by the Playwright flow tests arriving with the editing shell. Stacked on #727.