### PR TITLE
feat(ios): make enter not repaint text above the caret

### DIFF
--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputFormatter.mm
@@ -11,6 +11,54 @@
 #import "ENRMUnderlineStyleHandler.h"
 #import "ENRMUnorderedListBlockHandler.h"
 
+/// Sets `key` to `value` only on sub-runs whose value differs, recording each
+/// written range in `changed` so the caller can invalidate just what changed.
+static void ENRMSetAttributeIfChanged(NSMutableAttributedString *storage, NSAttributedStringKey key, id value,
+                                      NSRange range, NSMutableIndexSet *changed)
+{
+  if (range.length == 0) {
+    return;
+  }
+  NSMutableArray<NSValue *> *rangesToSet = [NSMutableArray array];
+  [storage enumerateAttribute:key
+                      inRange:range
+                      options:0
+                   usingBlock:^(id current, NSRange subRange, BOOL *stop) {
+                     BOOL equal = (current == value) || (current != nil && [current isEqual:value]);
+                     if (!equal) {
+                       [rangesToSet addObject:[NSValue valueWithRange:subRange]];
+                     }
+                   }];
+  for (NSValue *rangeValue in rangesToSet) {
+    NSRange subRange = rangeValue.rangeValue;
+    [storage addAttribute:key value:value range:subRange];
+    [changed addIndexesInRange:subRange];
+  }
+}
+
+/// Removes `key` only where present, recording cleared ranges in `changed`.
+static void ENRMRemoveAttributeIfPresent(NSMutableAttributedString *storage, NSAttributedStringKey key, NSRange range,
+                                         NSMutableIndexSet *changed)
+{
+  if (range.length == 0) {
+    return;
+  }
+  NSMutableArray<NSValue *> *rangesToClear = [NSMutableArray array];
+  [storage enumerateAttribute:key
+                      inRange:range
+                      options:0
+                   usingBlock:^(id current, NSRange subRange, BOOL *stop) {
+                     if (current != nil) {
+                       [rangesToClear addObject:[NSValue valueWithRange:subRange]];
+                     }
+                   }];
+  for (NSValue *rangeValue in rangesToClear) {
+    NSRange subRange = rangeValue.rangeValue;
+    [storage removeAttribute:key range:subRange];
+    [changed addIndexesInRange:subRange];
+  }
+}
+
 @implementation ENRMInputFormatter {
   NSDictionary<NSNumber *, id<ENRMStyleHandler>> *_styleHandlers;
   NSDictionary<NSNumber *, id<ENRMBlockHandler>> *_blockHandlers;
@@ -85,13 +133,17 @@
   NSRange scopeRange = NSMakeRange(scopeStart, scopeEnd - scopeStart);
   NSUInteger scopeLength = scopeRange.length;
 
+  // Diff every write and invalidate only what changed, so unchanged content in
+  // scope (e.g. a table below a plain-paragraph edit) is not re-laid out (#739).
+  NSMutableIndexSet *changed = [NSMutableIndexSet indexSet];
+
   [textStorage beginEditing];
 
-  [textStorage addAttribute:NSFontAttributeName value:style.baseFont range:scopeRange];
-  [textStorage addAttribute:NSForegroundColorAttributeName value:style.baseTextColor range:scopeRange];
-  [textStorage removeAttribute:NSUnderlineStyleAttributeName range:scopeRange];
-  [textStorage removeAttribute:NSStrikethroughStyleAttributeName range:scopeRange];
-  [textStorage removeAttribute:NSBackgroundColorAttributeName range:scopeRange];
+  // Reset to base; fonts are resolved per trait run below.
+  ENRMSetAttributeIfChanged(textStorage, NSForegroundColorAttributeName, style.baseTextColor, scopeRange, changed);
+  ENRMRemoveAttributeIfPresent(textStorage, NSUnderlineStyleAttributeName, scopeRange, changed);
+  ENRMRemoveAttributeIfPresent(textStorage, NSStrikethroughStyleAttributeName, scopeRange, changed);
+  ENRMRemoveAttributeIfPresent(textStorage, NSBackgroundColorAttributeName, scopeRange, changed);
 
   UIFontDescriptorSymbolicTraits *traitMap =
       (UIFontDescriptorSymbolicTraits *)calloc(scopeLength, sizeof(UIFontDescriptorSymbolicTraits));
@@ -126,21 +178,21 @@
       }
     }
 
