### PR TITLE
fix(android): skip explicit Kotlin plugin when AGP provides built-in Kotlin

### DIFF
--- a/packages/react-native-enriched-markdown/android/build.gradle
+++ b/packages/react-native-enriched-markdown/android/build.gradle
@@ -16,7 +16,28 @@ buildscript {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// Android Gradle Plugin 9 ships built-in Kotlin support and applies the Kotlin
+// plugin itself. Applying it a second time fails the configuration phase with
+// "Cannot add extension with name 'kotlin'". Apply it only when AGP is not
+// providing Kotlin: AGP 8 and older, or AGP 9 with android.builtInKotlin=false.
+def shouldApplyKotlinPlugin() {
+    def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpMajor <= 8) {
+        return true
+    }
+    // AGP 10 removes the opt-out: built-in Kotlin is always active there.
+    if (agpMajor >= 10) {
+        return false
+    }
+    def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
+    def builtInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
+    return !builtInKotlinEnabled
+}
+
+if (shouldApplyKotlinPlugin()) {
+    apply plugin: "kotlin-android"
+}
+
 apply plugin: "com.facebook.react"
 
 def getExtOrIntegerDefault(name) {


### PR DESCRIPTION
## Problem

Android Gradle Plugin 9 ships built-in Kotlin support and enables it by default, so AGP
applies the Kotlin plugin itself. When a library *also* applies `kotlin-android` explicitly, the
two collide and configuration fails before anything compiles:

```
> Failed to apply plugin 'kotlin-android'.
   > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.
```

The apply is unconditional in this file, so on an AGP 9 project it cannot be built
at all. There is no consumer-side workaround short of patching the file — setting
`android.builtInKotlin=false` project-wide just to build one dependency is not a
reasonable ask, and that escape hatch is removed in AGP 10.

## Change

Keep the explicit apply, but skip it when AGP is already providing Kotlin:

```groovy
def shouldApplyKotlinPlugin() {
    def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
    if (agpMajor <= 8) {
        return true
    }
    def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
    def builtInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
    return !builtInKotlinEnabled
}

if (shouldApplyKotlinPlugin()) {
    apply plugin: "kotlin-android"
}
```

Files changed:

- `packages/react-native-enriched-markdown/android/build.gradle`

## Why the condition has this shape

Both halves are load-bearing:

- **AGP 8 and older always apply.** Built-in Kotlin only exists from AGP 9.0. On older
  AGP nothing else applies the Kotlin plugin, so skipping would break the build in the
  opposite direction.
- **Absent is treated as enabled.** `android.builtInKotlin` defaults to on in AGP 9, so
  only an explicit `false` means "AGP is not providing Kotlin, apply it yourself". This
  mirrors AGP's own default.

| AGP | `android.builtInKotlin` | explicit apply |
|---|---|---|
| 8.x | unset or `false` | yes (unchanged) |
| 9.x | unset | no — AGP provides it |
| 9.x | `true` | no — AGP provides it |
| 9.x | `false` | yes — consumer opted out |

`com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION` requires no new plugin resolution,
and the apply already happens after `com.android.library`, so AGP is on the classpath.

## What I verified, and what I did not

- **Verified end to end** on a real Expo SDK 58 / React Native 0.87 project with AGP
  9.2.1 and Gradle 9.4.1: `:app:assembleDebug` succeeds both with
  `-Pandroid.newDsl=true -Pandroid.builtInKotlin=true` and with both flags off. Same
  guard, both configurations green.
- Syntax-checked this file with Groovy's `Phases.CONVERSION`.
- **Not run:** this repo's own CI or example app. The AGP <= 8 path is unchanged by
  construction, since `shouldApplyKotlinPlugin()` short-circuits to `true` there — but a
  CI run is the real confirmation and I could not do that from outside.

Found while sweeping 157 popular React Native libraries for AGP 9 new-DSL compatibility.
34 failed with the new DSL enabled, and 29 of those failed on exactly this — it is the
most common blocker by a wide margin.
