### PR TITLE
docs(ios): fix broken Swift Package Manager link in README

### DIFF
--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -10,7 +10,7 @@ Standalone SwiftUI library for rendering enriched Markdown on iOS. This package 
 
 ## Installation
 
-Add the package via [Swift Package Manager](https://www.swift.org/documentation/package-manager/). The `Package.swift` lives at the repository root.
+Add the package via [Swift Package Manager](https://docs.swift.org/latest/documentation/packagemanagerdocs/). The `Package.swift` lives at the repository root.
 
 **Xcode:** File → Add Package Dependencies… → enter `https://github.com/software-mansion-labs/enriched-markdown-ios`, then select the `EnrichedMarkdown` product.
 


### PR DESCRIPTION
## Description

The Swift Package Manager link in the iOS package README pointed to `https://www.swift.org/documentation/package-manager/`, which no longer resolves. Updated it to the current canonical location: `https://docs.swift.org/latest/documentation/packagemanagerdocs/`.

## Changes

- `packages/enriched-markdown-ios/README.md`: fix the SPM documentation link in the Installation section.

Created with usage of AI tools