+    // Handler writes are not diffed; mark the styled run changed to keep its invalidation.
     [handler applyNonFontAttributesToTextStorage:textStorage range:clipped formattingRange:formattingRange style:style];
+    [changed addIndexesInRange:clipped];
   }
 
+  // Resolve the final font per trait run (base or styled), diffed.
   NSUInteger runStart = 0;
   UIFontDescriptorSymbolicTraits currentTraits = traitMap[0];
 
   for (NSUInteger i = 1; i <= scopeLength; i++) {
     UIFontDescriptorSymbolicTraits nextTraits = (i < scopeLength) ? traitMap[i] : ~currentTraits;
     if (nextTraits != currentTraits) {
-      if (currentTraits != 0) {
-        UIFont *font = [style fontForTraits:currentTraits];
-        [textStorage addAttribute:NSFontAttributeName
-                            value:font
-                            range:NSMakeRange(scopeStart + runStart, i - runStart)];
-      }
+      UIFont *font = (currentTraits != 0) ? [style fontForTraits:currentTraits] : style.baseFont;
+      ENRMSetAttributeIfChanged(textStorage, NSFontAttributeName, font,
+                                NSMakeRange(scopeStart + runStart, i - runStart), changed);
       runStart = i;
       currentTraits = (i < scopeLength) ? traitMap[i] : 0;
     }
@@ -152,7 +204,11 @@
 
   NSLayoutManager *layoutManager = textStorage.layoutManagers.firstObject;
   if (layoutManager) {
-    [layoutManager invalidateLayoutForCharacterRange:scopeRange actualCharacterRange:NULL];
+    // Invalidate only changed ranges; ensureLayout over the scope only realizes
+    // already-dirty runs, so the inserted line still lays out.
+    [changed enumerateRangesUsingBlock:^(NSRange changedRange, BOOL *stop) {
+      [layoutManager invalidateLayoutForCharacterRange:changedRange actualCharacterRange:NULL];
+    }];
     [layoutManager ensureLayoutForCharacterRange:scopeRange];
   }
 

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -59,6 +59,7 @@ using namespace facebook::react;
 - (void)setupTextView;
 - (void)applyFormatting;
 - (void)applyFormattingScopedToEditAtLocation:(NSUInteger)editLocation insertedLength:(NSUInteger)insertedLength;
+- (void)applyFormattingScopedFromParagraphAtLocation:(NSUInteger)editLocation;
 - (void)toggleInlineStyle:(ENRMInputStyleType)styleType;
 - (void)resetBaseTypingAttributes;
 @end
@@ -819,6 +820,26 @@ static const NSTimeInterval kENRMAtomicSnapPollInterval = 0.1;
   NSUInteger rawEnd = MIN(editLocation + insertedLength, textLength);
   rawEnd = MAX(rawEnd, rawStart);
   NSRange scope = [plainText lineRangeForRange:NSMakeRange(rawStart, rawEnd - rawStart)];
+  [self applyFormattingScopedToRange:scope];
+}
+
+/// Newline variant: a newline can only restructure the paragraph it lands in and
+/// blocks below it, never content above. Scoping from the edit's paragraph start
+/// to the end of the text leaves paragraphs above untouched (issue #739). A
+/// backspace-merge is covered because editLocation lands at the merge point,
+/// whose paragraph range extends back over the joined previous line.
+- (void)applyFormattingScopedFromParagraphAtLocation:(NSUInteger)editLocation
+{
+  NSString *plainText = ENRMGetPlainText(_textView);
+  NSUInteger textLength = plainText.length;
+  if (textLength == 0) {
+    [self applyFormatting];
+    return;
+  }
+
+  NSUInteger location = MIN(editLocation, textLength);
+  NSRange paragraph = [plainText paragraphRangeForRange:NSMakeRange(location, 0)];
+  NSRange scope = NSMakeRange(paragraph.location, textLength - paragraph.location);
   [self applyFormattingScopedToRange:scope];
 }
 
@@ -1639,7 +1660,7 @@ static const NSTimeInterval kENRMAtomicSnapPollInterval = 0.1;
 #endif
 
   if (touchedNewline) {
-    [self applyFormatting];
+    [self applyFormattingScopedFromParagraphAtLocation:editLocation];
   } else {
     [self applyFormattingScopedToEditAtLocation:editLocation insertedLength:insertedLength];
   }

