### PR TITLE
chore: install clang-format at the workspace root

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@react-native/babel-preset": "0.85.0",
     "@react-native/eslint-config": "0.85.0",
     "@release-it/conventional-changelog": "^10.0.6",
+    "clang-format": "^1.8.0",
     "commitlint": "^20.5.0",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10295,6 +10295,7 @@ __metadata:
     "@react-native/babel-preset": "npm:0.85.0"
     "@react-native/eslint-config": "npm:0.85.0"
     "@release-it/conventional-changelog": "npm:^10.0.6"
+    clang-format: "npm:^1.8.0"
     commitlint: "npm:^20.5.0"
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.1.8"


### PR DESCRIPTION
## Description

The `clang-format` pre-commit hook fails with `clang-format: command not found` for any contributor who doesn't happen to have a system-wide `clang-format` on their `PATH`.

`.yarnrc.yml` sets `nmHoistingLimits: workspaces`, which keeps a dependency inside the workspace that declares it. `clang-format` is declared only in `packages/react-native-enriched-markdown/package.json`, so it installs to:

```
packages/react-native-enriched-markdown/node_modules/.bin/clang-format
```

and never reaches the root `node_modules/.bin`. But `lefthook.yml` runs the hook from the repository root:

```yaml
clang-format:
  glob: '*.{h,m,mm,cpp}'
  exclude: '(Pods|build|node_modules)'
  run: npx clang-format -i {staged_files} && git add {staged_files}
```

`npx` can't resolve the binary there, falls through to `PATH`, and the commit is rejected. Anyone staging an `.h`/`.m`/`.mm`/`.cpp` file hits this.

## Solution

Declare `clang-format` as a root `devDependency`. Root workspace dependencies do install into the root `node_modules/.bin` (that's already how `lefthook`, `eslint`, `prettier` and `commitlint` resolve), so `npx clang-format` finds it, the hook's cwd stays at the repo root where `.clang-format` lives, and the root-relative `{staged_files}` paths keep working unchanged.


## Changes

- `package.json` — add `"clang-format": "^1.8.0"` to root `devDependencies`
- `yarn.lock` — record it on the root workspace (the `clang-format@npm:1.8.0` resolution already existed, so no new package is pulled in)

## Test plan

- [x] Confirmed the binary resolves only under the workspace, not at the root, on `main`
- [x] Confirmed every existing root `devDependency` has a matching `node_modules/.bin` entry, which is what makes the fix work
- [x] `yarn install --mode=update-lockfile` produces a 1-line lockfile change with no new resolutions

After merging, run `yarn install` — `npx clang-format --version` should then report `1.8.0` / `clang-format version 15.0.0` from the repository root.


