### PR TITLE
chore: bump ratex to 0.1.14

### DIFF
--- a/packages/react-native-enriched-markdown/android/build.gradle
+++ b/packages/react-native-enriched-markdown/android/build.gradle
@@ -278,7 +278,7 @@ dependencies {
   implementation "androidx.profileinstaller:profileinstaller:1.3.1"
   // LaTeX math rendering (optional — set enrichedMarkdown.enableMath=false in gradle.properties to exclude)
   if (enableMath) {
-    implementation("io.github.erweixin:ratex-android:0.1.10")
+    implementation("io.github.erweixin:ratex-android:0.1.14")
   }
 }
 


### PR DESCRIPTION
### What/Why?

Fixes #748. Android was pinned to `ratex-android:0.1.10` while iOS already vendors RaTeX `v0.1.14`, so the same LaTeX could render differently per platform. This aligns Android to `0.1.14` (the latest release on both Maven Central and GitHub), putting both platforms on an identical engine.

`v0.1.11` was also a security release fixing two parser DoS advisories, so Android was still exposed - this closes that gap too.

**No breaking changes were observed.** The `feat(react-native)!` New-Arch-only change in `0.1.14` is in RaTeX's RN wrapper package, which we don't use; we consume the raw `ratex-android` AAR / vendored iOS core, whose APIs (`RaTeXEngine.parseBlocking`, `RaTeXRenderer`, `RaTeXFontLoader`) are unchanged across `0.1.10` -> `0.1.14`.

### Testing

- Confirmed `0.1.14` is the latest on Maven Central and resolves cleanly.
- Recompiled the Android library against `0.1.14`: `BUILD SUCCESSFUL`, all `io.ratex` usages resolve (only pre-existing deprecation warnings).
- iOS already ships `0.1.14` via the vendored XCFramework - no source change needed.

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)