### PR TITLE
chore: claim context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/software-mansion/react-native-enriched-markdown",
+  "public_key": "pk_HVXnZeDFdGGgKpEPX2zBP"
+}


### PR DESCRIPTION
### What/Why?
Config for context7 library. Used to claim the library so we can change around suff there
