### PR TITLE
fix: retry then curl-proxy fallback for ratex downloads

### DIFF
--- a/vendor/vendor-ratex.mjs
+++ b/vendor/vendor-ratex.mjs
@@ -52,8 +52,44 @@ function copyFile(src, dest) {
   fs.copyFileSync(src, dest);
 }
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Downloads a url to a Buffer, resilient to the two failure modes that turn a
+// routine install into #745: transient GitHub/CDN blips, and being behind a proxy.
+// Node's global fetch is undici, which ignores http_proxy/https_proxy unless
+// NODE_USE_ENV_PROXY is set, so on a proxied machine the source tarball can time out
+// even though curl and the package manager both work. Retry fetch a few times, then
+// fall back to curl, which honors the proxy env and retries itself. The caller still
+// verifies the sha256, so a truncated or tampered body is caught either way.
+async function download(url, label) {
+  const attempts = 3;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      return Buffer.from(await res.arrayBuffer());
+    } catch (err) {
+      log(`${label} fetch attempt ${i}/${attempts} failed: ${err.message}`);
+      if (i < attempts) await sleep(500 * i);
+    }
+  }
+  log(`${label} falling back to curl (honors http_proxy/https_proxy) for ${url}`);
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ratex-dl-'));
+  try {
+    const dest = path.join(tmp, 'asset');
+    const res = spawnSync('curl', ['-fsSL', '--retry', '3', '-o', dest, url], { stdio: ['ignore', 'ignore', 'inherit'] });
+    if (res.error && res.error.code === 'ENOENT') {
+      fail(`${label} download failed for ${url}: fetch failed and curl is not installed`);
+    }
+    if (res.status !== 0) fail(`${label} download failed for ${url} (curl exit ${res.status})`);
+    return fs.readFileSync(dest);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 // Reads a manifest asset from a local path when the url points at an existing file
-// (offline), otherwise fetches it. The sha256 is verified either way; a mismatch is
+// (offline), otherwise downloads it. The sha256 is verified either way; a mismatch is
 // fatal and prints the computed digest to paste back into ratex-version.json on a re-pin.
 async function fetchAndVerify(url, sha256, label) {
   if (!sha256) fail(`${label}.sha256 missing in ratex-version.json; cannot verify ${url}`);
@@ -63,13 +99,7 @@ async function fetchAndVerify(url, sha256, label) {
     buf = fs.readFileSync(url);
   } else {
     log(`fetching ${label} from ${url}`);
-    try {
-      const res = await fetch(url);
-      if (!res.ok) fail(`${label} download failed: ${res.status} ${res.statusText} for ${url}`);
-      buf = Buffer.from(await res.arrayBuffer());
-    } catch (err) {
-      fail(`${label} download failed for ${url}: ${err.message}`);
-    }
+    buf = await download(url, label);
   }
   const digest = crypto.createHash('sha256').update(buf).digest('hex');
   if (digest !== sha256) {


### PR DESCRIPTION
> Stacked on top of #752 (review/merge that first). Follow-up for #745.

### What/Why?

#752 makes a failed RaTeX download degrade cleanly instead of crashing the pod build, but the reporter's actual trigger was a proxy: Node's global `fetch` is undici, which ignores `http_proxy`/`https_proxy` unless `NODE_USE_ENV_PROXY` is set, so the download times out on a machine where `curl` and the package manager both work. Without this, math stays disabled for them even after #752.

This hardens the download itself in `vendor-ratex.mjs`:

- Retry `fetch` a few times with backoff, to ride out transient GitHub/CDN blips.
- Fall back to `curl -fsSL --retry 3` when `fetch` keeps failing. `curl` honors the proxy env, so this covers the proxy case directly (and errors clearly if `curl` is absent). RaTeX is iOS-only, so builds run on macOS where `curl` is always present.
- The sha256 verification is unchanged and still runs on whatever was downloaded, so a truncated or tampered body is caught either way.

Scoped to `vendor-ratex.mjs` (the reporter's case). `vendor-grammars.mjs` fetches similarly and could get the same treatment later if we see grammar downloads flaking behind proxies.

### Testing

- **Proxy case (the one this PR fixes):** forced global `fetch` to fail on every attempt (simulating undici blocked by a proxy) while leaving `curl` able to reach the real URLs. `curl` recovered both downloads and produced a complete, valid tree - XCFramework, all 4 Swift sources, 20 fonts, LICENSE - with a `.stamp` matching the pinned key exactly (so sha256 verification passed on the curl-fetched bytes). This confirms the fallback actually restores the download, not just that the code path runs.
- Happy path (`--force`, real network): succeeds on the first `fetch` attempt, no fallback, tree complete with stamp.
- Unreachable host (both `fetch` and `curl` fail): logs 3 `fetch` attempts, then the `curl` fallback, then a clean fatal - and (thanks to #752's staging) leaves no partial tree behind.
- `node --check` passes.

Not exercised: a real HTTP proxy in front of `curl` (the `fetch` failure was simulated rather than standing one up) - that relies on `curl`'s own proxy-env handling, not new code here.

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