--- a/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
@@ -150,6 +150,11 @@ void ENRMApplyWritingDirectionToParagraphStyles(NSMutableAttributedString *outpu
                     if (!style) {
                       return;
                     }
+                    // Skip runs already in the target direction (issue #739),
+                    // mirroring ENRMApplyFirstStrongParagraphDirections.
+                    if (style.baseWritingDirection == writingDirection) {
+                      return;
+                    }
                     NSNumber *isCodeBlock = [output attribute:CodeBlockAttributeName
                                                       atIndex:range.location
                                                effectiveRange:nil];


### PR DESCRIPTION
### What/Why?

Fixes #739. On iOS, pressing Enter in `EnrichedMarkdownTextInput` repainted the text **above** the caret and made the input jump. On a newline the formatter re-formatted the whole document, so `endEditing` reported every paragraph as edited and TextKit re-laid them all out.

This PR:

- Narrows the newline reformat scope to `[edit's paragraph, end)` - a newline can't change block structure above the paragraph it lands in.
- Makes the inline pass diff-based: only attributes that actually change are written, and only those ranges are invalidated, so unchanged content in scope (e.g. a table below the edit) isn't re-laid out.
- Adds the missing "skip if unchanged" guard to the explicit writing-direction pass (`auto`/`ltr`/`rtl`).

Follow-up: the block pass (headings/lists) still re-applies over its scope, so a list/heading *below* an edit can still re-lay out; the reported case is fully fixed.

### Testing

> [!NOTE]
> The repaint is a one-frame re-layout that the iOS Simulator's compositing usually swallows, so it is not directly visible there. To demonstrate it, the videos use a temporary debug overlay (not part of this PR) that paints the ranges TextKit actually re-lays out in yellow. Before the fix, pressing Enter flashes the whole document (the heading above and the table below); after the fix, only the edited paragraph flashes.

Steps (Simulator, with the temporary yellow overlay):

1. Use an input with `scrollEnabled={false}` inside a `ScrollView`, so the whole document is on screen and the frame can grow.
2. Load:
   ```
   # Heading

   some text

   | a | b |
   | - | - |
   | 1 | 2 |
   ```
3. Put the caret at the end of `some text` and press Enter.
4. Before: the whole document flashes yellow (everything above and below re-lays out). After: only the edited paragraph flashes.

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/c70fef67-8c83-462d-a4e7-c1d0910e542b" width=300 /> | <video src="https://github.com/user-attachments/assets/98f70ff0-960b-48b6-ae63-bc1ae1d1f214" width=300 /> |


<details>
<summary>How to reproduce the yellow overlay yourself</summary>

The repaint itself is invisible on the Simulator, so to see what re-lays out you can temporarily paint the invalidated ranges. In `ENRMInputFormatter.mm`, inside `applyFormattingRanges:...scopedToRange:`, right after `[textStorage endEditing];` (where `changed` holds the ranges the inline pass actually rewrote), add:

```objc
if (changed.count > 0) {
  UIColor *flash = [UIColor colorWithRed:1.0 green:0.85 blue:0.2 alpha:0.55];
  [textStorage beginEditing];
  [changed enumerateRangesUsingBlock:^(NSRange r, BOOL *stop) {
    [textStorage addAttribute:NSBackgroundColorAttributeName value:flash range:r];
  }];
  [textStorage endEditing];
  NSIndexSet *flashed = [changed copy];
  __weak ENRMPlatformTextView *weak = textView;
  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
    NSTextStorage *s = weak.textStorage;
    if (!s) return;
    [s beginEditing];
    [flashed enumerateRangesUsingBlock:^(NSRange r, BOOL *stop) {
      NSRange b = NSIntersectionRange(r, NSMakeRange(0, s.length));
      if (b.length) [s removeAttribute:NSBackgroundColorAttributeName range:b];
    }];
    [s endEditing];
  });
}
```

`changed` is the set of ranges this PR actually rewrites, so on Enter only the edited paragraph flashes. To see the "before" behavior, run the same overlay on `main`, where the inline pass rewrites the whole scope - flash `scopeRange` instead of `changed` and the entire document lights up. Remove the block before committing.

</details>

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android <!-- no Android changes -->
- [ ] Updated documentation/README if applicable <!-- n/a -->
- [x] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
