### PR TITLE
fix: harden ratex postinstall script; harden ratex handling in build phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,11 @@ packages/core/cpp/highlight/vendor/generated-*/
 # RaTeX (iOS LaTeX math): the prebuilt static XCFramework, RaTeX's four core Swift
 # sources, and the KaTeX fonts are restored from the pins in vendor/ratex-version.json
 # by vendor/vendor-ratex.mjs (via `prepare`) and baked into the npm tarball on prepack.
+# The .staging/.backup siblings are transient swap dirs the script writes during a
+# restore and clears on completion; ignore any that linger after an interrupted run.
 packages/react-native-enriched-markdown/ios/vendor/
+packages/react-native-enriched-markdown/ios/vendor.staging/
+packages/react-native-enriched-markdown/ios/vendor.backup/
 
 # React Native Nitro Modules
 nitrogen/

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -49,8 +49,10 @@ Pod::Spec.new do |s|
   # there, failing several hundred lines into the pod build with an opaque Swift
   # "cannot find type 'RaTeXRenderer' in scope" (#745).
   ratex_dir = File.join(__dir__, 'ios/vendor')
+  # File.file? (not File.exist?) so a stray .stamp/ directory can't pass the check and
+  # reintroduce the #745 failure mode; the vendor script only ever writes it as a file.
   ratex_present = File.directory?(File.join(ratex_dir, 'RaTeX.xcframework')) &&
-    File.exist?(File.join(ratex_dir, '.stamp'))
+    File.file?(File.join(ratex_dir, '.stamp'))
   math_flag = ENV['ENRICHED_MARKDOWN_ENABLE_MATH']
 
   if config.key?('enableMath')

--- a/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
+++ b/packages/react-native-enriched-markdown/ReactNativeEnrichedMarkdown.podspec
@@ -40,7 +40,17 @@ Pod::Spec.new do |s|
   # deprecated fallback. `math_explicit` tracks an active opt-in (vs the implicit
   # default), which decides the missing-framework behavior below.
   config = EnrichedMarkdownConfig.consumer_config
-  ratex_present = File.directory?(File.join(__dir__, 'ios/vendor/RaTeX.xcframework'))
+  # "present" mirrors the code-highlight side (see code_highlight_podspec.rb, which
+  # gates on grammars/.stamp): the vendor script writes ios/vendor/.stamp only after
+  # the XCFramework, the four Swift sources, and the fonts have all landed and it
+  # swaps the tree into place atomically. Gating on the XCFramework directory alone
+  # would treat a half-finished download (framework extracted, Swift sources/fonts
+  # still missing) as ready and compile the RaTeX bridge against sources that are not
+  # there, failing several hundred lines into the pod build with an opaque Swift
+  # "cannot find type 'RaTeXRenderer' in scope" (#745).
+  ratex_dir = File.join(__dir__, 'ios/vendor')
+  ratex_present = File.directory?(File.join(ratex_dir, 'RaTeX.xcframework')) &&
+    File.exist?(File.join(ratex_dir, '.stamp'))
   math_flag = ENV['ENRICHED_MARKDOWN_ENABLE_MATH']
 
   if config.key?('enableMath')
@@ -61,9 +71,9 @@ Pod::Spec.new do |s|
   end
 
   # RaTeX is downloaded at postinstall and kept out of the tarball. Reconcile the
