### PR TITLE
feat(web): add formatting commands to the web input

### DIFF
--- a/packages/react-native-enriched-markdown/src/web/input/editing/BlockEditCoordinator.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/BlockEditCoordinator.ts
@@ -1,0 +1,62 @@
+import { linesTouching, type BlockStore } from '../formatting/BlockStore';
+import { isListItem, MAX_LIST_DEPTH, type BlockType } from '../model/blocks';
+import type { RangeBounds } from '../model/rangeBounds';
+import { clamp } from '../utils';
+
+export class BlockEditCoordinator {
+  private readonly blockStore: BlockStore;
+
+  constructor(blockStore: BlockStore) {
+    this.blockStore = blockStore;
+  }
+
+  changeListDepthBy(
+    delta: number,
+    selection: RangeBounds,
+    text: string
+  ): boolean {
+    const startBlock = this.blockStore.blockAt(selection.start, text);
+    if (!isListItem(startBlock)) {
+      // Indenting a plain paragraph starts a list; a heading stays put.
+      if (delta > 0 && startBlock === null) {
+        this.toggleListType('unordered-list-item', selection, text);
+        return true;
+      }
+      return false;
+    }
+    if (delta < 0 && startBlock.level === 0) {
+      this.toggleListType(startBlock.type, selection, text);
+      return true;
+    }
+
+    for (const line of linesTouching(selection, text)) {
+      const block = this.blockStore.blockStartingAt(line.start);
+      if (!isListItem(block)) {
+        continue;
+      }
+      const depth = clamp(block.level + delta, 0, MAX_LIST_DEPTH);
+      this.blockStore.setBlock(block.type, depth, line.start, line.start, text);
+    }
+    this.blockStore.normalizeToLineBounds(text);
+    return true;
+  }
+
+  // Turns the list off when the item at the selection start already has
+  // `type`; otherwise makes every touched line an item of `type`, keeping an
+  // existing depth.
+  toggleListType(type: BlockType, selection: RangeBounds, text: string): void {
+    const startBlock = this.blockStore.blockAt(selection.start, text);
+    const turningOff = isListItem(startBlock) && startBlock.type === type;
+
+    for (const line of linesTouching(selection, text)) {
+      if (turningOff) {
+        this.blockStore.removeBlock(line.start, line.start, text);
+        continue;
+      }
+      const existing = this.blockStore.blockStartingAt(line.start);
+      const depth = isListItem(existing) ? existing.level : 0;
+      this.blockStore.setBlock(type, depth, line.start, line.start, text);
+    }
+    this.blockStore.normalizeToLineBounds(text);
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/BlockEditCoordinator.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/BlockEditCoordinator.ts
@@ -1,5 +1,10 @@
 import { linesTouching, type BlockStore } from '../formatting/BlockStore';
-import { isListItem, MAX_LIST_DEPTH, type BlockType } from '../model/blocks';
+import {
+  blockTypeForHeadingLevel,
+  isListItem,
+  MAX_LIST_DEPTH,
+  type BlockType,
+} from '../model/blocks';
 import type { RangeBounds } from '../model/rangeBounds';
 import { clamp } from '../utils';
 
@@ -39,6 +44,27 @@ export class BlockEditCoordinator {
     }
     this.blockStore.normalizeToLineBounds(text);
     return true;
+  }
+
+  toggleHeading(level: number, selection: RangeBounds, text: string): void {
+    const type = blockTypeForHeadingLevel(level);
+    if (type === null) {
+      return;
+    }
+    const startBlock = this.blockStore.blockAt(selection.start, text);
+    const turningOff =
+      startBlock !== null &&
+      startBlock.type === type &&
+      startBlock.level === level;
+
+    for (const line of linesTouching(selection, text)) {
+      if (turningOff) {
+        this.blockStore.removeBlock(line.start, line.start, text);
+      } else {
+        this.blockStore.setBlock(type, level, line.start, line.start, text);
+      }
+    }
+    this.blockStore.normalizeToLineBounds(text);
   }
 
   // Turns the list off when the item at the selection start already has

--- a/packages/react-native-enriched-markdown/src/web/input/editing/EditPipeline.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/EditPipeline.ts
@@ -1,5 +1,6 @@
-import type { BlockStore } from '../formatting/BlockStore';
+import { paragraphBounds, type BlockStore } from '../formatting/BlockStore';
 import type { FormattingStore } from '../formatting/FormattingStore';
+import { LIST_ITEM_BLOCK_TYPES } from '../model/blocks';
 import {
   createFormattingRange,
   type InputStyleType,
@@ -37,6 +38,12 @@ export class EditPipeline {
       deletedText.length,
       insertedText.length
     );
+    // Continuation must precede normalization: the new anchor keeps the
+    // line chain adjacent, or the depth clamp would flatten nested items
+    // that follow the fresh empty line.
+    if (insertedText === '\n') {
+      this.continueBlockOnNewline(text, editStart);
+    }
     this.blockStore.normalizeToLineBounds(text);
 
     if (insertedText.length > 0) {
@@ -44,6 +51,22 @@ export class EditPipeline {
     }
 
     return deletedText.includes('\n') || insertedText.includes('\n');
+  }
+
+  // Enter inside a list item continues the list on the new line; other
+  // blocks do not continue.
+  private continueBlockOnNewline(text: string, newlinePosition: number): void {
+    // The inserted newline closes the line before it; take that line's block.
+    const closedLine = paragraphBounds(newlinePosition, newlinePosition, text);
+    const closedBlock = this.blockStore.blockStartingAt(closedLine.start);
+    if (closedBlock === null || !LIST_ITEM_BLOCK_TYPES.has(closedBlock.type)) {
+      return;
+    }
+    const { type, level } = closedBlock;
+    const lineStart = closedLine.start;
+    const freshLineStart = newlinePosition + 1;
+    this.blockStore.setBlock(type, level, lineStart, lineStart, text);
+    this.blockStore.setBlock(type, level, freshLineStart, freshLineStart, text);
   }
 
   private applyPendingStyles(context: EditContext): void {

--- a/packages/react-native-enriched-markdown/src/web/input/editing/EditPipeline.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/EditPipeline.ts
@@ -1,6 +1,6 @@
-import { paragraphBounds, type BlockStore } from '../formatting/BlockStore';
+import { lineAtPosition, type BlockStore } from '../formatting/BlockStore';
 import type { FormattingStore } from '../formatting/FormattingStore';
-import { LIST_ITEM_BLOCK_TYPES } from '../model/blocks';
+import { isListItem } from '../model/blocks';
 import {
   createFormattingRange,
   type InputStyleType,
@@ -57,9 +57,9 @@ export class EditPipeline {
   // blocks do not continue.
   private continueBlockOnNewline(text: string, newlinePosition: number): void {
     // The inserted newline closes the line before it; take that line's block.
-    const closedLine = paragraphBounds(newlinePosition, newlinePosition, text);
+    const closedLine = lineAtPosition(newlinePosition, text);
     const closedBlock = this.blockStore.blockStartingAt(closedLine.start);
-    if (closedBlock === null || !LIST_ITEM_BLOCK_TYPES.has(closedBlock.type)) {
+    if (!isListItem(closedBlock)) {
       return;
     }
     const { type, level } = closedBlock;

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -1,11 +1,12 @@
-import { BlockStore, paragraphBounds } from '../formatting/BlockStore';
+import { BlockStore, lineAtPosition } from '../formatting/BlockStore';
 import { FormattingStore } from '../formatting/FormattingStore';
 import { parseToPlainTextAndRanges } from '../formatting/InputParser';
 import type { RangeBounds } from '../model/rangeBounds';
 import { DomRenderer } from '../render/DomRenderer';
 import { projectParagraphs } from '../render/InputProjection';
 import { ENRM_INPUT_CLASS, injectInputStyles } from '../render/inputStyles';
-import { LIST_ITEM_BLOCK_TYPES } from '../model/blocks';
+import { isListItem, type BlockType } from '../model/blocks';
+import { BlockEditCoordinator } from './BlockEditCoordinator';
 import { EditPipeline } from './EditPipeline';
 import { EditSession } from './EditSession';
 import { SelectionMapper } from './SelectionMapper';
@@ -23,6 +24,7 @@ export class InputHost {
   private readonly blockStore = new BlockStore();
   private readonly session = new EditSession();
   private readonly pipeline: EditPipeline;
+  private readonly blockCoordinator: BlockEditCoordinator;
   private readonly renderer: DomRenderer;
   private readonly mapper: SelectionMapper;
 
@@ -33,6 +35,7 @@ export class InputHost {
     this.root = root;
     this.callbacks = callbacks;
     this.pipeline = new EditPipeline(this.formattingStore, this.blockStore);
+    this.blockCoordinator = new BlockEditCoordinator(this.blockStore);
     this.renderer = new DomRenderer(root);
     this.mapper = new SelectionMapper(root, () => this.renderer.paragraphs);
 
@@ -46,6 +49,7 @@ export class InputHost {
     root.setAttribute('translate', 'no');
 
     root.addEventListener('beforeinput', this.handleBeforeInput);
+    root.addEventListener('keydown', this.handleKeyDown);
     root.addEventListener('compositionstart', this.handleCompositionStart);
     root.addEventListener('compositionend', this.handleCompositionEnd);
     root.ownerDocument.addEventListener(
@@ -58,6 +62,7 @@ export class InputHost {
 
   destroy(): void {
     this.root.removeEventListener('beforeinput', this.handleBeforeInput);
+    this.root.removeEventListener('keydown', this.handleKeyDown);
     this.root.removeEventListener(
       'compositionstart',
       this.handleCompositionStart
@@ -85,6 +90,22 @@ export class InputHost {
     });
     this.render();
     this.emitChanges();
+  }
+
+  indentList(): void {
+    this.changeListDepthBy(1);
+  }
+
+  outdentList(): void {
+    this.changeListDepthBy(-1);
+  }
+
+  toggleUnorderedList(): void {
+    this.toggleListType('unordered-list-item');
+  }
+
+  toggleOrderedList(): void {
+    this.toggleListType('ordered-list-item');
   }
 
   private readonly handleBeforeInput = (event: InputEvent): void => {
@@ -126,6 +147,21 @@ export class InputHost {
       this.selection = mapped;
     }
   }
+
+  // Tab never reaches beforeinput (the browser moves focus), so it is the
+  // one key handled here.
+  private readonly handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== 'Tab' || this.session.isComposing) {
+      return;
+    }
+    event.preventDefault();
+    this.syncSelectionFromDom();
+    if (event.shiftKey) {
+      this.outdentList();
+    } else {
+      this.indentList();
+    }
+  };
 
   private readonly handleCompositionStart = (): void => {
     this.session.isComposing = true;
@@ -169,20 +205,43 @@ export class InputHost {
   }
 
   private unlistEmptyListItem(caret: number): boolean {
-    const line = paragraphBounds(caret, caret, this.text);
-    if (line.start !== line.end) {
+    const line = lineAtPosition(caret, this.text);
+    const block = this.blockStore.blockAt(caret, this.text);
+    if (line.start !== line.end || !isListItem(block)) {
       return false;
     }
-    const block = this.blockStore.blockStartingAt(line.start);
-    if (block === null || !LIST_ITEM_BLOCK_TYPES.has(block.type)) {
-      return false;
-    }
-    this.session.scoped('processing', () => {
-      this.blockStore.removeBlock(line.start, line.start, this.text);
-      this.blockStore.normalizeToLineBounds(this.text);
-    });
-    this.render();
+    this.toggleListType(block.type);
     return true;
+  }
+
+  // Backspace at the start of a list item outdents it, or un-lists it at
+  // depth 0, instead of merging with the line above.
+  private outdentListAtLineStart(caret: number): boolean {
+    const line = lineAtPosition(caret, this.text);
+    if (
+      caret !== line.start ||
+      !isListItem(this.blockStore.blockAt(caret, this.text))
+    ) {
+      return false;
+    }
+    this.outdentList();
+    return true;
+  }
+
+  private changeListDepthBy(delta: number): void {
+    const changed = this.session.scoped('processing', () =>
+      this.blockCoordinator.changeListDepthBy(delta, this.selection, this.text)
+    );
+    if (changed) {
+      this.render();
+    }
+  }
+
+  private toggleListType(type: BlockType): void {
+    this.session.scoped('processing', () =>
+      this.blockCoordinator.toggleListType(type, this.selection, this.text)
+    );
+    this.render();
   }
 
   private replaceSelection(insertedText: string): void {
@@ -196,7 +255,7 @@ export class InputHost {
       this.replaceSelection('');
       return;
     }
-    if (start === 0) {
+    if (this.outdentListAtLineStart(start) || start === 0) {
       return;
     }
     const deleteFrom = start - charLengthBefore(this.text, start);

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -1,10 +1,11 @@
-import { BlockStore } from '../formatting/BlockStore';
+import { BlockStore, paragraphBounds } from '../formatting/BlockStore';
 import { FormattingStore } from '../formatting/FormattingStore';
 import { parseToPlainTextAndRanges } from '../formatting/InputParser';
 import type { RangeBounds } from '../model/rangeBounds';
 import { DomRenderer } from '../render/DomRenderer';
 import { projectParagraphs } from '../render/InputProjection';
 import { ENRM_INPUT_CLASS, injectInputStyles } from '../render/inputStyles';
+import { LIST_ITEM_BLOCK_TYPES } from '../model/blocks';
 import { EditPipeline } from './EditPipeline';
 import { EditSession } from './EditSession';
 import { SelectionMapper } from './SelectionMapper';
@@ -100,6 +101,10 @@ export class InputHost {
       case 'insertText':
         this.replaceSelection(event.data ?? '');
         break;
+      case 'insertParagraph':
+      case 'insertLineBreak':
+        this.insertNewline();
+        break;
       case 'deleteContentBackward':
         this.deleteBackward();
         break;
@@ -154,6 +159,31 @@ export class InputHost {
     this.selection = mapped;
     this.callbacks.onChangeSelection?.(mapped);
   };
+
+  private insertNewline(): void {
+    const { start, end } = this.selection;
+    if (start === end && this.unlistEmptyListItem(start)) {
+      return;
+    }
+    this.replaceSelection('\n');
+  }
+
+  private unlistEmptyListItem(caret: number): boolean {
+    const line = paragraphBounds(caret, caret, this.text);
+    if (line.start !== line.end) {
+      return false;
+    }
+    const block = this.blockStore.blockStartingAt(line.start);
+    if (block === null || !LIST_ITEM_BLOCK_TYPES.has(block.type)) {
+      return false;
+    }
+    this.session.scoped('processing', () => {
+      this.blockStore.removeBlock(line.start, line.start, this.text);
+      this.blockStore.normalizeToLineBounds(this.text);
+    });
+    this.render();
+    return true;
+  }
 
   private replaceSelection(insertedText: string): void {
     const { start, end } = this.selection;

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -6,15 +6,19 @@ import { DomRenderer } from '../render/DomRenderer';
 import { projectParagraphs } from '../render/InputProjection';
 import { ENRM_INPUT_CLASS, injectInputStyles } from '../render/inputStyles';
 import { isListItem, type BlockType } from '../model/blocks';
+import type { InputStyleType } from '../model/inlineStyles';
 import { BlockEditCoordinator } from './BlockEditCoordinator';
 import { EditPipeline } from './EditPipeline';
 import { EditSession } from './EditSession';
 import { SelectionMapper } from './SelectionMapper';
+import { TypingAttributesController } from './TypingAttributesController';
+import { buildInputState, sameInputState, type InputState } from './InputState';
 import { charLengthBefore, charLengthAfter } from '../utils';
 
 export interface InputHostCallbacks {
   onChangeText?: (text: string) => void;
   onChangeSelection?: (selection: RangeBounds) => void;
+  onChangeState?: (state: InputState) => void;
 }
 
 export class InputHost {
@@ -25,17 +29,20 @@ export class InputHost {
   private readonly session = new EditSession();
   private readonly pipeline: EditPipeline;
   private readonly blockCoordinator: BlockEditCoordinator;
+  private readonly typing: TypingAttributesController;
   private readonly renderer: DomRenderer;
   private readonly mapper: SelectionMapper;
 
   private text = '';
   private selection: RangeBounds = { start: 0, end: 0 };
+  private lastEmittedState: InputState | null = null;
 
   constructor(root: HTMLElement, callbacks: InputHostCallbacks = {}) {
     this.root = root;
     this.callbacks = callbacks;
     this.pipeline = new EditPipeline(this.formattingStore, this.blockStore);
     this.blockCoordinator = new BlockEditCoordinator(this.blockStore);
+    this.typing = new TypingAttributesController(this.formattingStore);
     this.renderer = new DomRenderer(root);
     this.mapper = new SelectionMapper(root, () => this.renderer.paragraphs);
 
@@ -106,6 +113,34 @@ export class InputHost {
 
   toggleOrderedList(): void {
     this.toggleListType('ordered-list-item');
+  }
+
+  toggleBold(): void {
+    this.toggleInlineStyle('strong');
+  }
+
+  toggleItalic(): void {
+    this.toggleInlineStyle('em');
+  }
+
+  toggleUnderline(): void {
+    this.toggleInlineStyle('underline');
+  }
+
+  toggleStrikethrough(): void {
+    this.toggleInlineStyle('strikethrough');
+  }
+
+  toggleSpoiler(): void {
+    this.toggleInlineStyle('spoiler');
+  }
+
+  toggleHeading(level: number): void {
+    this.session.scoped('processing', () =>
+      this.blockCoordinator.toggleHeading(level, this.selection, this.text)
+    );
+    this.render();
+    this.emitState();
   }
 
   private readonly handleBeforeInput = (event: InputEvent): void => {
@@ -193,7 +228,11 @@ export class InputHost {
       return;
     }
     this.selection = mapped;
+    if (!this.session.isPostEditGracePeriod) {
+      this.typing.resetForSelectionChange(mapped);
+    }
     this.callbacks.onChangeSelection?.(mapped);
+    this.emitState();
   };
 
   private insertNewline(): void {
@@ -242,6 +281,17 @@ export class InputHost {
       this.blockCoordinator.toggleListType(type, this.selection, this.text)
     );
     this.render();
+    this.emitState();
+  }
+
+  private toggleInlineStyle(type: InputStyleType): void {
+    const { start, end } = this.selection;
+    const wasActive = this.session.scoped('processing', () =>
+      this.formattingStore.toggleStyle(type, start, end)
+    );
+    this.typing.toggleStyle(type, wasActive, start !== end);
+    this.render();
+    this.emitState();
   }
 
   private replaceSelection(insertedText: string): void {
@@ -291,8 +341,8 @@ export class InputHost {
         editStart,
         deletedText,
         insertedText,
-        pendingStyles: [],
-        pendingStyleRemovals: [],
+        pendingStyles: this.typing.styles,
+        pendingStyleRemovals: this.typing.styleRemovals,
       });
       const caret = editStart + insertedText.length;
       this.selection = { start: caret, end: caret };
@@ -300,6 +350,7 @@ export class InputHost {
     });
     this.render();
     this.emitChanges();
+    this.emitState();
   }
 
   private render(): void {
@@ -357,5 +408,26 @@ export class InputHost {
     }
     this.callbacks.onChangeText?.(this.text);
     this.callbacks.onChangeSelection?.(this.selection);
+  }
+
+  private emitState(): void {
+    if (this.session.shouldSuppressEvents) {
+      return;
+    }
+    const state = buildInputState(
+      this.formattingStore,
+      this.blockStore,
+      this.typing,
+      this.selection,
+      this.text
+    );
+    if (
+      this.lastEmittedState !== null &&
+      sameInputState(state, this.lastEmittedState)
+    ) {
+      return;
+    }
+    this.lastEmittedState = state;
+    this.callbacks.onChangeState?.(state);
   }
 }

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputState.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputState.ts
@@ -1,0 +1,81 @@
+import type { BlockStore } from '../formatting/BlockStore';
+import type { FormattingStore } from '../formatting/FormattingStore';
+import { isHeading } from '../model/blocks';
+import type { RangeBounds } from '../model/rangeBounds';
+import type { TypingAttributesController } from './TypingAttributesController';
+
+export interface InputState {
+  bold: { isActive: boolean };
+  italic: { isActive: boolean };
+  underline: { isActive: boolean };
+  strikethrough: { isActive: boolean };
+  spoiler: { isActive: boolean };
+  link: { isActive: boolean };
+  heading: { isActive: boolean; level: number };
+  unorderedList: { isActive: boolean; depth: number };
+  orderedList: { isActive: boolean; depth: number };
+}
+
+// A style is active over a selection when it covers the whole of it, and at a
+// caret when it is effectively active there.
+function inlineStates(
+  formattingStore: FormattingStore,
+  typing: TypingAttributesController,
+  selection: RangeBounds
+): Pick<
+  InputState,
+  'bold' | 'italic' | 'underline' | 'strikethrough' | 'spoiler' | 'link'
+> {
+  const active = (type: Parameters<FormattingStore['isStyleActive']>[0]) =>
+    selection.start === selection.end
+      ? typing.isEffectiveStyleActive(type, selection.start)
+      : formattingStore.isStyleFullyActive(
+          type,
+          selection.start,
+          selection.end
+        );
+  return {
+    bold: { isActive: active('strong') },
+    italic: { isActive: active('em') },
+    underline: { isActive: active('underline') },
+    strikethrough: { isActive: active('strikethrough') },
+    spoiler: { isActive: active('spoiler') },
+    link: { isActive: active('link') },
+  };
+}
+
+export function buildInputState(
+  formattingStore: FormattingStore,
+  blockStore: BlockStore,
+  typing: TypingAttributesController,
+  selection: RangeBounds,
+  text: string
+): InputState {
+  const block = blockStore.blockAt(selection.start, text);
+  const headingLevel = isHeading(block) ? block.level : 0;
+  const unordered = block?.type === 'unordered-list-item';
+  const ordered = block?.type === 'ordered-list-item';
+  return {
+    ...inlineStates(formattingStore, typing, selection),
+    heading: { isActive: headingLevel > 0, level: headingLevel },
+    unorderedList: { isActive: unordered, depth: unordered ? block.level : 0 },
+    orderedList: { isActive: ordered, depth: ordered ? block.level : 0 },
+  };
+}
+
+export function sameInputState(a: InputState, b: InputState): boolean {
+  return (
+    a.bold.isActive === b.bold.isActive &&
+    a.italic.isActive === b.italic.isActive &&
+    a.underline.isActive === b.underline.isActive &&
+    a.strikethrough.isActive === b.strikethrough.isActive &&
+    a.spoiler.isActive === b.spoiler.isActive &&
+    a.link.isActive === b.link.isActive &&
+    a.heading.isActive === b.heading.isActive &&
+    a.heading.level === b.heading.level &&
+    a.unorderedList.isActive === b.unorderedList.isActive &&
+    a.unorderedList.depth === b.unorderedList.depth &&
+    a.orderedList.isActive === b.orderedList.isActive &&
+    a.orderedList.depth === b.orderedList.depth
+  );
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/TypingAttributesController.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/TypingAttributesController.ts
@@ -1,0 +1,80 @@
+import type { FormattingStore } from '../formatting/FormattingStore';
+import {
+  TYPING_ATTRIBUTE_STYLES,
+  type InputStyleType,
+} from '../model/inlineStyles';
+import type { RangeBounds } from '../model/rangeBounds';
+
+// Holds the styles the caret carries into the next keystroke. With a
+// selection the store already changed, so nothing pends; with a caret a
+// toggle is remembered until the next character or selection move.
+export class TypingAttributesController {
+  private readonly formattingStore: FormattingStore;
+  private readonly pendingStyles = new Set<InputStyleType>();
+  private readonly pendingStyleRemovals = new Set<InputStyleType>();
+
+  constructor(formattingStore: FormattingStore) {
+    this.formattingStore = formattingStore;
+  }
+
+  get styles(): InputStyleType[] {
+    return [...this.pendingStyles];
+  }
+
+  get styleRemovals(): InputStyleType[] {
+    return [...this.pendingStyleRemovals];
+  }
+
+  isEffectiveStyleActive(type: InputStyleType, position: number): boolean {
+    if (this.pendingStyleRemovals.has(type)) {
+      return false;
+    }
+    if (this.pendingStyles.has(type)) {
+      return true;
+    }
+    return this.formattingStore.isStyleActive(type, position);
+  }
+
+  toggleStyle(
+    type: InputStyleType,
+    wasActive: boolean,
+    hasSelection: boolean
+  ): void {
+    if (hasSelection) {
+      this.pendingStyles.delete(type);
+      this.pendingStyleRemovals.delete(type);
+      return;
+    }
+    if (this.pendingStyleRemovals.delete(type)) {
+      return;
+    }
+    if (this.pendingStyles.delete(type)) {
+      return;
+    }
+    if (wasActive) {
+      this.pendingStyleRemovals.add(type);
+    } else {
+      this.pendingStyles.add(type);
+    }
+  }
+
+  // Rebuilds the pending styles from the caret's surroundings after the
+  // selection moves: the styles a plain insert there would inherit.
+  resetForSelectionChange(selection: RangeBounds): void {
+    this.pendingStyles.clear();
+    this.pendingStyleRemovals.clear();
+    if (selection.start !== selection.end) {
+      for (const type of TYPING_ATTRIBUTE_STYLES) {
+        if (this.formattingStore.isStyleActive(type, selection.start)) {
+          this.pendingStyles.add(type);
+        }
+      }
+      return;
+    }
+    for (const type of TYPING_ATTRIBUTE_STYLES) {
+      if (this.formattingStore.isStyleAdjacentBefore(type, selection.start)) {
+        this.pendingStyles.add(type);
+      }
+    }
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/BlockEditCoordinator.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/BlockEditCoordinator.test.ts
@@ -1,0 +1,95 @@
+import { BlockEditCoordinator } from '../BlockEditCoordinator';
+import { BlockStore } from '../../formatting/BlockStore';
+import { createBlockRange as block } from '../../model/blocks';
+
+// "stack\nreview\nmerge": 0-5 | 6-12 | 13-18
+const text = 'stack\nreview\nmerge';
+
+function caret(position: number) {
+  return { start: position, end: position };
+}
+
+function depths(store: BlockStore) {
+  return store.allRanges.map((b) => [b.type, b.level]);
+}
+
+describe('BlockEditCoordinator', () => {
+  it('indents no deeper than one level below the item above', () => {
+    const store = new BlockStore();
+    store.setRanges([
+      block('unordered-list-item', 0, 5),
+      block('unordered-list-item', 6, 12),
+    ]);
+    const coordinator = new BlockEditCoordinator(store);
+
+    coordinator.changeListDepthBy(1, caret(8), text);
+    coordinator.changeListDepthBy(1, caret(8), text);
+
+    expect(depths(store)).toEqual([
+      ['unordered-list-item', 0],
+      ['unordered-list-item', 1],
+    ]);
+  });
+
+  it('outdents at depth 0 out of the list, and indent starts a list only on a paragraph', () => {
+    const store = new BlockStore();
+    store.setRanges([
+      block('unordered-list-item', 0, 5),
+      block('h2', 13, 18, 2),
+    ]);
+    const coordinator = new BlockEditCoordinator(store);
+
+    expect(coordinator.changeListDepthBy(-1, caret(2), text)).toBe(true);
+    expect(coordinator.changeListDepthBy(1, caret(8), text)).toBe(true);
+    expect(coordinator.changeListDepthBy(1, caret(15), text)).toBe(false);
+
+    expect(depths(store)).toEqual([
+      ['unordered-list-item', 0],
+      ['h2', 2],
+    ]);
+  });
+
+  it('changes depth only on the list items a selection touches', () => {
+    const store = new BlockStore();
+    store.setRanges([
+      block('unordered-list-item', 0, 5),
+      block('unordered-list-item', 6, 12),
+    ]);
+    const coordinator = new BlockEditCoordinator(store);
+
+    // Selection spans "review" (item) and "merge" (paragraph).
+    coordinator.changeListDepthBy(1, { start: 8, end: 15 }, text);
+
+    expect(depths(store)).toEqual([
+      ['unordered-list-item', 0],
+      ['unordered-list-item', 1],
+    ]);
+  });
+
+  it('toggles the type across a selection and switching type keeps depth', () => {
+    const store = new BlockStore();
+    store.setRanges([
+      block('unordered-list-item', 0, 5),
+      block('unordered-list-item', 6, 12, 1),
+    ]);
+    const coordinator = new BlockEditCoordinator(store);
+
+    coordinator.toggleListType(
+      'ordered-list-item',
+      { start: 0, end: 18 },
+      text
+    );
+    expect(depths(store)).toEqual([
+      ['ordered-list-item', 0],
+      ['ordered-list-item', 1],
+      ['ordered-list-item', 0],
+    ]);
+
+    coordinator.toggleListType(
+      'ordered-list-item',
+      { start: 0, end: 12 },
+      text
+    );
+    expect(depths(store)).toEqual([['ordered-list-item', 0]]);
+  });
+});

--- a/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/EditPipeline.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/EditPipeline.test.ts
@@ -73,3 +73,52 @@ describe('EditPipeline', () => {
     expect(styles.allRanges).toEqual([]);
   });
 });
+
+describe('EditPipeline on enter', () => {
+  it('keeps nested items nested when a list continues above them', () => {
+    // "- stack\n   - review": press Enter at the end of "stack".
+    const blocks = new BlockStore();
+    blocks.setRanges([
+      block('unordered-list-item', 0, 5, 0),
+      block('unordered-list-item', 6, 12, 1),
+    ]);
+    const pipeline = new EditPipeline(new FormattingStore(), blocks);
+
+    pipeline.processTextChange(
+      'stack\n\nreview',
+      context({ editStart: 5, insertedText: '\n' })
+    );
+
+    // The fresh empty line continues the outer list and "review" below it
+    // stays at depth 1: continuation must precede normalization, or the
+    // depth clamp sees a gap and flattens it.
+    expect(blocks.allRanges.map((b) => [b.start, b.level])).toEqual([
+      [0, 0],
+      [6, 0],
+      [7, 1],
+    ]);
+  });
+
+  it('keeps both halves in the list when an item is split mid-word', () => {
+    // "- stack\n   - review": press Enter inside "review".
+    const blocks = new BlockStore();
+    blocks.setRanges([
+      block('unordered-list-item', 0, 5, 0),
+      block('unordered-list-item', 6, 12, 1),
+    ]);
+    const pipeline = new EditPipeline(new FormattingStore(), blocks);
+
+    pipeline.processTextChange(
+      'stack\nre\nview',
+      context({ editStart: 8, insertedText: '\n' })
+    );
+
+    // The adjusted item spans the newline until it is snapped back; without
+    // that the fresh anchor removes it and "re" drops out of the list.
+    expect(blocks.allRanges.map((b) => [b.start, b.end, b.level])).toEqual([
+      [0, 5, 0],
+      [6, 8, 1],
+      [9, 13, 1],
+    ]);
+  });
+});

--- a/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/TypingAttributesController.test.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/__tests__/TypingAttributesController.test.ts
@@ -1,0 +1,26 @@
+import { TypingAttributesController } from '../TypingAttributesController';
+import { FormattingStore } from '../../formatting/FormattingStore';
+import { createFormattingRange as range } from '../../model/inlineStyles';
+
+describe('TypingAttributesController', () => {
+  it('remembers a caret toggle as a three-way switch', () => {
+    const typing = new TypingAttributesController(new FormattingStore());
+
+    // Off -> pending add; toggled again -> back to nothing.
+    typing.toggleStyle('strong', false, false);
+    expect(typing.styles).toEqual(['strong']);
+    typing.toggleStyle('strong', false, false);
+    expect(typing.styles).toEqual([]);
+    expect(typing.styleRemovals).toEqual([]);
+  });
+
+  it('pends a removal when toggling off an active style at a caret', () => {
+    const store = new FormattingStore();
+    store.setRanges([range('strong', 0, 4)]);
+    const typing = new TypingAttributesController(store);
+
+    typing.toggleStyle('strong', true, false);
+    expect(typing.styleRemovals).toEqual(['strong']);
+    expect(typing.isEffectiveStyleActive('strong', 2)).toBe(false);
+  });
+});

--- a/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/formatting/BlockStore.ts
@@ -35,6 +35,28 @@ export function paragraphBounds(
   return { start, end };
 }
 
+// The line containing `position`.
+export function lineAtPosition(position: number, text: string): RangeBounds {
+  return paragraphBounds(position, position, text);
+}
+
+// Bounds of every line the selection touches, first to last.
+export function linesTouching(
+  selection: RangeBounds,
+  text: string
+): RangeBounds[] {
+  const lines: RangeBounds[] = [];
+  const { end } = paragraphBounds(selection.start, selection.end, text);
+  let line = lineAtPosition(selection.start, text);
+  while (true) {
+    lines.push(line);
+    if (line.end >= end) {
+      return lines;
+    }
+    line = lineAtPosition(line.end + 1, text);
+  }
+}
+
 // Stores the block-level (line-scoped) ranges for the editor, mirroring
 // FormattingStore. Block ranges never overlap: at most one block covers any
 // paragraph, and ranges stay normalized to whole-line boundaries.
@@ -100,7 +122,7 @@ export class BlockStore {
 
     let previousEnd = -1;
     this.ranges = this.ranges.filter((range) => {
-      const line = paragraphBounds(range.start, range.start, text);
+      const line = lineAtPosition(range.start, text);
       const isEmptyLine = line.end === line.start;
       if (
         (isEmptyLine && !ANCHORED_BLOCK_TYPES.has(range.type)) ||
@@ -246,6 +268,11 @@ export class BlockStore {
     }
 
     this.ranges = ranges;
+  }
+
+  // The block on the line containing `position`, if any.
+  blockAt(position: number, text: string): BlockRange | null {
+    return this.blockStartingAt(lineAtPosition(position, text).start);
   }
 
   // Starts are unique (one block per paragraph), so a binary search finds the

--- a/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
@@ -35,6 +35,10 @@ export const ANCHORED_BLOCK_TYPES: ReadonlySet<BlockType> = new Set([
   ...LIST_ITEM_BLOCK_TYPES,
 ]);
 
+export function isListItem(block: BlockRange | null): block is BlockRange {
+  return block !== null && LIST_ITEM_BLOCK_TYPES.has(block.type);
+}
+
 export function blockTypeForHeadingLevel(level: number): BlockType | null {
   return HEADING_BLOCK_TYPES[level - 1] ?? null;
 }

--- a/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/model/blocks.ts
@@ -39,6 +39,14 @@ export function isListItem(block: BlockRange | null): block is BlockRange {
   return block !== null && LIST_ITEM_BLOCK_TYPES.has(block.type);
 }
 
+const HEADING_BLOCK_TYPES_SET: ReadonlySet<BlockType> = new Set(
+  HEADING_BLOCK_TYPES
+);
+
+export function isHeading(block: BlockRange | null): block is BlockRange {
+  return block !== null && HEADING_BLOCK_TYPES_SET.has(block.type);
+}
+
 export function blockTypeForHeadingLevel(level: number): BlockType | null {
   return HEADING_BLOCK_TYPES[level - 1] ?? null;
 }

--- a/packages/react-native-enriched-markdown/src/web/input/model/inlineStyles.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/model/inlineStyles.ts
@@ -8,6 +8,14 @@ export type InputStyleType =
   | 'link'
   | 'spoiler';
 
+export const TYPING_ATTRIBUTE_STYLES: readonly InputStyleType[] = [
+  'strong',
+  'em',
+  'underline',
+  'strikethrough',
+  'spoiler',
+];
+
 export interface FormattingRange extends RangeBounds {
   type: InputStyleType;
   url?: string;


### PR DESCRIPTION
Adds the command layer over the input model: the keys and toolbar actions that change blocks, mirroring the native block coordinators.

- Enter: inserts a line break, continues list items (both halves keep their type and depth when a word is split) and exits an empty item. Continuation runs before normalization so nested items below the fresh line stay nested.
- `BlockEditCoordinator`: list toggling and depth changes over every line the selection touches, decided by the line where the selection starts. Indenting a paragraph starts a list, outdenting at depth 0 leaves it.
- Keys: Tab and Shift+Tab never leave the editor and indent or outdent like a hardware keyboard on iOS. Backspace at the start of an item outdents it, then un-lists it, then merges lines.
- Public `indentList`, `outdentList`, `toggleUnorderedList` and `toggleOrderedList` on the host.

Inline style commands and typing attributes land here next. Verified with real key events in Chrome through Playwright and by hand in the web example. Stacked on #743.