### PR TITLE
feat(ios): add a render-plugin seam for optional modules

### DIFF
--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -199,7 +199,6 @@ public struct Md4cFlags: Equatable, Sendable {
   public var permissiveAutolinks: Bool  // bare URLs become links (default true)
   public var superscript: Bool          // ^text^ renders as superscript
   public var subscript: Bool            // ~text~ renders as subscript
-  public var latexMath: Bool
   public var highlight: Bool
 
   public static let commonMark: Md4cFlags

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownExtractor.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownExtractor.swift
@@ -163,6 +163,11 @@ private extension MarkdownExtractor {
             return
         }
 
+        if let attachment = attrs[.attachment] as? any MarkdownPluginAttachment {
+            appendPluginAttachment(attachment, attrs: attrs, to: &result, state: &state)
+            return
+        }
+
         if text == "\u{FFFC}" {
             return
         }
@@ -224,6 +229,35 @@ private extension MarkdownExtractor {
         state.needsBlankLine = true
         state.blockquoteDepth = -1
         state.listDepth = -1
+    }
+
+    static func appendPluginAttachment(
+        _ attachment: any MarkdownPluginAttachment,
+        attrs: [NSAttributedString.Key: Any],
+        to result: inout String,
+        state: inout ExtractionState
+    ) {
+        if attachment.isBlock {
+            flushHeading(&result, state: &state)
+            ensureBlankLine(&result)
+            result += attachment.markdownText() + "\n"
+            state.needsBlankLine = true
+            state.blockquoteDepth = -1
+            state.listDepth = -1
+            return
+        }
+
+        if let level = MarkdownAttributeValue.intValue(from: attrs[MarkdownAttribute.headingLevel]) {
+            accumulateHeading(attachment.markdownText(), level: level, to: &result, state: &state)
+            return
+        }
+        flushHeading(&result, state: &state)
+
+        if state.needsBlankLine, !result.isEmpty {
+            ensureBlankLine(&result)
+            state.needsBlankLine = false
+        }
+        result += attachment.markdownText()
     }
 
     /// Paragraph breaks and margin/padding spacers.

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Parser/MarkdownParserBridge.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Parser/MarkdownParserBridge.swift
@@ -11,7 +11,7 @@ enum MarkdownParserBridge {
             guard let result = em_parse_markdown(
                 cString,
                 flags.underline ? 1 : 0,
-                flags.latexMath ? 1 : 0,
+                flags.latexMathEnabled ? 1 : 0,
                 flags.superscript ? 1 : 0,
                 flags.subscript ? 1 : 0,
                 flags.highlight ? 1 : 0,

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Parser/Md4cFlags.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Parser/Md4cFlags.swift
@@ -1,6 +1,5 @@
 public struct Md4cFlags: Sendable, Equatable {
     public var underline: Bool
-    public var latexMath: Bool
     public var superscript: Bool
     public var `subscript`: Bool
     public var highlight: Bool
@@ -8,9 +7,12 @@ public struct Md4cFlags: Sendable, Equatable {
     public var permissiveAutolinks: Bool
     public var preserveBlankLines: Bool
 
+    /// Set only via `MarkdownRenderPlugin.adjustFlags` (the
+    /// EnrichedMarkdownLaTeX product) — base cannot render math nodes.
+    package var latexMathEnabled: Bool = false
+
     public init(
         underline: Bool = false,
-        latexMath: Bool = false,
         superscript: Bool = false,
         subscript subscriptEnabled: Bool = false,
         highlight: Bool = false,
@@ -19,7 +21,6 @@ public struct Md4cFlags: Sendable, Equatable {
         preserveBlankLines: Bool = false
     ) {
         self.underline = underline
-        self.latexMath = latexMath
         self.superscript = superscript
         self.subscript = subscriptEnabled
         self.highlight = highlight

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/AttributedRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/AttributedRenderer.swift
@@ -3,10 +3,20 @@ import UIKit
 final class AttributedRenderer {
     private let config: MarkdownStyleConfig
     private let factory: RendererFactory
+    private let rootBlockTypes: Set<NodeType>
 
-    init(config: MarkdownStyleConfig, imageRequestHeaders: [String: String] = [:]) {
+    init(
+        config: MarkdownStyleConfig,
+        imageRequestHeaders: [String: String] = [:],
+        plugins: [any MarkdownRenderPlugin] = []
+    ) {
         self.config = config
-        self.factory = RendererFactory(config: config, imageRequestHeaders: imageRequestHeaders)
+        self.factory = RendererFactory(
+            config: config,
+            imageRequestHeaders: imageRequestHeaders,
+            plugins: plugins
+        )
+        self.rootBlockTypes = plugins.reduce(into: []) { $0.formUnion($1.rootBlockNodeTypes) }
     }
 
     func renderRoot(_ root: MarkdownASTNode) -> NSMutableAttributedString {
@@ -18,6 +28,15 @@ final class AttributedRenderer {
         context.setBlockStyle(font: paragraphFont, color: paragraphColor)
 
         for child in root.children {
+            // A synthetic paragraph gives bare plugin block nodes their
+            // block margins and alignment.
+            if rootBlockTypes.contains(child.type) {
+                context.rendersPluginBlock = true
+                let paragraph = MarkdownASTNode(type: .paragraph, children: [child])
+                factory.renderer(for: .paragraph).render(node: paragraph, into: output, context: context)
+                context.rendersPluginBlock = false
+                continue
+            }
             factory.renderer(for: child.type).render(node: child, into: output, context: context)
         }
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/MarkdownRenderPlugin.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/MarkdownRenderPlugin.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+/// Extension seam for optional sibling modules (EnrichedMarkdownLaTeX today).
+/// Plugins are consulted before the built-in renderers.
+package protocol MarkdownRenderPlugin {
+    /// A renderer for `type`, or nil to leave it to the next plugin or the
+    /// built-ins. Called once per node type per render; the result is cached.
+    func renderer(for type: NodeType, config: MarkdownStyleConfig) -> NodeRenderer?
+
+    /// Adjusts parser flags before parsing, e.g. enabling the md4c extension
+    /// whose nodes the plugin renders.
+    func adjustFlags(_ flags: inout Md4cFlags)
+
+    /// Node types the parser emits bare at document root (promoted isolated
+    /// display math, for instance) that should render wrapped in a synthetic
+    /// paragraph; `RenderContext.rendersPluginBlock` is true while it renders.
+    var rootBlockNodeTypes: Set<NodeType> { get }
+}
+
+package extension MarkdownRenderPlugin {
+    func adjustFlags(_ flags: inout Md4cFlags) {}
+
+    var rootBlockNodeTypes: Set<NodeType> { [] }
+}
+
+/// Adopted by plugin-created attachments so base components can handle them
+/// without knowing their concrete types.
+package protocol MarkdownPluginAttachment: NSTextAttachment {
+    /// Source with markdown syntax restored, for Copy as Markdown.
+    func markdownText() -> String
+    /// Standalone block; wrapped in blank lines by Copy as Markdown.
+    var isBlock: Bool { get }
+    /// True exempts paragraphs containing the attachment from fixed
+    /// line-height caps, so taller-than-text content is not clipped.
+    var preservesNaturalLineHeight: Bool { get }
+}
+
+package extension MarkdownPluginAttachment {
+    var preservesNaturalLineHeight: Bool { true }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/MarkdownRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/MarkdownRenderer.swift
@@ -7,9 +7,33 @@ public enum MarkdownRenderer {
         flags: Md4cFlags = .commonMark,
         imageRequestHeaders: [String: String] = [:]
     ) -> NSAttributedString {
-        let ast = Parser.shared.parseMarkdown(markdown, flags: flags)
+        render(
+            markdown,
+            config: config,
+            flags: flags,
+            imageRequestHeaders: imageRequestHeaders,
+            plugins: []
+        )
+    }
+
+    package static func render(
+        _ markdown: String,
+        config: MarkdownStyleConfig,
+        flags: Md4cFlags,
+        imageRequestHeaders: [String: String],
+        plugins: [any MarkdownRenderPlugin]
+    ) -> NSAttributedString {
+        var effectiveFlags = flags
+        for plugin in plugins {
+            plugin.adjustFlags(&effectiveFlags)
+        }
+        let ast = Parser.shared.parseMarkdown(markdown, flags: effectiveFlags)
         let annotated = SourceOffsetAnnotator.annotate(ast, source: markdown)
-        let renderer = AttributedRenderer(config: config, imageRequestHeaders: imageRequestHeaders)
+        let renderer = AttributedRenderer(
+            config: config,
+            imageRequestHeaders: imageRequestHeaders,
+            plugins: plugins
+        )
         return renderer.renderRoot(annotated)
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/NodeRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/NodeRenderer.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol NodeRenderer: AnyObject {
+package protocol NodeRenderer: AnyObject {
     func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext)
 }
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/ParagraphStyleHelpers.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/ParagraphStyleHelpers.swift
@@ -57,10 +57,28 @@ enum ParagraphStyleHelpers {
         output.addAttribute(.paragraphStyle, value: style, range: range)
     }
 
+    static func rangeContainsNaturalHeightAttachment(
+        in output: NSAttributedString,
+        range: NSRange
+    ) -> Bool {
+        var found = false
+        output.enumerateAttribute(.attachment, in: range, options: []) { value, _, stop in
+            if let attachment = value as? any MarkdownPluginAttachment,
+               attachment.preservesNaturalLineHeight {
+                found = true
+                stop.pointee = true
+            }
+        }
+        return found
+    }
+
+    /// `capMaximum: false` keeps only the minimum line height, so
+    /// taller-than-text content is not clipped.
     static func applyLineHeight(
         to output: NSMutableAttributedString,
         range: NSRange,
-        lineHeight: CGFloat
+        lineHeight: CGFloat,
+        capMaximum: Bool = true
     ) {
         guard lineHeight > 0, range.length > 0 else { return }
 
@@ -68,7 +86,7 @@ enum ParagraphStyleHelpers {
         let style = getOrCreateParagraphStyle(in: output, at: range.location)
         style.lineSpacing = 0
         style.minimumLineHeight = roundedLineHeight
-        style.maximumLineHeight = roundedLineHeight
+        style.maximumLineHeight = capMaximum ? roundedLineHeight : 0
         output.addAttribute(.paragraphStyle, value: style, range: range)
     }
 
@@ -103,9 +121,10 @@ enum ParagraphStyleHelpers {
     static func applyBlockLineHeight(
         to output: NSMutableAttributedString,
         range: NSRange,
-        lineHeight: CGFloat
+        lineHeight: CGFloat,
+        capMaximum: Bool = true
     ) {
-        applyLineHeight(to: output, range: range, lineHeight: lineHeight)
+        applyLineHeight(to: output, range: range, lineHeight: lineHeight, capMaximum: capMaximum)
         applyBaselineOffset(to: output, range: range)
     }
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
@@ -15,9 +15,9 @@ enum ListType: Int {
     case ordered = 1
 }
 
-struct BlockStyle {
-    var font: UIFont
-    var color: UIColor
+package struct BlockStyle {
+    package var font: UIFont
+    package var color: UIColor
     var headingLevel: Int
 }
 
@@ -46,7 +46,7 @@ enum MarkdownAttribute {
     static let sourceRange = NSAttributedString.Key("EnrichedMarkdownSourceRange")
 }
 
-final class RenderContext {
+package final class RenderContext {
     private(set) var currentBlockType: BlockType = .none
     private(set) var currentBlockStyle: BlockStyle?
 
@@ -56,6 +56,9 @@ final class RenderContext {
     var listItemNumber = 0
     var taskItemIndex = 0
     var rendersBlockImage = false
+    /// True while rendering the synthetic paragraph around a bare root-level
+    /// plugin block node (see `MarkdownRenderPlugin.rootBlockNodeTypes`).
+    package var rendersPluginBlock = false
 
     private static let blockSpacerTemplate: NSParagraphStyle = {
         let style = NSMutableParagraphStyle()
@@ -73,6 +76,7 @@ final class RenderContext {
         listItemNumber = 0
         taskItemIndex = 0
         rendersBlockImage = false
+        rendersPluginBlock = false
     }
 
     func setBlockStyle(
@@ -90,11 +94,11 @@ final class RenderContext {
         currentBlockStyle = nil
     }
 
-    func getBlockStyle() -> BlockStyle? {
+    package func getBlockStyle() -> BlockStyle? {
         currentBlockStyle
     }
 
-    func getTextAttributes() -> [NSAttributedString.Key: Any] {
+    package func getTextAttributes() -> [NSAttributedString.Key: Any] {
         guard let blockStyle = currentBlockStyle else {
             return [:]
         }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -3,12 +3,18 @@ import UIKit
 final class RendererFactory {
     private let config: MarkdownStyleConfig
     private let imageRequestHeaders: [String: String]
+    private let plugins: [any MarkdownRenderPlugin]
     private var cache: [NodeType: NodeRenderer] = [:]
     private lazy var childrenOnlyRenderer = ChildrenOnlyRenderer(factory: self)
 
-    init(config: MarkdownStyleConfig, imageRequestHeaders: [String: String] = [:]) {
+    init(
+        config: MarkdownStyleConfig,
+        imageRequestHeaders: [String: String] = [:],
+        plugins: [any MarkdownRenderPlugin] = []
+    ) {
         self.config = config
         self.imageRequestHeaders = imageRequestHeaders
+        self.plugins = plugins
     }
 
     func renderer(for type: NodeType) -> NodeRenderer {
@@ -32,6 +38,11 @@ final class RendererFactory {
     }
 
     private func createRenderer(for type: NodeType) -> NodeRenderer {
+        for plugin in plugins {
+            if let renderer = plugin.renderer(for: type, config: config) {
+                return renderer
+            }
+        }
         if let renderer = createInlineRenderer(for: type) {
             return renderer
         }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/ParagraphRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/ParagraphRenderer.swift
@@ -58,7 +58,13 @@ final class ParagraphRenderer: NodeRenderer {
         let range = NSRange(location: start, length: output.length - start)
 
         if !isBlockImage, let lineHeight = paragraphStyle.lineHeight {
-            ParagraphStyleHelpers.applyBlockLineHeight(to: output, range: range, lineHeight: lineHeight)
+            // A capped line height would clip taller-than-text plugin content.
+            ParagraphStyleHelpers.applyBlockLineHeight(
+                to: output,
+                range: range,
+                lineHeight: lineHeight,
+                capMaximum: !ParagraphStyleHelpers.rangeContainsNaturalHeightAttachment(in: output, range: range)
+            )
         }
 
         if let alignment = paragraphStyle.textAlignment {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -14,6 +14,7 @@ public struct EnrichedMarkdownText: View {
     @Environment(\.markdownSelectable) private var isSelectionEnabled
     @Environment(\.markdownSelectionColor) private var selectionColor
     @Environment(\.markdownImageRequestHeaders) private var imageRequestHeaders
+    @Environment(\.markdownRenderPlugins) private var renderPlugins
     @Environment(\.markdownTaskListItemPressHandler) private var onTaskListItemPress
     @Environment(\.markdownTaskListItemToggleEnabled) private var isTaskListToggleEnabled
     @StateObject private var renderStore = MarkdownRenderStore()
@@ -55,7 +56,8 @@ public struct EnrichedMarkdownText: View {
                 markdown: markdown,
                 config: styleConfig,
                 flags: flags,
-                imageRequestHeaders: imageRequestHeaders
+                imageRequestHeaders: imageRequestHeaders,
+                plugins: renderPlugins
             )
         }
         // The onChange closures run against the previous view value, so the
@@ -66,7 +68,8 @@ public struct EnrichedMarkdownText: View {
                 markdown: newValue,
                 config: styleConfig,
                 flags: flags,
-                imageRequestHeaders: imageRequestHeaders
+                imageRequestHeaders: imageRequestHeaders,
+                plugins: renderPlugins
             )
         }
         .onChange(of: styleConfig) { newValue in
@@ -74,7 +77,8 @@ public struct EnrichedMarkdownText: View {
                 markdown: markdown,
                 config: newValue,
                 flags: flags,
-                imageRequestHeaders: imageRequestHeaders
+                imageRequestHeaders: imageRequestHeaders,
+                plugins: renderPlugins
             )
         }
         .onChange(of: flags) { newValue in
@@ -82,7 +86,8 @@ public struct EnrichedMarkdownText: View {
                 markdown: markdown,
                 config: styleConfig,
                 flags: newValue,
-                imageRequestHeaders: imageRequestHeaders
+                imageRequestHeaders: imageRequestHeaders,
+                plugins: renderPlugins
             )
         }
         .onChange(of: imageRequestHeaders) { newValue in
@@ -90,7 +95,8 @@ public struct EnrichedMarkdownText: View {
                 markdown: markdown,
                 config: styleConfig,
                 flags: flags,
-                imageRequestHeaders: newValue
+                imageRequestHeaders: newValue,
+                plugins: renderPlugins
             )
         }
         .onDisappear {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/Environment+RenderPlugins.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/Environment+RenderPlugins.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+private struct MarkdownRenderPluginsKey: EnvironmentKey {
+    static let defaultValue: [any MarkdownRenderPlugin] = []
+}
+
+package extension EnvironmentValues {
+    /// Populated by optional modules' public modifiers (`.markdownLaTeX()`).
+    var markdownRenderPlugins: [any MarkdownRenderPlugin] {
+        get { self[MarkdownRenderPluginsKey.self] }
+        set { self[MarkdownRenderPluginsKey.self] = newValue }
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownRenderStore.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownRenderStore.swift
@@ -31,7 +31,8 @@ final class MarkdownRenderStore: ObservableObject {
         markdown: String,
         config: MarkdownStyleConfig,
         flags: Md4cFlags = .commonMark,
-        imageRequestHeaders: [String: String] = [:]
+        imageRequestHeaders: [String: String] = [:],
+        plugins: [any MarkdownRenderPlugin] = []
     ) {
         if isBlank(markdown) {
             attributedText = NSAttributedString()
@@ -49,7 +50,8 @@ final class MarkdownRenderStore: ObservableObject {
                 resolved,
                 config: config,
                 flags: flags,
-                imageRequestHeaders: imageRequestHeaders
+                imageRequestHeaders: imageRequestHeaders,
+                plugins: plugins
             )
         } apply: { [weak self] result in
             self?.attributedText = result

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/RenderPluginTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/RenderPluginTests.swift
@@ -1,0 +1,157 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+private final class StubAttachment: NSTextAttachment, MarkdownPluginAttachment {
+    let markdown: String
+    let isBlock: Bool
+
+    init(markdown: String, isBlock: Bool) {
+        self.markdown = markdown
+        self.isBlock = isBlock
+        super.init(data: nil, ofType: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func markdownText() -> String { markdown }
+}
+
+/// Emits a stub attachment, taking block-ness from the context like a real
+/// plugin renderer would.
+private final class StubAttachmentRenderer: NodeRenderer {
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        var attributes = context.getTextAttributes()
+        attributes[.attachment] = StubAttachment(markdown: "$stub$", isBlock: context.rendersPluginBlock)
+        output.append(NSAttributedString(string: "\u{FFFC}", attributes: attributes))
+    }
+}
+
+private final class MarkerTextRenderer: NodeRenderer {
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        output.append(NSAttributedString(string: "[plugin]", attributes: context.getTextAttributes()))
+    }
+}
+
+/// Rides on the math md4c extension for a node type base has no renderer
+/// for, like the LaTeX module does.
+private struct StubPlugin: MarkdownRenderPlugin {
+    let claimed: Set<NodeType>
+    let makeRenderer: () -> NodeRenderer
+
+    func renderer(for type: NodeType, config: MarkdownStyleConfig) -> NodeRenderer? {
+        claimed.contains(type) ? makeRenderer() : nil
+    }
+
+    func adjustFlags(_ flags: inout Md4cFlags) {
+        flags.latexMathEnabled = true
+    }
+
+    var rootBlockNodeTypes: Set<NodeType> { [.latexMathDisplay] }
+}
+
+final class RenderPluginTests: XCTestCase {
+    private var config: MarkdownStyleConfig!
+
+    private let mathStubPlugin = StubPlugin(
+        claimed: [.latexMathInline, .latexMathDisplay],
+        makeRenderer: { StubAttachmentRenderer() }
+    )
+
+    override func setUp() {
+        super.setUp()
+        config = MarkdownStyleConfig.baseline()
+    }
+
+    private func render(_ markdown: String, plugins: [any MarkdownRenderPlugin]) -> NSAttributedString {
+        MarkdownRenderer.render(
+            markdown,
+            config: config,
+            flags: .commonMark,
+            imageRequestHeaders: [:],
+            plugins: plugins
+        )
+    }
+
+    private func stubAttachments(in rendered: NSAttributedString) -> [StubAttachment] {
+        var found: [StubAttachment] = []
+        rendered.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: rendered.length)
+        ) { value, _, _ in
+            if let attachment = value as? StubAttachment {
+                found.append(attachment)
+            }
+        }
+        return found
+    }
+
+    func testWithoutPluginsDollarSignsStayLiteralText() {
+        let rendered = render("a $x^2$ b", plugins: [])
+        XCTAssertTrue(rendered.string.contains("a $x^2$ b"))
+    }
+
+    func testPluginEnablesParsingAndClaimsNodes() {
+        let rendered = render("a $x$ b", plugins: [mathStubPlugin])
+
+        XCTAssertEqual(stubAttachments(in: rendered).count, 1)
+        XCTAssertTrue(rendered.string.contains("\u{FFFC}"))
+        XCTAssertFalse(rendered.string.contains("$"))
+    }
+
+    func testPluginOverridesBuiltInRenderer() {
+        let plugin = StubPlugin(claimed: [.code], makeRenderer: { MarkerTextRenderer() })
+        let rendered = render("before `code` after", plugins: [plugin])
+
+        XCTAssertTrue(rendered.string.contains("[plugin]"))
+        XCTAssertFalse(rendered.string.contains("code"))
+    }
+
+    func testUnclaimedNodesUseBuiltIns() {
+        let rendered = render("**bold** and $x$", plugins: [mathStubPlugin])
+        XCTAssertTrue(rendered.string.contains("bold"))
+    }
+
+    func testInlinePluginAttachmentExtraction() {
+        let rendered = render("a $x$ b", plugins: [mathStubPlugin])
+        let extracted = MarkdownExtractor.extractMarkdown(
+            from: rendered,
+            in: NSRange(location: 0, length: rendered.length)
+        )
+        XCTAssertEqual(extracted?.trimmingCharacters(in: .whitespacesAndNewlines), "a $stub$ b")
+    }
+
+    func testBlockPluginAttachmentExtractionWrapsBlankLines() {
+        let rendered = render("before\n\n$$x$$\n\nafter", plugins: [mathStubPlugin])
+
+        XCTAssertEqual(stubAttachments(in: rendered).first?.isBlock, true)
+
+        let extracted = MarkdownExtractor.extractMarkdown(
+            from: rendered,
+            in: NSRange(location: 0, length: rendered.length)
+        )
+        XCTAssertEqual(
+            extracted?.trimmingCharacters(in: .whitespacesAndNewlines),
+            "before\n\n$stub$\n\nafter"
+        )
+    }
+
+    func testPluginAttachmentDropsLineHeightCap() {
+        config.paragraph.lineHeight = 20
+
+        let plain = render("plain text", plugins: [mathStubPlugin])
+        let withAttachment = render("with $x$ math", plugins: [mathStubPlugin])
+
+        XCTAssertEqual(paragraphStyle(in: plain)?.maximumLineHeight, 20)
+        XCTAssertEqual(paragraphStyle(in: withAttachment)?.maximumLineHeight, 0)
+        XCTAssertEqual(paragraphStyle(in: withAttachment)?.minimumLineHeight, 20)
+    }
+
+    private func paragraphStyle(in rendered: NSAttributedString) -> NSParagraphStyle? {
+        guard rendered.length > 0 else { return nil }
+        return rendered.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle
+    }
+}


### PR DESCRIPTION
Optional sibling modules plug into the render pipeline through a package-level MarkdownRenderPlugin (renderer lookup consulted before the built-ins, parser-flag adjustment, root-level block wrapping) plus a MarkdownPluginAttachment protocol that keeps Copy as Markdown and fixed line-height handling generic. The latexMath parser flag leaves the public API: math parsing can only be enabled by a plugin, so base needs no math renderer at all and $…$ stays literal text without one. No public API is added; the whole seam is SE-0386 package access.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

