### PR TITLE
feat(web): add the contentEditable input shell

### DIFF
--- a/packages/react-native-enriched-markdown/src/web/input/editing/EditPipeline.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/EditPipeline.ts
@@ -1,0 +1,68 @@
+import type { BlockStore } from '../formatting/BlockStore';
+import type { FormattingStore } from '../formatting/FormattingStore';
+import {
+  createFormattingRange,
+  type InputStyleType,
+} from '../model/inlineStyles';
+
+export interface EditContext {
+  editStart: number;
+  deletedText: string;
+  insertedText: string;
+  pendingStyles: readonly InputStyleType[];
+  pendingStyleRemovals: readonly InputStyleType[];
+}
+
+export class EditPipeline {
+  private readonly formattingStore: FormattingStore;
+  private readonly blockStore: BlockStore;
+
+  constructor(formattingStore: FormattingStore, blockStore: BlockStore) {
+    this.formattingStore = formattingStore;
+    this.blockStore = blockStore;
+  }
+
+  // `text` is the buffer after the edit. Returns whether a line boundary was
+  // touched, so the caller knows to re-render beyond the edited line.
+  processTextChange(text: string, context: EditContext): boolean {
+    const { editStart, deletedText, insertedText } = context;
+
+    this.formattingStore.adjustForEdit(
+      editStart,
+      deletedText.length,
+      insertedText.length
+    );
+    this.blockStore.adjustForEdit(
+      editStart,
+      deletedText.length,
+      insertedText.length
+    );
+    this.blockStore.normalizeToLineBounds(text);
+
+    if (insertedText.length > 0) {
+      this.applyPendingStyles(context);
+    }
+
+    return deletedText.includes('\n') || insertedText.includes('\n');
+  }
+
+  private applyPendingStyles(context: EditContext): void {
+    const { editStart, insertedText, pendingStyles, pendingStyleRemovals } =
+      context;
+    const insertEnd = editStart + insertedText.length;
+
+    // A newline-only insert gains no pending styles, but removals still
+    // apply to it, so a style cannot flow across the new line boundary.
+    const hasGlyphContent = /[^\n]/.test(insertedText);
+    if (hasGlyphContent) {
+      for (const type of pendingStyles) {
+        this.formattingStore.addRange(
+          createFormattingRange(type, editStart, insertEnd)
+        );
+      }
+    }
+    for (const type of pendingStyleRemovals) {
+      this.formattingStore.removeType(type, editStart, insertEnd);
+    }
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/EditSession.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/EditSession.ts
@@ -1,0 +1,60 @@
+export type EditPhase = 'idle' | 'processing' | 'formatting' | 'importing';
+
+const POST_EDIT_GRACE_PERIOD_MS = 100;
+
+// Tracks what our own code is currently doing, so handlers can tell a user
+// action from an echo of ours. Composition state lives alongside the phase:
+// it describes the browser's IME, not our code.
+export class EditSession {
+  isComposing = false;
+
+  private currentPhase: EditPhase = 'idle';
+  private lastTextChangeTime = 0;
+
+  get phase(): EditPhase {
+    return this.currentPhase;
+  }
+
+  enterPhase(phase: EditPhase): void {
+    this.currentPhase = phase;
+  }
+
+  exitPhase(): void {
+    this.currentPhase = 'idle';
+  }
+
+  scoped<T>(phase: EditPhase, block: () => T): T {
+    const previous = this.currentPhase;
+    this.currentPhase = phase;
+    try {
+      return block();
+    } finally {
+      this.currentPhase = previous;
+    }
+  }
+
+  recordTextChange(): void {
+    this.lastTextChangeTime = performance.now();
+  }
+
+  get isPostEditGracePeriod(): boolean {
+    return (
+      this.lastTextChangeTime > 0 &&
+      performance.now() - this.lastTextChangeTime < POST_EDIT_GRACE_PERIOD_MS
+    );
+  }
+
+  get shouldSuppressFormatting(): boolean {
+    return (
+      this.currentPhase === 'formatting' || this.currentPhase === 'importing'
+    );
+  }
+
+  get shouldSuppressEvents(): boolean {
+    return this.currentPhase === 'importing';
+  }
+
+  get shouldSuppressSelectionSideEffects(): boolean {
+    return this.currentPhase !== 'idle';
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -33,7 +33,7 @@ export class InputHost {
     this.callbacks = callbacks;
     this.pipeline = new EditPipeline(this.formattingStore, this.blockStore);
     this.renderer = new DomRenderer(root);
-    this.mapper = new SelectionMapper(root);
+    this.mapper = new SelectionMapper(root, () => this.renderer.paragraphs);
 
     injectInputStyles();
     root.classList.add(ENRM_INPUT_CLASS);

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -8,7 +8,7 @@ import { ENRM_INPUT_CLASS, injectInputStyles } from '../render/inputStyles';
 import { EditPipeline } from './EditPipeline';
 import { EditSession } from './EditSession';
 import { SelectionMapper } from './SelectionMapper';
-import { backwardStep, forwardStep } from '../utils';
+import { charLengthBefore, charLengthAfter } from '../utils';
 
 export interface InputHostCallbacks {
   onChangeText?: (text: string) => void;
@@ -169,7 +169,7 @@ export class InputHost {
     if (start === 0) {
       return;
     }
-    const deleteFrom = start - backwardStep(this.text, start);
+    const deleteFrom = start - charLengthBefore(this.text, start);
     this.applyEdit(deleteFrom, this.text.slice(deleteFrom, start), '');
   }
 
@@ -182,7 +182,7 @@ export class InputHost {
     if (end >= this.text.length) {
       return;
     }
-    const deleteTo = end + forwardStep(this.text, end);
+    const deleteTo = end + charLengthAfter(this.text, end);
     this.applyEdit(end, this.text.slice(end, deleteTo), '');
   }
 

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -1,0 +1,272 @@
+import { BlockStore } from '../formatting/BlockStore';
+import { FormattingStore } from '../formatting/FormattingStore';
+import { parseToPlainTextAndRanges } from '../formatting/InputParser';
+import type { RangeBounds } from '../model/rangeBounds';
+import { DomRenderer } from '../render/DomRenderer';
+import { projectParagraphs } from '../render/InputProjection';
+import { ENRM_INPUT_CLASS, injectInputStyles } from '../render/inputStyles';
+import { EditPipeline } from './EditPipeline';
+import { EditSession } from './EditSession';
+import { SelectionMapper } from './SelectionMapper';
+import { backwardStep, forwardStep } from '../utils';
+
+export interface InputHostCallbacks {
+  onChangeText?: (text: string) => void;
+  onChangeSelection?: (selection: RangeBounds) => void;
+}
+
+export class InputHost {
+  private readonly root: HTMLElement;
+  private readonly callbacks: InputHostCallbacks;
+  private readonly formattingStore = new FormattingStore();
+  private readonly blockStore = new BlockStore();
+  private readonly session = new EditSession();
+  private readonly pipeline: EditPipeline;
+  private readonly renderer: DomRenderer;
+  private readonly mapper: SelectionMapper;
+
+  private text = '';
+  private selection: RangeBounds = { start: 0, end: 0 };
+
+  constructor(root: HTMLElement, callbacks: InputHostCallbacks = {}) {
+    this.root = root;
+    this.callbacks = callbacks;
+    this.pipeline = new EditPipeline(this.formattingStore, this.blockStore);
+    this.renderer = new DomRenderer(root);
+    this.mapper = new SelectionMapper(root);
+
+    injectInputStyles();
+    root.classList.add(ENRM_INPUT_CLASS);
+    root.contentEditable = 'true';
+    root.setAttribute('role', 'textbox');
+    root.setAttribute('aria-multiline', 'true');
+    root.setAttribute('spellcheck', 'false');
+    root.setAttribute('data-gramm', 'false');
+    root.setAttribute('translate', 'no');
+
+    root.addEventListener('beforeinput', this.handleBeforeInput);
+    root.addEventListener('compositionstart', this.handleCompositionStart);
+    root.addEventListener('compositionend', this.handleCompositionEnd);
+    root.ownerDocument.addEventListener(
+      'selectionchange',
+      this.handleSelectionChange
+    );
+
+    this.render();
+  }
+
+  destroy(): void {
+    this.root.removeEventListener('beforeinput', this.handleBeforeInput);
+    this.root.removeEventListener(
+      'compositionstart',
+      this.handleCompositionStart
+    );
+    this.root.removeEventListener('compositionend', this.handleCompositionEnd);
+    this.root.ownerDocument.removeEventListener(
+      'selectionchange',
+      this.handleSelectionChange
+    );
+  }
+
+  get value(): string {
+    return this.text;
+  }
+
+  async setValue(markdown: string): Promise<void> {
+    const { plainText, formattingRanges, blockRanges } =
+      await parseToPlainTextAndRanges(markdown);
+
+    this.session.scoped('importing', () => {
+      this.text = plainText;
+      this.formattingStore.setRanges(formattingRanges);
+      this.blockStore.setRanges(blockRanges);
+      this.selection = { start: plainText.length, end: plainText.length };
+    });
+    this.render();
+    this.emitChanges();
+  }
+
+  private readonly handleBeforeInput = (event: InputEvent): void => {
+    // During composition the browser owns the DOM; the read-back step will
+    // reconcile it later.
+    if (this.session.isComposing) {
+      return;
+    }
+    // Default-deny: unhandled input types become no-ops, never native edits.
+    event.preventDefault();
+    this.syncSelectionFromDom();
+
+    switch (event.inputType) {
+      case 'insertText':
+        this.replaceSelection(event.data ?? '');
+        break;
+      case 'deleteContentBackward':
+        this.deleteBackward();
+        break;
+      case 'deleteContentForward':
+        this.deleteForward();
+        break;
+      default:
+        break;
+    }
+  };
+
+  private syncSelectionFromDom(): void {
+    const domSelection = this.root.ownerDocument.getSelection();
+    if (domSelection === null) {
+      return;
+    }
+    const mapped = this.mapper.modelSelectionFromDom(domSelection);
+    if (mapped !== null) {
+      this.selection = mapped;
+    }
+  }
+
+  private readonly handleCompositionStart = (): void => {
+    this.session.isComposing = true;
+  };
+
+  private readonly handleCompositionEnd = (): void => {
+    this.session.isComposing = false;
+  };
+
+  private readonly handleSelectionChange = (): void => {
+    if (
+      this.session.shouldSuppressSelectionSideEffects ||
+      this.session.isComposing
+    ) {
+      return;
+    }
+    const domSelection = this.root.ownerDocument.getSelection();
+    if (domSelection === null) {
+      return;
+    }
+    const mapped = this.mapper.modelSelectionFromDom(domSelection);
+    if (mapped === null) {
+      return;
+    }
+    if (
+      mapped.start === this.selection.start &&
+      mapped.end === this.selection.end
+    ) {
+      return;
+    }
+    this.selection = mapped;
+    this.callbacks.onChangeSelection?.(mapped);
+  };
+
+  private replaceSelection(insertedText: string): void {
+    const { start, end } = this.selection;
+    this.applyEdit(start, this.text.slice(start, end), insertedText);
+  }
+
+  private deleteBackward(): void {
+    const { start, end } = this.selection;
+    if (start !== end) {
+      this.replaceSelection('');
+      return;
+    }
+    if (start === 0) {
+      return;
+    }
+    const deleteFrom = start - backwardStep(this.text, start);
+    this.applyEdit(deleteFrom, this.text.slice(deleteFrom, start), '');
+  }
+
+  private deleteForward(): void {
+    const { start, end } = this.selection;
+    if (start !== end) {
+      this.replaceSelection('');
+      return;
+    }
+    if (end >= this.text.length) {
+      return;
+    }
+    const deleteTo = end + forwardStep(this.text, end);
+    this.applyEdit(end, this.text.slice(end, deleteTo), '');
+  }
+
+  // The native keystroke choreography: model phase, render phase, then
+  // events, in the iOS order.
+  private applyEdit(
+    editStart: number,
+    deletedText: string,
+    insertedText: string
+  ): void {
+    this.session.scoped('processing', () => {
+      this.text =
+        this.text.slice(0, editStart) +
+        insertedText +
+        this.text.slice(editStart + deletedText.length);
+      this.pipeline.processTextChange(this.text, {
+        editStart,
+        deletedText,
+        insertedText,
+        pendingStyles: [],
+        pendingStyleRemovals: [],
+      });
+      const caret = editStart + insertedText.length;
+      this.selection = { start: caret, end: caret };
+      this.session.recordTextChange();
+    });
+    this.render();
+    this.emitChanges();
+  }
+
+  private render(): void {
+    this.session.scoped('formatting', () => {
+      this.renderer.render(
+        this.text,
+        projectParagraphs(
+          this.text,
+          this.formattingStore.allRanges,
+          this.blockStore.allRanges
+        )
+      );
+      this.writeSelectionToDom();
+    });
+  }
+
+  private writeSelectionToDom(): void {
+    const document = this.root.ownerDocument;
+    if (!this.root.contains(document.activeElement)) {
+      return;
+    }
+    const domSelection = document.getSelection();
+    if (domSelection === null) {
+      return;
+    }
+    // Compare in model offsets: a boundary caret has two DOM addresses, so
+    // node identity would report false divergence on every render.
+    const current = this.mapper.modelSelectionFromDom(domSelection);
+    if (
+      current !== null &&
+      current.start === this.selection.start &&
+      current.end === this.selection.end
+    ) {
+      return;
+    }
+    const start = this.mapper.domPositionFromModelOffset(this.selection.start);
+    const end =
+      this.selection.start === this.selection.end
+        ? start
+        : this.mapper.domPositionFromModelOffset(this.selection.end);
+    if (start === null || end === null) {
+      return;
+    }
+    domSelection.setBaseAndExtent(
+      start.node,
+      start.offset,
+      end.node,
+      end.offset
+    );
+  }
+
+  private emitChanges(): void {
+    if (this.session.shouldSuppressEvents) {
+      return;
+    }
+    this.callbacks.onChangeText?.(this.text);
+    this.callbacks.onChangeSelection?.(this.selection);
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/SelectionMapper.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/SelectionMapper.ts
@@ -1,31 +1,33 @@
 import type { RangeBounds } from '../model/rangeBounds';
+import type { ParagraphProjection } from '../render/InputProjection';
+import { firstIndexReachingTarget } from '../utils';
 
 export interface DomPosition {
   node: Node;
   offset: number;
 }
 
-// Paragraph divs map to buffer lines, so crossing one costs a newline;
-// runs within a line have no separators.
-const NEWLINE_LENGTH = '\n'.length;
-
 // Translates DOM positions to buffer offsets and back over the renderer's
-// canonical DOM.
+// canonical DOM. Line offsets come from the projection the renderer last
+// wrote.
 // A run-boundary offset maps to the start of the following run.
 export class SelectionMapper {
   private readonly root: HTMLElement;
+  private readonly paragraphs: () => readonly ParagraphProjection[];
 
-  constructor(root: HTMLElement) {
+  constructor(
+    root: HTMLElement,
+    paragraphs: () => readonly ParagraphProjection[]
+  ) {
     this.root = root;
+    this.paragraphs = paragraphs;
   }
 
   // Returns null for positions outside the editor.
   modelOffsetFromDom(node: Node, offset: number): number | null {
     if (node === this.root) {
-      const paragraph = this.root.childNodes[offset];
-      return paragraph === undefined
-        ? this.documentLength()
-        : paragraphStart(paragraph);
+      const paragraph = this.paragraphs()[offset];
+      return paragraph === undefined ? this.documentLength() : paragraph.start;
     }
 
     const paragraph = this.paragraphContaining(node);
@@ -33,27 +35,31 @@ export class SelectionMapper {
       return null;
     }
     return (
-      paragraphStart(paragraph) + offsetWithinParagraph(paragraph, node, offset)
+      this.lineStart(paragraph) + offsetWithinParagraph(paragraph, node, offset)
     );
   }
 
   // Offsets past the end clamp to the end of the document.
   domPositionFromModelOffset(offset: number): DomPosition | null {
-    const paragraphs = this.root.children;
+    const paragraphs = this.paragraphs();
     if (paragraphs.length === 0) {
       return null;
     }
-
-    let remaining = Math.max(offset, 0);
-    for (let i = 0; i < paragraphs.length; i++) {
-      const paragraph = paragraphs[i]!;
-      const length = textLength(paragraph);
-      if (remaining <= length || i === paragraphs.length - 1) {
-        return positionInParagraph(paragraph, Math.min(remaining, length));
-      }
-      remaining -= length + NEWLINE_LENGTH;
+    const clamped = Math.max(offset, 0);
+    const index = Math.min(
+      firstIndexReachingTarget(
+        clamped,
+        paragraphs.length,
+        (i) => paragraphs[i]!.end
+      ),
+      paragraphs.length - 1
+    );
+    const element = this.root.children[index];
+    if (element === undefined) {
+      return null;
     }
-    return null;
+    const { start, end } = paragraphs[index]!;
+    return positionInParagraph(element, Math.min(clamped - start, end - start));
   }
 
   modelSelectionFromDom(selection: Selection): RangeBounds | null {
@@ -80,25 +86,25 @@ export class SelectionMapper {
     return current;
   }
 
-  // n lines hold n - 1 newlines, hence the negative start.
+  private lineStart(paragraph: Node): number {
+    const index = paragraphIndex(paragraph);
+    const line = this.paragraphs()[index];
+    return line?.start ?? 0;
+  }
+
   private documentLength(): number {
-    let length = -NEWLINE_LENGTH;
-    for (const paragraph of this.root.childNodes) {
-      length += textLength(paragraph) + NEWLINE_LENGTH;
-    }
-    return Math.max(length, 0);
+    return this.paragraphs().at(-1)?.end ?? 0;
   }
 }
 
-// --- Line level: paragraph siblings, a newline per boundary. ---
+// --- Line level: a paragraph div per line, in projection order. ---
 
-// Buffer offset at which this paragraph's line starts.
-function paragraphStart(paragraph: Node): number {
-  let offset = 0;
+function paragraphIndex(paragraph: Node): number {
+  let index = 0;
   for (let s = paragraph.previousSibling; s !== null; s = s.previousSibling) {
-    offset += textLength(s) + NEWLINE_LENGTH;
+    index++;
   }
-  return offset;
+  return index;
 }
 
 // --- Run level: spans within one line, nothing between them. ---

--- a/packages/react-native-enriched-markdown/src/web/input/editing/SelectionMapper.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/SelectionMapper.ts
@@ -1,0 +1,166 @@
+import type { RangeBounds } from '../model/rangeBounds';
+
+export interface DomPosition {
+  node: Node;
+  offset: number;
+}
+
+// Paragraph divs map to buffer lines, so crossing one costs a newline;
+// runs within a line have no separators.
+const NEWLINE_LENGTH = '\n'.length;
+
+// Translates DOM positions to buffer offsets and back over the renderer's
+// canonical DOM.
+// A run-boundary offset maps to the start of the following run.
+export class SelectionMapper {
+  private readonly root: HTMLElement;
+
+  constructor(root: HTMLElement) {
+    this.root = root;
+  }
+
+  // Returns null for positions outside the editor.
+  modelOffsetFromDom(node: Node, offset: number): number | null {
+    if (node === this.root) {
+      const paragraph = this.root.childNodes[offset];
+      return paragraph === undefined
+        ? this.documentLength()
+        : paragraphStart(paragraph);
+    }
+
+    const paragraph = this.paragraphContaining(node);
+    if (paragraph === null) {
+      return null;
+    }
+    return (
+      paragraphStart(paragraph) + offsetWithinParagraph(paragraph, node, offset)
+    );
+  }
+
+  // Offsets past the end clamp to the end of the document.
+  domPositionFromModelOffset(offset: number): DomPosition | null {
+    const paragraphs = this.root.children;
+    if (paragraphs.length === 0) {
+      return null;
+    }
+
+    let remaining = Math.max(offset, 0);
+    for (let i = 0; i < paragraphs.length; i++) {
+      const paragraph = paragraphs[i]!;
+      const length = textLength(paragraph);
+      if (remaining <= length || i === paragraphs.length - 1) {
+        return positionInParagraph(paragraph, Math.min(remaining, length));
+      }
+      remaining -= length + NEWLINE_LENGTH;
+    }
+    return null;
+  }
+
+  modelSelectionFromDom(selection: Selection): RangeBounds | null {
+    const { anchorNode, anchorOffset, focusNode, focusOffset } = selection;
+    if (anchorNode === null || focusNode === null) {
+      return null;
+    }
+    const anchor = this.modelOffsetFromDom(anchorNode, anchorOffset);
+    const focus = this.modelOffsetFromDom(focusNode, focusOffset);
+    if (anchor === null || focus === null) {
+      return null;
+    }
+    return { start: Math.min(anchor, focus), end: Math.max(anchor, focus) };
+  }
+
+  private paragraphContaining(node: Node): Node | null {
+    let current: Node = node;
+    while (current.parentNode !== this.root) {
+      if (current.parentNode === null) {
+        return null;
+      }
+      current = current.parentNode;
+    }
+    return current;
+  }
+
+  // n lines hold n - 1 newlines, hence the negative start.
+  private documentLength(): number {
+    let length = -NEWLINE_LENGTH;
+    for (const paragraph of this.root.childNodes) {
+      length += textLength(paragraph) + NEWLINE_LENGTH;
+    }
+    return Math.max(length, 0);
+  }
+}
+
+// --- Line level: paragraph siblings, a newline per boundary. ---
+
+// Buffer offset at which this paragraph's line starts.
+function paragraphStart(paragraph: Node): number {
+  let offset = 0;
+  for (let s = paragraph.previousSibling; s !== null; s = s.previousSibling) {
+    offset += textLength(s) + NEWLINE_LENGTH;
+  }
+  return offset;
+}
+
+// --- Run level: spans within one line, nothing between them. ---
+
+function offsetWithinParagraph(
+  paragraph: Node,
+  node: Node,
+  offset: number
+): number {
+  let position =
+    node.nodeType === Node.TEXT_NODE ? offset : childLengthBefore(node, offset);
+  for (
+    let current = node;
+    current !== paragraph;
+    current = current.parentNode!
+  ) {
+    position += siblingLengthBefore(current);
+  }
+  return position;
+}
+
+function positionInParagraph(paragraph: Element, offset: number): DomPosition {
+  let remaining = offset;
+  for (const child of paragraph.children) {
+    // An empty line holds a <br>, not run spans; fall through to the div.
+    if (child.nodeName === 'BR') {
+      break;
+    }
+    const length = textLength(child);
+    const isLast = child.nextElementSibling === null;
+    if (remaining < length || (isLast && remaining === length)) {
+      const text = child.firstChild;
+      return text === null
+        ? { node: child, offset: 0 }
+        : { node: text, offset: remaining };
+    }
+    remaining -= length;
+  }
+  // An empty line: the caret sits in the div itself, before the <br>.
+  return { node: paragraph, offset: 0 };
+}
+
+// Total text length of the node's preceding siblings.
+function siblingLengthBefore(node: Node): number {
+  let length = 0;
+  for (let s = node.previousSibling; s !== null; s = s.previousSibling) {
+    length += textLength(s);
+  }
+  return length;
+}
+
+// Text length of the first `index` children, for element-addressed positions.
+function childLengthBefore(parent: Node, index: number): number {
+  let length = 0;
+  const children = parent.childNodes;
+  const count = Math.min(index, children.length);
+  for (let i = 0; i < count; i++) {
+    length += textLength(children[i]!);
+  }
+  return length;
+}
+
+function textLength(node: Node): number {
+  return (node.textContent ?? '').length;
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/EditPipeline.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/EditPipeline.test.ts
@@ -1,0 +1,75 @@
+import { EditPipeline, type EditContext } from '../EditPipeline';
+import { FormattingStore } from '../../formatting/FormattingStore';
+import { BlockStore } from '../../formatting/BlockStore';
+import { createFormattingRange as range } from '../../model/inlineStyles';
+import { createBlockRange as block } from '../../model/blocks';
+
+function context(partial: Partial<EditContext>): EditContext {
+  return {
+    editStart: 0,
+    deletedText: '',
+    insertedText: '',
+    pendingStyles: [],
+    pendingStyleRemovals: [],
+    ...partial,
+  };
+}
+
+describe('EditPipeline', () => {
+  it('walks both stores through one edit and renumbers ordinals', () => {
+    // "fetch\nmerge" as an ordered list, strong on "merge"; delete line one.
+    const styles = new FormattingStore();
+    styles.setRanges([range('strong', 6, 11)]);
+    const blocks = new BlockStore();
+    blocks.setRanges([
+      block('ordered-list-item', 0, 5),
+      { ...block('ordered-list-item', 6, 11), ordinal: 2 },
+    ]);
+    const pipeline = new EditPipeline(styles, blocks);
+
+    const touchedNewline = pipeline.processTextChange(
+      'merge',
+      context({ editStart: 0, deletedText: 'fetch\n' })
+    );
+
+    expect(touchedNewline).toBe(true);
+    expect(styles.allRanges).toEqual([range('strong', 0, 5)]);
+    expect(blocks.allRanges).toEqual([block('ordered-list-item', 0, 5)]);
+  });
+
+  it('wraps a glyph insert in the pending styles and carves the removals', () => {
+    const styles = new FormattingStore();
+    styles.setRanges([range('em', 0, 2)]);
+    const pipeline = new EditPipeline(styles, new BlockStore());
+
+    const touchedNewline = pipeline.processTextChange(
+      'axb',
+      context({
+        editStart: 1,
+        insertedText: 'x',
+        pendingStyles: ['strong'],
+        pendingStyleRemovals: ['em'],
+      })
+    );
+
+    expect(touchedNewline).toBe(false);
+    expect(styles.allRanges).toEqual([
+      range('em', 0, 1),
+      range('strong', 1, 2),
+      range('em', 2, 3),
+    ]);
+  });
+
+  it('never wraps a bare newline in pending styles', () => {
+    const styles = new FormattingStore();
+    const pipeline = new EditPipeline(styles, new BlockStore());
+
+    const touchedNewline = pipeline.processTextChange(
+      'a\nb',
+      context({ editStart: 1, insertedText: '\n', pendingStyles: ['strong'] })
+    );
+
+    expect(touchedNewline).toBe(true);
+    expect(styles.allRanges).toEqual([]);
+  });
+});

--- a/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/EditSession.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/EditSession.test.ts
@@ -1,0 +1,26 @@
+import { EditSession } from '../EditSession';
+
+describe('EditSession', () => {
+  it('scoped restores the previous phase, also when nested or throwing', () => {
+    const session = new EditSession();
+    session.enterPhase('processing');
+
+    const result = session.scoped('formatting', () => {
+      expect(session.phase).toBe('formatting');
+      session.scoped('importing', () => {
+        expect(session.phase).toBe('importing');
+      });
+      expect(session.phase).toBe('formatting');
+      return 'done';
+    });
+    expect(result).toBe('done');
+    expect(session.phase).toBe('processing');
+
+    expect(() =>
+      session.scoped('importing', () => {
+        throw new Error('boom');
+      })
+    ).toThrow('boom');
+    expect(session.phase).toBe('processing');
+  });
+});

--- a/packages/react-native-enriched-markdown/src/web/input/render/DomRenderer.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/DomRenderer.ts
@@ -15,6 +15,11 @@ export class DomRenderer {
     this.root.replaceChildren();
   }
 
+  // The projection the DOM currently shows; line offsets for the mapper.
+  get paragraphs(): readonly ParagraphProjection[] {
+    return this.renderedParagraphs;
+  }
+
   render(text: string, paragraphs: readonly ParagraphProjection[]): void {
     const document = this.root.ownerDocument;
     const { start, stalePairs, freshPairs } = changedWindow(

--- a/packages/react-native-enriched-markdown/src/web/input/utils.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/utils.ts
@@ -23,3 +23,33 @@ export function firstIndexReachingTarget(
 export function isWhitespace(char: string): boolean {
   return /\s/.test(char);
 }
+
+// Characters outside the 16-bit range (emoji, mostly) occupy two string
+// units: a high surrogate (0xD800-0xDBFF) followed by a low one
+// (0xDC00-0xDFFF). These ranges never encode standalone characters, so a
+// unit's value alone tells whether it is half of a pair.
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff;
+}
+
+// Deleting half a surrogate pair would corrupt the buffer, so a delete step
+// spans the whole pair.
+export function backwardStep(text: string, position: number): number {
+  return position >= 2 &&
+    isLowSurrogate(text.charCodeAt(position - 1)) &&
+    isHighSurrogate(text.charCodeAt(position - 2))
+    ? 2
+    : 1;
+}
+
+export function forwardStep(text: string, position: number): number {
+  return position + 1 < text.length &&
+    isHighSurrogate(text.charCodeAt(position)) &&
+    isLowSurrogate(text.charCodeAt(position + 1))
+    ? 2
+    : 1;
+}

--- a/packages/react-native-enriched-markdown/src/web/input/utils.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/utils.ts
@@ -36,9 +36,10 @@ function isLowSurrogate(code: number): boolean {
   return code >= 0xdc00 && code <= 0xdfff;
 }
 
-// Deleting half a surrogate pair would corrupt the buffer, so a delete step
-// spans the whole pair.
-export function backwardStep(text: string, position: number): number {
+// Length in UTF-16 units of the character before/after `position`: 2 for a
+// surrogate pair (an emoji), else 1. Deleting half a pair would corrupt the
+// buffer, so deletes remove whole characters.
+export function charLengthBefore(text: string, position: number): number {
   return position >= 2 &&
     isLowSurrogate(text.charCodeAt(position - 1)) &&
     isHighSurrogate(text.charCodeAt(position - 2))
@@ -46,7 +47,7 @@ export function backwardStep(text: string, position: number): number {
     : 1;
 }
 
-export function forwardStep(text: string, position: number): number {
+export function charLengthAfter(text: string, position: number): number {
   return position + 1 < text.length &&
     isHighSurrogate(text.charCodeAt(position)) &&
     isLowSurrogate(text.charCodeAt(position + 1))


### PR DESCRIPTION
Adds the editing shell that turns the renderer into a working input: browser events flow into the model, the model renders back, and the caret stays in place.

- `EditSession`: the phase guard ported from native (idle/processing/formatting/importing + composition flag and the post-edit grace period) so handlers can tell a real user action from an echo of our own DOM writes.
- `SelectionMapper`: two-way translation between DOM positions and buffer offsets over the renderer's canonical DOM.
- `EditPipeline`: walks the model through one text edit (adjust both stores, normalize to line bounds, apply pending styles).
- `InputHost`: owns the object graph and routes `beforeinput`, insertText and delete backward/forward (surrogate-pair aware), with default-deny for everything else, plus selection mapping and defensive attributes.

Enter, list editing and formatting commands follow in #747. Verified by hand in the web example. Stacked on #734.