-  # request with the vendored framework: an explicit opt-in with the framework missing
-  # fails loud; on by default but missing (a partial/failed download, or a monorepo root
-  # opt-out) falls back to a clean build without math.
+  # request with the vendored tree: an explicit opt-in with the tree missing or
+  # incomplete fails loud; on by default but missing (a partial/failed download, or a
+  # monorepo root opt-out) falls back to a clean build without math.
   enable_math = math_requested && ratex_present
   if !math_requested
     EnrichedMarkdownConfig.warn_once(:math_disabled, '[ReactNativeEnrichedMarkdown] LaTeX math disabled via ' \
@@ -71,13 +81,14 @@ Pod::Spec.new do |s|
   elsif !ratex_present
     if math_explicit
       raise '[ReactNativeEnrichedMarkdown] LaTeX math is enabled but the vendored RaTeX ' \
-        'XCFramework is missing at ios/vendor/RaTeX.xcframework. Reinstall to fetch it: ' \
-        '`npm rebuild react-native-enriched-markdown`. ' \
+        'assets are missing or incomplete at ios/vendor (need RaTeX.xcframework, the core ' \
+        'Swift sources, the fonts, and the .stamp the vendor script writes on success). ' \
+        'Reinstall to fetch them: `npm rebuild react-native-enriched-markdown`. ' \
         'To disable math, set "enriched-markdown".enableMath = false in your app package.json. ' \
         'Troubleshooting: https://github.com/software-mansion/enriched-markdown/blob/main/docs/NATIVE_ASSETS.md'
     end
     EnrichedMarkdownConfig.warn_once(:math_disabled, '[ReactNativeEnrichedMarkdown] LaTeX math disabled: the vendored RaTeX ' \
-      'XCFramework was not found at ios/vendor/RaTeX.xcframework. If this is unintended, re-run ' \
+      'assets were not found or are incomplete at ios/vendor. If this is unintended, re-run ' \
       '`node node_modules/react-native-enriched-markdown/postinstall.mjs`.')
   end
 
@@ -92,9 +103,10 @@ Pod::Spec.new do |s|
   preprocessor_defs = "$(inherited) MD4C_USE_UTF8=1#{code_highlight[:defines]}"
   if enable_math
     preprocessor_defs += ' ENRICHED_MARKDOWN_MATH=1'
-    # enable_math already implies ratex_present (the reconciliation above raises on an
-    # explicit opt-in with a missing framework and disables the default-on path), so the
-    # vendored references below always resolve.
+    # enable_math already implies ratex_present, i.e. a complete vendored tree marked by
+    # ios/vendor/.stamp (the reconciliation above raises on an explicit opt-in with a
+    # missing/incomplete tree and disables the default-on path), so the vendored
+    # references below always resolve.
     # Prebuilt static XCFramework (device + simulator[arm64,x86_64] + macOS). Vendored
     # rather than pulled via spm_dependency, which compiled RaTeX's Swift wrapper per
     # requested arch (breaking universal simulator builds, #527) and double-collected

--- a/packages/react-native-enriched-markdown/postinstall.mjs
+++ b/packages/react-native-enriched-markdown/postinstall.mjs
@@ -119,6 +119,13 @@ if (!enableMath) {
     console.warn(`${LOG} WARNING: vendor-ratex failed. iOS math rendering may not work.`);
     failed = true;
   }
+} else {
+  // Math is on (explicitly or by default) but the vendor script or its manifest is
+  // absent, so nothing was downloaded. Never fall through silently -- the iOS build
+  // would otherwise just quietly ship without math. Warn like any other failure.
+  console.warn(`${LOG} WARNING: math is enabled but the RaTeX vendor script or manifest is missing ` +
+    `(${vendorRatex}, ${ratexManifest}); iOS math rendering will be unavailable.`);
+  failed = true;
 }
 
 if (failed) {

--- a/vendor/vendor-ratex.mjs
+++ b/vendor/vendor-ratex.mjs
@@ -107,8 +107,6 @@ async function main() {
   if (args.manifest) manifestPath = path.resolve(args.manifest);
   if (args.output) outDir = path.resolve(args.output);
 
-  const xcframeworkDir = path.join(outDir, 'RaTeX.xcframework');
-  const fontsOut = path.join(outDir, 'Fonts');
   const stampFile = path.join(outDir, '.stamp');
 
   const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
@@ -120,19 +118,39 @@ async function main() {
     return;
   }
 
-  fs.rmSync(outDir, { recursive: true, force: true });
-  fs.mkdirSync(outDir, { recursive: true });
+  // Assemble the whole tree in a sibling staging dir and swap it into place only
+  // after every asset (XCFramework, the four Swift sources, the fonts, the stamp)
+  // has landed. A failure partway -- most commonly the source tarball fetch after
+  // the XCFramework already extracted -- must never leave a half-written tree: the
+  // podspec would read the lone XCFramework as "math ready" and compile the RaTeX
+  // bridge against Swift sources that are not there (#745). Staging plus a final
+  // swap makes a failed vendor indistinguishable from an absent one, which the
+  // podspec's default-on path degrades cleanly. The staging dir is a sibling of
+  // outDir so it shares its filesystem and the closing rename never crosses
+  // devices (EXDEV), and a --force that fails leaves the previous good tree intact.
+  const staging = outDir + '.staging';
+  // fail() exits the process directly rather than throwing, so cleanup cannot live
+  // in a catch alone; an exit hook removes the staging dir on every failure path.
+  // After a successful swap the dir no longer exists, so this becomes a no-op.
+  process.on('exit', () => {
+    try { fs.rmSync(staging, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+  fs.rmSync(staging, { recursive: true, force: true });
+  fs.mkdirSync(staging, { recursive: true });
+
+  const xcframeworkDir = path.join(staging, 'RaTeX.xcframework');
+  const fontsOut = path.join(staging, 'Fonts');
 
   // 1. Prebuilt static XCFramework (device + simulator[arm64,x86_64] + macOS slices).
   const xcBuf = await fetchAndVerify(m.xcframework.url, m.xcframework.sha256, 'xcframework');
   {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ratex-xcf-'));
     try {
-      extractTo(xcBuf, '.zip', ['-d', outDir], tmp);
+      extractTo(xcBuf, '.zip', ['-d', staging], tmp);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
-    if (!fs.existsSync(xcframeworkDir)) fail(`extracted zip has no RaTeX.xcframework in ${outDir}`);
+    if (!fs.existsSync(xcframeworkDir)) fail(`extracted zip has no RaTeX.xcframework in ${staging}`);
   }
 
   // 2. Core Swift sources + KaTeX fonts + LICENSE from the pinned source tag.
@@ -147,7 +165,7 @@ async function main() {
       for (const rel of m.source.swiftSources) {
         const from = path.join(root, rel);
         if (!fs.existsSync(from)) fail(`source tarball missing ${rel}`);
-        copyFile(from, path.join(outDir, path.basename(rel)));
+        copyFile(from, path.join(staging, path.basename(rel)));
       }
 
       const fontsSrc = path.join(root, m.source.fontsDir);
@@ -159,13 +177,19 @@ async function main() {
       if (n === 0) fail(`no .ttf fonts found under ${m.source.fontsDir}`);
 
       const licenseFrom = path.join(root, m.source.license);
-      if (fs.existsSync(licenseFrom)) copyFile(licenseFrom, path.join(outDir, 'LICENSE'));
+      if (fs.existsSync(licenseFrom)) copyFile(licenseFrom, path.join(staging, 'LICENSE'));
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   }
 
-  fs.writeFileSync(stampFile, key + '\n');
+  fs.writeFileSync(path.join(staging, '.stamp'), key + '\n');
+
+  // Publish atomically: drop the previous tree (a good one, or a partial left by an
+  // older interrupted run) and move the fully-staged replacement into its place.
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.renameSync(staging, outDir);
+
   log(`RaTeX ${m.tag} -> ${outDir}`);
   log('done.');
 }

--- a/vendor/vendor-ratex.mjs
+++ b/vendor/vendor-ratex.mjs
@@ -185,10 +185,25 @@ async function main() {
 
   fs.writeFileSync(path.join(staging, '.stamp'), key + '\n');
 
-  // Publish atomically: drop the previous tree (a good one, or a partial left by an
-  // older interrupted run) and move the fully-staged replacement into its place.
-  fs.rmSync(outDir, { recursive: true, force: true });
-  fs.renameSync(staging, outDir);
+  // Publish by swapping directories, never deleting the previous tree before the new
+  // one is in place. rm-then-rename has a window where a failed rename leaves the
+  // vendor dir empty and wipes a previously-good tree. Instead: move any existing tree
+  // aside (a rename, atomic on one filesystem), then move the staged tree in; if that
+  // second move fails, restore the one set aside so a failed install can never empty
+  // the vendor dir. Only once the new tree is live is the old one removed -- a failure
+  // there is harmless, leaving a .backup the next run clears. A previously-good tree
+  // therefore survives any single failure in this sequence.
+  const backup = outDir + '.backup';
+  fs.rmSync(backup, { recursive: true, force: true });
+  const hadPrevious = fs.existsSync(outDir);
+  if (hadPrevious) fs.renameSync(outDir, backup);
+  try {
+    fs.renameSync(staging, outDir);
+  } catch (err) {
+    if (hadPrevious) fs.renameSync(backup, outDir);
+    throw err;
+  }
+  fs.rmSync(backup, { recursive: true, force: true });
 
   log(`RaTeX ${m.tag} -> ${outDir}`);
   log('done.');


### PR DESCRIPTION
### What/Why?

Fixes #745. When `vendor-ratex.mjs` failed on its second download (the source tarball) after the first (the XCFramework) had already extracted, it left a half-vendored tree behind. The podspec then gated math on the XCFramework directory alone, so it compiled the RaTeX bridge against Swift sources that were not there and failed hundreds of lines into the pod build with an opaque `ENRMRaTeXBridge.swift:18:25: error: cannot find type 'RaTeXRenderer' in scope`.

- **`vendor-ratex.mjs`** now assembles the whole tree in a sibling `.staging` dir and swaps it into place only after every asset (XCFramework, Swift sources, fonts, stamp) has landed. A failed vendor now looks identical to an absent one instead of a partial one; a `--force` that fails leaves the previous good tree intact. The swap moves any existing tree aside (a rename) before moving the staged one in, and restores it if that second move fails, so a failed rename can never delete a previously-good tree and leave the vendor dir empty (addresses review feedback on the earlier rm-then-rename).
- **Podspec** gates on `ios/vendor/.stamp` (written only on full success) in addition to the XCFramework, mirroring what the code-highlight podspec already does with `grammars/.stamp`. A partial/failed download now degrades to a clean build (or raises a clear reinstall message on an explicit opt-in) instead of the Swift error.
- **`postinstall.mjs`** now warns when math is requested but the vendor script/manifest is missing, instead of falling through silently. Keeping install non-fatal is intended; the warning is not.

`vendor-grammars.mjs` was left as-is: it batches all downloads before writing and its podspec already stamp-gates, so it is not susceptible to the same partial-tree failure.

### Testing

Reproduced #745, then verified the fix by forcing the second download to fail (offline manifest with a bad source sha, XCFramework served locally):

- Failure with an existing good tree (`--force`): previous tree left intact, no `.staging` leftover.
- Swap rollback: with the `staging` -> `outDir` rename forced to throw, the set-aside tree is restored and the previously-good tree survives, with no `.backup` leftover.
- Failure with an absent tree (the real #745 trigger): tree stays absent, never the partial XCFramework-only state.
- Happy path (real `--force` download): staging -> atomic swap -> complete tree + stamp; idempotent skip still no-ops.
- Podspec predicate: complete tree -> present; XCFramework-only (no stamp) -> not present.
- `node --check` on both scripts and `ruby -c` on the podspec pass.

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)


