### PR TITLE
feat(web): add the EnrichedMarkdownTextInput wrapper and the web example editor

### DIFF
--- a/apps/react-native-web-example/src/App.tsx
+++ b/apps/react-native-web-example/src/App.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useState } from 'react';
-import { Linking, ScrollView, StyleSheet, View, Text } from 'react-native';
+import {
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+  Text,
+} from 'react-native';
 import { EnrichedMarkdownText } from 'react-native-enriched-markdown';
+import { InputEditor } from './InputEditor';
 import type {
   LinkPressEvent,
   LinkLongPressEvent,
@@ -110,6 +118,7 @@ const KIND_COLOR: Record<EventLog['kind'], string> = {
 };
 
 export default function App() {
+  const [screen, setScreen] = useState<'input' | 'renderer'>('input');
   const [lastEvent, setLastEvent] = useState<EventLog | null>(null);
 
   const onLinkPress = useCallback(({ url }: LinkPressEvent) => {
@@ -146,40 +155,64 @@ export default function App() {
         <Text style={styles.headerText}>
           react-native-enriched-markdown — web example
         </Text>
+        <View style={styles.segmented}>
+          {(['input', 'renderer'] as const).map((key) => (
+            <Pressable
+              key={key}
+              onPress={() => setScreen(key)}
+              style={[styles.segment, screen === key && styles.segmentActive]}
+            >
+              <Text
+                style={[
+                  styles.segmentText,
+                  screen === key && styles.segmentTextActive,
+                ]}
+              >
+                {key === 'input' ? 'Input' : 'Renderer'}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
       </View>
 
-      <ScrollView
-        style={styles.scroll}
-        contentContainerStyle={styles.scrollContent}
-      >
-        <SectionLabel>LaTeX</SectionLabel>
-        <EnrichedMarkdownText markdown={latexMarkdown} />
+      {screen === 'input' ? (
+        <ScrollView style={styles.scroll}>
+          <InputEditor />
+        </ScrollView>
+      ) : (
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+        >
+          <SectionLabel>LaTeX</SectionLabel>
+          <EnrichedMarkdownText markdown={latexMarkdown} />
 
-        <View style={styles.divider} />
+          <View style={styles.divider} />
 
-        <SectionLabel>LTR</SectionLabel>
-        <EnrichedMarkdownText
-          markdown={sampleMarkdown}
-          onLinkPress={onLinkPress}
-          onLinkLongPress={onLinkLongPress}
-          onImagePress={onImagePress}
-          onTaskListItemPress={onTaskListItemPress}
-          selectionColor="#DCDDFE"
-          md4cFlags={{
-            superscript: true,
-            subscript: true,
-          }}
-        />
+          <SectionLabel>LTR</SectionLabel>
+          <EnrichedMarkdownText
+            markdown={sampleMarkdown}
+            onLinkPress={onLinkPress}
+            onLinkLongPress={onLinkLongPress}
+            onImagePress={onImagePress}
+            onTaskListItemPress={onTaskListItemPress}
+            selectionColor="#DCDDFE"
+            md4cFlags={{
+              superscript: true,
+              subscript: true,
+            }}
+          />
 
-        <View style={styles.divider} />
+          <View style={styles.divider} />
 
-        <SectionLabel>RTL</SectionLabel>
-        <EnrichedMarkdownText
-          markdown={rtlMarkdown}
-          dir="rtl"
-          onTaskListItemPress={onTaskListItemPress}
-        />
-      </ScrollView>
+          <SectionLabel>RTL</SectionLabel>
+          <EnrichedMarkdownText
+            markdown={rtlMarkdown}
+            dir="rtl"
+            onTaskListItemPress={onTaskListItemPress}
+          />
+        </ScrollView>
+      )}
 
       {lastEvent && (
         <View style={styles.eventBar}>
@@ -217,12 +250,37 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff',
   },
   header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingVertical: 10,
     borderBottomWidth: 1,
     borderBottomColor: '#E5E7EB',
     backgroundColor: '#F9FAFB',
   },
+  segmented: {
+    flexDirection: 'row',
+    padding: 3,
+    borderRadius: 9,
+    backgroundColor: '#E9EBEF',
+  },
+  segment: {
+    minWidth: 92,
+    paddingVertical: 5,
+    paddingHorizontal: 14,
+    borderRadius: 7,
+    alignItems: 'center',
+  },
+  segmentActive: {
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000',
+    shadowOpacity: 0.08,
+    shadowRadius: 2,
+    shadowOffset: { width: 0, height: 1 },
+  },
+  segmentText: { fontSize: 13, fontWeight: '600', color: '#6B7280' },
+  segmentTextActive: { color: '#111827' },
   headerText: {
     fontSize: 14,
     fontWeight: '600',

--- a/apps/react-native-web-example/src/InputEditor.tsx
+++ b/apps/react-native-web-example/src/InputEditor.tsx
@@ -1,0 +1,325 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+  type PressableStateCallbackType,
+} from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import {
+  EnrichedMarkdownTextInput,
+  type EnrichedMarkdownTextInputInstance,
+  type StyleState,
+} from 'react-native-enriched-markdown';
+
+const SAMPLE =
+  '## Rebase\n\nfetch **now**, then *merge* the [branch](https://git-scm.com)\n\n- stack\n   - review\n\n1. fetch\n2. merge\n\n||spoiler|| and _underline_ and 🎉';
+
+type Instance = EnrichedMarkdownTextInputInstance;
+type IconName = React.ComponentProps<typeof MaterialIcons>['name'];
+type WebPressableState = PressableStateCallbackType & {
+  hovered?: boolean;
+  focused?: boolean;
+};
+
+interface Button {
+  key: string;
+  title: string;
+  icon?: IconName;
+  label?: string;
+  active: (s: StyleState | null) => boolean;
+  run: (input: Instance) => void;
+  disabled?: boolean;
+}
+
+const GROUPS: Button[][] = [
+  [
+    {
+      key: 'bold',
+      title: 'Bold',
+      icon: 'format-bold',
+      active: (s) => !!s?.bold.isActive,
+      run: (i) => i.toggleBold(),
+    },
+    {
+      key: 'italic',
+      title: 'Italic',
+      icon: 'format-italic',
+      active: (s) => !!s?.italic.isActive,
+      run: (i) => i.toggleItalic(),
+    },
+    {
+      key: 'underline',
+      title: 'Underline',
+      icon: 'format-underlined',
+      active: (s) => !!s?.underline.isActive,
+      run: (i) => i.toggleUnderline(),
+    },
+    {
+      key: 'strikethrough',
+      title: 'Strikethrough',
+      icon: 'strikethrough-s',
+      active: (s) => !!s?.strikethrough.isActive,
+      run: (i) => i.toggleStrikethrough(),
+    },
+    {
+      key: 'spoiler',
+      title: 'Spoiler',
+      icon: 'visibility-off',
+      active: (s) => !!s?.spoiler.isActive,
+      run: (i) => i.toggleSpoiler(),
+    },
+  ],
+  ([1, 2, 3, 4, 5, 6] as const).map((level) => ({
+    key: `h${level}`,
+    title: `Heading ${level}`,
+    label: `H${level}`,
+    active: (s: StyleState | null) =>
+      !!s?.heading.isActive && s.heading.level === level,
+    run: (i: Instance) => i.toggleHeading(level),
+  })),
+  [
+    {
+      key: 'bullet',
+      title: 'Bulleted list',
+      icon: 'format-list-bulleted',
+      active: (s) => !!s?.unorderedList.isActive,
+      run: (i) => i.toggleUnorderedList(),
+    },
+    {
+      key: 'ordered',
+      title: 'Numbered list',
+      icon: 'format-list-numbered',
+      active: (s) => !!s?.orderedList.isActive,
+      run: (i) => i.toggleOrderedList(),
+    },
+    {
+      key: 'outdent',
+      title: 'Outdent',
+      icon: 'format-indent-decrease',
+      active: () => false,
+      run: (i) => i.outdentList(),
+    },
+    {
+      key: 'indent',
+      title: 'Indent',
+      icon: 'format-indent-increase',
+      active: () => false,
+      run: (i) => i.indentList(),
+    },
+  ],
+  [
+    // Links are not wired on web yet, so the control is shown but disabled.
+    {
+      key: 'link',
+      title: 'Link (not available yet)',
+      icon: 'add-link',
+      active: (s) => !!s?.link.isActive,
+      run: () => {},
+      disabled: true,
+    },
+  ],
+];
+
+const COLORS = {
+  icon: '#374151',
+  iconOnActive: '#ffffff',
+  iconDisabled: '#b6bcc6',
+  active: '#2563eb',
+  hover: '#eceef1',
+  focusRing: '#93c5fd',
+  border: '#e5e7eb',
+  bar: '#f9fafb',
+  sourceBackground: '#fbfbfd',
+  sourceText: '#4b5563',
+  label: '#9ca3af',
+};
+
+function ToolbarButton({
+  button,
+  active,
+  onRun,
+}: {
+  button: Button;
+  active: boolean;
+  onRun: () => void;
+}) {
+  const color = button.disabled
+    ? COLORS.iconDisabled
+    : active
+      ? COLORS.iconOnActive
+      : COLORS.icon;
+  return (
+    <Pressable
+      accessibilityLabel={button.title}
+      aria-pressed={active}
+      disabled={button.disabled}
+      onPointerDown={(event) => event.preventDefault()}
+      onPress={onRun}
+      style={(state: WebPressableState) => [
+        styles.button,
+        active && styles.buttonActive,
+        !active && !button.disabled && state.hovered && styles.buttonHovered,
+        state.focused && styles.buttonFocused,
+      ]}
+    >
+      {button.icon ? (
+        <MaterialIcons name={button.icon} size={20} color={color} />
+      ) : (
+        <Text style={[styles.buttonLabel, { color }]}>{button.label}</Text>
+      )}
+    </Pressable>
+  );
+}
+
+export function InputEditor() {
+  const inputRef = useRef<Instance>(null);
+  const [state, setState] = useState<StyleState | null>(null);
+  const [markdown, setMarkdown] = useState(SAMPLE);
+  const { height: windowHeight } = useWindowDimensions();
+
+  useEffect(() => {
+    inputRef.current?.setValue(SAMPLE);
+  }, []);
+
+  return (
+    <View style={styles.wrap}>
+      <View style={[styles.card, { minHeight: windowHeight - 110 }]}>
+        <View style={styles.editorPane}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.toolbar}
+            contentContainerStyle={styles.toolbarContent}
+            accessibilityRole="toolbar"
+          >
+            {GROUPS.map((group, index) => (
+              <View key={index} style={styles.group}>
+                {index > 0 ? <View style={styles.separator} /> : null}
+                {group.map((button) => (
+                  <ToolbarButton
+                    key={button.key}
+                    button={button}
+                    active={button.active(state)}
+                    onRun={() => {
+                      if (inputRef.current) button.run(inputRef.current);
+                    }}
+                  />
+                ))}
+              </View>
+            ))}
+          </ScrollView>
+
+          <View style={styles.editorArea}>
+            <EnrichedMarkdownTextInput
+              ref={inputRef}
+              placeholder="Write markdown…"
+              style={editorStyle}
+              onChangeState={setState}
+              onChangeMarkdown={setMarkdown}
+            />
+          </View>
+        </View>
+
+        <View style={styles.sourcePane}>
+          <View style={styles.sourceLabelBar}>
+            <Text style={styles.sourceLabel}>MARKDOWN</Text>
+          </View>
+          <pre style={sourceStyle}>{markdown}</pre>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const BAR_HEIGHT = 46;
+
+const styles = StyleSheet.create({
+  wrap: { padding: 24 },
+  card: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '#ffffff',
+    boxShadow: '0 1px 3px rgba(0,0,0,0.06), 0 8px 24px rgba(0,0,0,0.04)',
+  },
+  editorPane: { flex: 1, minWidth: 0 },
+  toolbar: {
+    flexGrow: 0,
+    height: BAR_HEIGHT,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.border,
+    backgroundColor: COLORS.bar,
+  },
+  toolbarContent: {
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    gap: 2,
+  },
+  group: { flexDirection: 'row', alignItems: 'center', gap: 2 },
+  separator: {
+    width: 1,
+    height: 22,
+    marginHorizontal: 4,
+    backgroundColor: COLORS.border,
+  },
+  button: {
+    minWidth: 30,
+    height: 30,
+    paddingHorizontal: 5,
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonActive: { backgroundColor: COLORS.active },
+  buttonHovered: { backgroundColor: COLORS.hover },
+  buttonFocused: { outlineWidth: 2, outlineColor: COLORS.focusRing },
+  buttonLabel: { fontSize: 13, fontWeight: '700' },
+  editorArea: { flex: 1, paddingVertical: 20, paddingHorizontal: 24 },
+  sourcePane: {
+    flex: 1,
+    minWidth: 0,
+    borderLeftWidth: 1,
+    borderLeftColor: COLORS.border,
+    backgroundColor: COLORS.sourceBackground,
+  },
+  sourceLabelBar: {
+    height: BAR_HEIGHT,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.border,
+    backgroundColor: COLORS.bar,
+  },
+  sourceLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 1.2,
+    color: COLORS.label,
+  },
+});
+
+const editorStyle: React.CSSProperties = {
+  fontSize: 16,
+  lineHeight: 1.65,
+  outline: 'none',
+  minHeight: '100%',
+};
+
+const sourceStyle: React.CSSProperties = {
+  flex: 1,
+  margin: 0,
+  padding: '18px 20px',
+  fontFamily: 'ui-monospace, monospace',
+  fontSize: 13,
+  lineHeight: 1.65,
+  color: COLORS.sourceText,
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'anywhere',
+  overflow: 'auto',
+};

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -44,6 +44,12 @@ import { normalizeMenuItem } from './normalizeMenuItem';
 import { toNativeRegexConfig } from './utils/regexParser';
 import { TextInputState } from './utils/textInputState';
 import type { RefObject } from 'react';
+import type {
+  CaretRect,
+  HeadingLevel,
+  MarkdownTextInputInstance,
+  StyleState,
+} from './types/MarkdownTextInputInstance';
 
 type NativeRef = HostInstance;
 
@@ -53,7 +59,9 @@ export interface LinkStyle {
   backgroundColor?: string;
 }
 
-export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+export type { HeadingLevel, StyleState, CaretRect };
+export type EnrichedMarkdownTextInputInstance =
+  MarkdownTextInputInstance<HostInstance>;
 
 const VALID_HEADING_LEVELS = new Set<number>([1, 2, 3, 4, 5, 6]);
 
@@ -102,18 +110,6 @@ export interface MarkdownTextInputStyle {
   };
 }
 
-export interface StyleState {
-  bold: { isActive: boolean };
-  italic: { isActive: boolean };
-  underline: { isActive: boolean };
-  strikethrough: { isActive: boolean };
-  spoiler: { isActive: boolean };
-  link: { isActive: boolean };
-  heading: { isActive: boolean; level: HeadingLevel };
-  unorderedList: { isActive: boolean; depth: number };
-  orderedList: { isActive: boolean; depth: number };
-}
-
 export interface ContextMenuItem {
   text: string;
   onPress: (event: {
@@ -123,42 +119,6 @@ export interface ContextMenuItem {
   }) => void;
   icon?: string;
   visible?: boolean;
-}
-
-export interface CaretRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-export interface EnrichedMarkdownTextInputInstance {
-  focus: () => void;
-  blur: () => void;
-  measure: HostInstance['measure'];
-  measureInWindow: HostInstance['measureInWindow'];
-  measureLayout: HostInstance['measureLayout'];
-  setValue: (markdown: string) => void;
-  setSelection: (start: number, end: number) => void;
-  toggleBold: () => void;
-  toggleItalic: () => void;
-  toggleUnderline: () => void;
-  toggleStrikethrough: () => void;
-  toggleSpoiler: () => void;
-  toggleHeading: (level: HeadingLevel) => void;
-  toggleUnorderedList: () => void;
-  toggleOrderedList: () => void;
-  indentList: () => void;
-  outdentList: () => void;
-  setLink: (url: string) => void;
-  insertLink: (text: string, url: string) => void;
-  insertText: (text: string) => void;
-  insertMention: (displayText: string, url: string) => void;
-  startMention: (indicator: string) => void;
-  removeLink: () => void;
-  copyToClipboard: () => void;
-  getMarkdown: () => Promise<string>;
-  getCaretRect: () => Promise<CaretRect>;
 }
 
 /**

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -50,16 +50,16 @@ import type {
   MarkdownTextInputInstance,
   StyleState,
 } from './types/MarkdownTextInputInstance';
+import type {
+  HeadingStyle,
+  LinkStyle,
+  MarkdownTextInputStyle,
+} from './types/MarkdownTextInputStyle';
 
 type NativeRef = HostInstance;
 
-export interface LinkStyle {
-  color?: string;
-  underline?: boolean;
-  backgroundColor?: string;
-}
-
 export type { HeadingLevel, StyleState, CaretRect };
+export type { HeadingStyle, LinkStyle, MarkdownTextInputStyle };
 export type EnrichedMarkdownTextInputInstance =
   MarkdownTextInputInstance<HostInstance>;
 
@@ -67,47 +67,6 @@ const VALID_HEADING_LEVELS = new Set<number>([1, 2, 3, 4, 5, 6]);
 
 function toHeadingLevel(n: number): HeadingLevel {
   return (VALID_HEADING_LEVELS.has(n) ? n : 1) as HeadingLevel;
-}
-
-export interface HeadingStyle {
-  fontSize?: number;
-  fontWeight?: string;
-  color?: string;
-}
-
-export interface MarkdownTextInputStyle {
-  strong?: {
-    color?: string;
-  };
-  em?: {
-    color?: string;
-  };
-  link?: LinkStyle;
-  linkVariants?: Record<string, LinkStyle>;
-  spoiler?: {
-    color?: string;
-    backgroundColor?: string;
-  };
-  /**
-   * Per-level heading styling for the editor, mirroring the readonly
-   * renderer's `markdownStyle` h1..h6. Omitted levels fall back to defaults
-   * (font sizes 30/24/20/18/16/14).
-   */
-  h1?: HeadingStyle;
-  h2?: HeadingStyle;
-  h3?: HeadingStyle;
-  h4?: HeadingStyle;
-  h5?: HeadingStyle;
-  h6?: HeadingStyle;
-  /** List styling shared by bullet and numbered lists. */
-  list?: {
-    /**
-     * Vertical spacing (points) added above each list item so items read as
-     * separate rows. iOS uses `paragraphSpacingBefore`; Android a `LineHeightSpan`.
-     * @default 0
-     */
-    itemSpacing?: number;
-  };
 }
 
 export interface ContextMenuItem {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.web.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.web.tsx
@@ -1,0 +1,234 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+} from 'react';
+import type {
+  CaretRect,
+  HeadingLevel,
+  MarkdownTextInputInstance,
+  MeasureCallback,
+  MeasureInWindowCallback,
+  MeasureLayoutCallback,
+  StyleState,
+} from './types/MarkdownTextInputInstance';
+import { ImportQueue } from './web/input/editing/ImportQueue';
+import { InputHost } from './web/input/editing/InputHost';
+import type { InputState } from './web/input/editing/InputState';
+import {
+  measure,
+  measureInWindow,
+  measureLayout,
+} from './web/input/measureElement';
+
+export type {
+  CaretRect,
+  HeadingLevel,
+  MeasureCallback,
+  MeasureInWindowCallback,
+  MeasureLayoutCallback,
+  StyleState,
+};
+export type EnrichedMarkdownTextInputInstance =
+  MarkdownTextInputInstance<Element>;
+
+export interface EnrichedMarkdownTextInputProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'style' | 'defaultValue' | 'onFocus' | 'onBlur'
+> {
+  defaultValue?: string;
+  placeholder?: string;
+  placeholderTextColor?: string;
+  editable?: boolean;
+  autoFocus?: boolean;
+  style?: CSSProperties;
+  onChangeText?: (text: string) => void;
+  onChangeSelection?: (selection: { start: number; end: number }) => void;
+  onChangeState?: (state: StyleState) => void;
+  onChangeMarkdown?: (markdown: string) => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
+}
+
+const EMPTY_CARET_RECT: CaretRect = { x: 0, y: 0, width: 0, height: 0 };
+
+function logImportError(error: unknown): void {
+  console.error('EnrichedMarkdownTextInput.setValue failed', error);
+}
+
+function toStyleState(state: InputState): StyleState {
+  return {
+    ...state,
+    heading: {
+      isActive: state.heading.isActive,
+      level: state.heading.level as HeadingLevel,
+    },
+  };
+}
+
+function warnOnce(): (name: string) => () => void {
+  const warned = new Set<string>();
+  return (name) => () => {
+    if (!warned.has(name)) {
+      warned.add(name);
+      console.warn(
+        `EnrichedMarkdownTextInput.${name} is not yet implemented on web`
+      );
+    }
+  };
+}
+
+export const EnrichedMarkdownTextInput = forwardRef<
+  EnrichedMarkdownTextInputInstance,
+  EnrichedMarkdownTextInputProps
+>(function EnrichedMarkdownTextInput(
+  {
+    defaultValue,
+    placeholder,
+    placeholderTextColor,
+    editable = true,
+    autoFocus = false,
+    style,
+    onChangeText,
+    onChangeSelection,
+    onChangeState,
+    onChangeMarkdown,
+    onFocus,
+    onBlur,
+    ...domProps
+  },
+  ref
+) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const host = useRef<InputHost | null>(null);
+  const [queue] = useState(() => new ImportQueue());
+  const initialDefaultValue = useRef(defaultValue).current;
+  const initialAutoFocus = useRef(autoFocus).current;
+  const currentCallbacks = {
+    onChangeText,
+    onChangeSelection,
+    onChangeState,
+    onChangeMarkdown,
+    onFocus,
+    onBlur,
+  };
+  const callbacks = useRef(currentCallbacks);
+  useLayoutEffect(() => {
+    callbacks.current = currentCallbacks;
+  });
+
+  useEffect(() => {
+    const instance = new InputHost(rootRef.current!, {
+      onChangeText: (text) => callbacks.current.onChangeText?.(text),
+      onChangeSelection: (selection) =>
+        callbacks.current.onChangeSelection?.(selection),
+      onChangeState: (state) =>
+        callbacks.current.onChangeState?.(toStyleState(state)),
+      onChangeMarkdown: (markdown) =>
+        callbacks.current.onChangeMarkdown?.(markdown),
+    });
+    host.current = instance;
+    if (initialDefaultValue !== undefined) {
+      queue.startImport(
+        () => instance.setValue(initialDefaultValue),
+        logImportError
+      );
+    }
+    if (initialAutoFocus) {
+      instance.focus();
+    }
+    return () => {
+      instance.destroy();
+      host.current = null;
+    };
+  }, [queue, initialDefaultValue, initialAutoFocus]);
+
+  useEffect(() => {
+    host.current?.setEditable(editable);
+  }, [editable]);
+
+  useEffect(() => {
+    const root = rootRef.current!;
+    const handleFocus = () => callbacks.current.onFocus?.();
+    const handleBlur = () => callbacks.current.onBlur?.();
+    root.addEventListener('focus', handleFocus);
+    root.addEventListener('blur', handleBlur);
+    return () => {
+      root.removeEventListener('focus', handleFocus);
+      root.removeEventListener('blur', handleBlur);
+    };
+  }, []);
+
+  useImperativeHandle(ref, () => {
+    const root = rootRef.current!;
+    const notImplemented = warnOnce();
+    return {
+      focus: () => host.current?.focus(),
+      blur: () => host.current?.blur(),
+      measure: (callback) => measure(root, callback),
+      measureInWindow: (callback) => measureInWindow(root, callback),
+      measureLayout: (relativeTo, onSuccess, onFail) =>
+        measureLayout(root, relativeTo, onSuccess, onFail),
+
+      setValue: (markdown) =>
+        queue.startImport(
+          () => host.current?.setValue(markdown),
+          logImportError
+        ),
+      setSelection: (start, end) =>
+        queue.afterImport(() => host.current?.setSelection(start, end)),
+      insertText: (text) =>
+        queue.afterImport(() => host.current?.insertText(text)),
+      getMarkdown: () =>
+        Promise.resolve(
+          queue.afterImport(() => host.current?.getMarkdown() ?? '')
+        ),
+      getCaretRect: () =>
+        Promise.resolve(
+          queue.afterImport(() => host.current?.caretRect() ?? EMPTY_CARET_RECT)
+        ),
+
+      toggleBold: () => queue.afterImport(() => host.current?.toggleBold()),
+      toggleItalic: () => queue.afterImport(() => host.current?.toggleItalic()),
+      toggleUnderline: () =>
+        queue.afterImport(() => host.current?.toggleUnderline()),
+      toggleStrikethrough: () =>
+        queue.afterImport(() => host.current?.toggleStrikethrough()),
+      toggleSpoiler: () =>
+        queue.afterImport(() => host.current?.toggleSpoiler()),
+      toggleHeading: (level) =>
+        queue.afterImport(() => host.current?.toggleHeading(level)),
+      toggleUnorderedList: () =>
+        queue.afterImport(() => host.current?.toggleUnorderedList()),
+      toggleOrderedList: () =>
+        queue.afterImport(() => host.current?.toggleOrderedList()),
+      indentList: () => queue.afterImport(() => host.current?.indentList()),
+      outdentList: () => queue.afterImport(() => host.current?.outdentList()),
+
+      setLink: notImplemented('setLink'),
+      insertLink: notImplemented('insertLink'),
+      removeLink: notImplemented('removeLink'),
+      insertMention: notImplemented('insertMention'),
+      startMention: notImplemented('startMention'),
+      copyToClipboard: notImplemented('copyToClipboard'),
+    };
+  }, [queue]);
+
+  const cssVariables = {
+    '--enrm-placeholder-color': placeholderTextColor,
+  } as CSSProperties;
+  return (
+    <div
+      {...domProps}
+      ref={rootRef}
+      style={{ ...cssVariables, ...style }}
+      data-placeholder={placeholder}
+      aria-disabled={!editable}
+    />
+  );
+});

--- a/packages/react-native-enriched-markdown/src/index.web.tsx
+++ b/packages/react-native-enriched-markdown/src/index.web.tsx
@@ -1,4 +1,15 @@
 export { EnrichedMarkdownText, default } from './web/EnrichedMarkdownText';
+export { EnrichedMarkdownTextInput } from './EnrichedMarkdownTextInput.web';
+export type {
+  CaretRect,
+  EnrichedMarkdownTextInputInstance,
+  EnrichedMarkdownTextInputProps,
+  StyleState,
+  HeadingLevel,
+  MeasureCallback,
+  MeasureInWindowCallback,
+  MeasureLayoutCallback,
+} from './EnrichedMarkdownTextInput.web';
 export type { EnrichedMarkdownTextProps } from './types/MarkdownTextProps.web';
 export type { MarkdownStyle, Md4cFlags } from './types/MarkdownStyle';
 export type {

--- a/packages/react-native-enriched-markdown/src/inputStyleDefaults.ts
+++ b/packages/react-native-enriched-markdown/src/inputStyleDefaults.ts
@@ -1,0 +1,6 @@
+// Default input colors shared by the native normalizer and the web editor.
+
+export const DEFAULT_LINK_COLOR = '#2563EB';
+export const DEFAULT_LINK_BG_COLOR = 'transparent';
+export const DEFAULT_SPOILER_COLOR = '#374151';
+export const DEFAULT_SPOILER_BG_COLOR = '#E5E7EB';

--- a/packages/react-native-enriched-markdown/src/normalizeMarkdownTextInputStyle.ts
+++ b/packages/react-native-enriched-markdown/src/normalizeMarkdownTextInputStyle.ts
@@ -3,7 +3,13 @@ import type {
   HeadingStyle,
   LinkStyle,
   MarkdownTextInputStyle,
-} from './EnrichedMarkdownTextInput';
+} from './types/MarkdownTextInputStyle';
+import {
+  DEFAULT_LINK_BG_COLOR,
+  DEFAULT_LINK_COLOR,
+  DEFAULT_SPOILER_BG_COLOR,
+  DEFAULT_SPOILER_COLOR,
+} from './inputStyleDefaults';
 import { normalizeLinkVariantEntries } from './linkVariantUtils';
 import { normalizeColor } from './styleUtils';
 import {
@@ -52,11 +58,6 @@ interface MarkdownTextInputStyleInternal {
     itemSpacing: number;
   };
 }
-
-export const DEFAULT_LINK_COLOR = '#2563EB';
-const DEFAULT_LINK_BG_COLOR = 'transparent';
-export const DEFAULT_SPOILER_COLOR = '#374151';
-export const DEFAULT_SPOILER_BG_COLOR = '#E5E7EB';
 
 // Defaults shared with the read-only renderer via headingDefaults; consumers
 // override per level via markdownStyle h1..h6.

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextInputInstance.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextInputInstance.ts
@@ -1,0 +1,76 @@
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface StyleState {
+  bold: { isActive: boolean };
+  italic: { isActive: boolean };
+  underline: { isActive: boolean };
+  strikethrough: { isActive: boolean };
+  spoiler: { isActive: boolean };
+  link: { isActive: boolean };
+  heading: { isActive: boolean; level: HeadingLevel };
+  unorderedList: { isActive: boolean; depth: number };
+  orderedList: { isActive: boolean; depth: number };
+}
+
+export interface CaretRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type MeasureCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  pageX: number,
+  pageY: number
+) => void;
+
+export type MeasureInWindowCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number
+) => void;
+
+export type MeasureLayoutCallback = (
+  left: number,
+  top: number,
+  width: number,
+  height: number
+) => void;
+
+export interface MarkdownTextInputInstance<Node = unknown> {
+  focus: () => void;
+  blur: () => void;
+  measure: (callback: MeasureCallback) => void;
+  measureInWindow: (callback: MeasureInWindowCallback) => void;
+  measureLayout: (
+    relativeTo: number | Node,
+    onSuccess: MeasureLayoutCallback,
+    onFail?: () => void
+  ) => void;
+  setValue: (markdown: string) => void;
+  setSelection: (start: number, end: number) => void;
+  toggleBold: () => void;
+  toggleItalic: () => void;
+  toggleUnderline: () => void;
+  toggleStrikethrough: () => void;
+  toggleSpoiler: () => void;
+  toggleHeading: (level: HeadingLevel) => void;
+  toggleUnorderedList: () => void;
+  toggleOrderedList: () => void;
+  indentList: () => void;
+  outdentList: () => void;
+  setLink: (url: string) => void;
+  insertLink: (text: string, url: string) => void;
+  insertText: (text: string) => void;
+  insertMention: (displayText: string, url: string) => void;
+  startMention: (indicator: string) => void;
+  removeLink: () => void;
+  copyToClipboard: () => void;
+  getMarkdown: () => Promise<string>;
+  getCaretRect: () => Promise<CaretRect>;
+}

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextInputStyle.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextInputStyle.ts
@@ -1,0 +1,46 @@
+export interface LinkStyle {
+  color?: string;
+  underline?: boolean;
+  backgroundColor?: string;
+}
+
+export interface HeadingStyle {
+  fontSize?: number;
+  fontWeight?: string;
+  color?: string;
+}
+
+export interface MarkdownTextInputStyle {
+  strong?: {
+    color?: string;
+  };
+  em?: {
+    color?: string;
+  };
+  link?: LinkStyle;
+  linkVariants?: Record<string, LinkStyle>;
+  spoiler?: {
+    color?: string;
+    backgroundColor?: string;
+  };
+  /**
+   * Per-level heading styling for the editor, mirroring the readonly
+   * renderer's `markdownStyle` h1..h6. Omitted levels fall back to defaults
+   * (font sizes 30/24/20/18/16/14).
+   */
+  h1?: HeadingStyle;
+  h2?: HeadingStyle;
+  h3?: HeadingStyle;
+  h4?: HeadingStyle;
+  h5?: HeadingStyle;
+  h6?: HeadingStyle;
+  /** List styling shared by bullet and numbered lists. */
+  list?: {
+    /**
+     * Vertical spacing (points) added above each list item so items read as
+     * separate rows. iOS uses `paragraphSpacingBefore`; Android a `LineHeightSpan`.
+     * @default 0
+     */
+    itemSpacing?: number;
+  };
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/ImportQueue.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/ImportQueue.ts
@@ -1,0 +1,27 @@
+// Serializes work behind an import in flight, so commands issued right after
+// setValue act on the new document.
+export class ImportQueue {
+  private pending: Promise<void> | null = null;
+
+  afterImport<T>(task: () => T): T | Promise<T> {
+    return this.pending === null ? task() : this.pending.then(task);
+  }
+
+  startImport(
+    importTask: () => Promise<void> | void,
+    onError: (error: unknown) => void
+  ): void {
+    const previous = this.pending ?? Promise.resolve();
+    const next = previous
+      .then(importTask)
+      // A failed import must not block the work queued behind it.
+      .catch(onError)
+      .finally(() => {
+        // A newer import may already be pending; only the latest one clears.
+        if (this.pending === next) {
+          this.pending = null;
+        }
+      });
+    this.pending = next;
+  }
+}

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -1,6 +1,10 @@
 import { BlockStore, lineAtPosition } from '../formatting/BlockStore';
 import { FormattingStore } from '../formatting/FormattingStore';
 import { parseToPlainTextAndRanges } from '../formatting/InputParser';
+import {
+  markdownLinePrefix,
+  serialize,
+} from '../formatting/MarkdownSerializer';
 import type { RangeBounds } from '../model/rangeBounds';
 import { DomRenderer } from '../render/DomRenderer';
 import { projectParagraphs } from '../render/InputProjection';
@@ -19,6 +23,7 @@ export interface InputHostCallbacks {
   onChangeText?: (text: string) => void;
   onChangeSelection?: (selection: RangeBounds) => void;
   onChangeState?: (state: InputState) => void;
+  onChangeMarkdown?: (markdown: string) => void;
 }
 
 export class InputHost {
@@ -85,6 +90,15 @@ export class InputHost {
     return this.text;
   }
 
+  getMarkdown(): string {
+    return serialize(
+      this.text,
+      this.formattingStore.allRanges,
+      this.blockStore.allRanges,
+      markdownLinePrefix
+    );
+  }
+
   async setValue(markdown: string): Promise<void> {
     const { plainText, formattingRanges, blockRanges } =
       await parseToPlainTextAndRanges(markdown);
@@ -96,7 +110,7 @@ export class InputHost {
       this.selection = { start: plainText.length, end: plainText.length };
     });
     this.render();
-    this.emitChanges();
+    this.emitTextEdited();
   }
 
   indentList(): void {
@@ -140,7 +154,7 @@ export class InputHost {
       this.blockCoordinator.toggleHeading(level, this.selection, this.text)
     );
     this.render();
-    this.emitState();
+    this.emitFormattingChanged();
   }
 
   private readonly handleBeforeInput = (event: InputEvent): void => {
@@ -273,6 +287,7 @@ export class InputHost {
     );
     if (changed) {
       this.render();
+      this.emitFormattingChanged();
     }
   }
 
@@ -281,7 +296,7 @@ export class InputHost {
       this.blockCoordinator.toggleListType(type, this.selection, this.text)
     );
     this.render();
-    this.emitState();
+    this.emitFormattingChanged();
   }
 
   private toggleInlineStyle(type: InputStyleType): void {
@@ -291,7 +306,7 @@ export class InputHost {
     );
     this.typing.toggleStyle(type, wasActive, start !== end);
     this.render();
-    this.emitState();
+    this.emitFormattingChanged();
   }
 
   private replaceSelection(insertedText: string): void {
@@ -349,8 +364,7 @@ export class InputHost {
       this.session.recordTextChange();
     });
     this.render();
-    this.emitChanges();
-    this.emitState();
+    this.emitTextEdited();
   }
 
   private render(): void {
@@ -402,11 +416,17 @@ export class InputHost {
     );
   }
 
-  private emitChanges(): void {
+  private emitText(): void {
     if (this.session.shouldSuppressEvents) {
       return;
     }
     this.callbacks.onChangeText?.(this.text);
+  }
+
+  private emitSelection(): void {
+    if (this.session.shouldSuppressEvents) {
+      return;
+    }
     this.callbacks.onChangeSelection?.(this.selection);
   }
 
@@ -429,5 +449,24 @@ export class InputHost {
     }
     this.lastEmittedState = state;
     this.callbacks.onChangeState?.(state);
+  }
+
+  private emitMarkdown(): void {
+    if (this.session.shouldSuppressEvents || !this.callbacks.onChangeMarkdown) {
+      return;
+    }
+    this.callbacks.onChangeMarkdown(this.getMarkdown());
+  }
+
+  private emitTextEdited(): void {
+    this.emitText();
+    this.emitSelection();
+    this.emitState();
+    this.emitMarkdown();
+  }
+
+  private emitFormattingChanged(): void {
+    this.emitState();
+    this.emitMarkdown();
   }
 }

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -393,13 +393,13 @@ export class InputHost {
     if (domSelection === null) {
       return;
     }
-    // Compare in model offsets: a boundary caret has two DOM addresses, so
-    // node identity would report false divergence on every render.
     const current = this.mapper.modelSelectionFromDom(domSelection);
+    const collapsed = this.selection.start === this.selection.end;
     if (
       current !== null &&
       current.start === this.selection.start &&
-      current.end === this.selection.end
+      current.end === this.selection.end &&
+      domSelection.isCollapsed === collapsed
     ) {
       return;
     }

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -433,6 +433,10 @@ export class InputHost {
 
   private render(): void {
     this.session.scoped('formatting', () => {
+      this.root.toggleAttribute(
+        'data-empty',
+        this.text.length === 0 && this.blockStore.allRanges.length === 0
+      );
       this.renderer.render(
         this.text,
         projectParagraphs(

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -242,12 +242,15 @@ export class InputHost {
       return;
     }
     this.selection = mapped;
-    if (!this.session.isPostEditGracePeriod) {
-      this.typing.resetForSelectionChange(mapped);
-    }
-    this.callbacks.onChangeSelection?.(mapped);
-    this.emitState();
+    this.resetTypingAfterSelectionMove();
+    this.emitSelectionMoved();
   };
+
+  private resetTypingAfterSelectionMove(): void {
+    if (!this.session.isPostEditGracePeriod) {
+      this.typing.resetForSelectionChange(this.selection);
+    }
+  }
 
   private insertNewline(): void {
     const { start, end } = this.selection;
@@ -468,5 +471,10 @@ export class InputHost {
   private emitFormattingChanged(): void {
     this.emitState();
     this.emitMarkdown();
+  }
+
+  private emitSelectionMoved(): void {
+    this.emitSelection();
+    this.emitState();
   }
 }

--- a/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/editing/InputHost.ts
@@ -19,6 +19,13 @@ import { TypingAttributesController } from './TypingAttributesController';
 import { buildInputState, sameInputState, type InputState } from './InputState';
 import { charLengthBefore, charLengthAfter } from '../utils';
 
+export interface CaretRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface InputHostCallbacks {
   onChangeText?: (text: string) => void;
   onChangeSelection?: (selection: RangeBounds) => void;
@@ -40,6 +47,7 @@ export class InputHost {
 
   private text = '';
   private selection: RangeBounds = { start: 0, end: 0 };
+  private editable = true;
   private lastEmittedState: InputState | null = null;
 
   constructor(root: HTMLElement, callbacks: InputHostCallbacks = {}) {
@@ -99,6 +107,39 @@ export class InputHost {
     );
   }
 
+  focus(): void {
+    this.root.focus();
+  }
+
+  setEditable(editable: boolean): void {
+    this.editable = editable;
+    this.root.contentEditable = editable ? 'true' : 'false';
+  }
+
+  caretRect(): CaretRect | null {
+    const position = this.mapper.domPositionFromModelOffset(
+      this.selection.start
+    );
+    if (position === null) {
+      return null;
+    }
+    const range = this.root.ownerDocument.createRange();
+    range.setStart(position.node, position.offset);
+    range.collapse(true);
+    const rect = range.getBoundingClientRect();
+    const rootRect = this.root.getBoundingClientRect();
+    return {
+      x: rect.left - rootRect.left,
+      y: rect.top - rootRect.top,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  blur(): void {
+    this.root.blur();
+  }
+
   async setValue(markdown: string): Promise<void> {
     const { plainText, formattingRanges, blockRanges } =
       await parseToPlainTextAndRanges(markdown);
@@ -111,6 +152,18 @@ export class InputHost {
     });
     this.render();
     this.emitTextEdited();
+  }
+
+  setSelection(start: number, end: number): void {
+    const max = this.text.length;
+    const clampedStart = Math.max(0, Math.min(start, max));
+    this.selection = {
+      start: clampedStart,
+      end: Math.max(clampedStart, Math.min(end, max)),
+    };
+    this.render();
+    this.resetTypingAfterSelectionMove();
+    this.emitSelectionMoved();
   }
 
   indentList(): void {
@@ -158,6 +211,10 @@ export class InputHost {
   }
 
   private readonly handleBeforeInput = (event: InputEvent): void => {
+    if (!this.editable) {
+      event.preventDefault();
+      return;
+    }
     // During composition the browser owns the DOM; the read-back step will
     // reconcile it later.
     if (this.session.isComposing) {
@@ -200,7 +257,7 @@ export class InputHost {
   // Tab never reaches beforeinput (the browser moves focus), so it is the
   // one key handled here.
   private readonly handleKeyDown = (event: KeyboardEvent): void => {
-    if (event.key !== 'Tab' || this.session.isComposing) {
+    if (!this.editable || event.key !== 'Tab' || this.session.isComposing) {
       return;
     }
     event.preventDefault();
@@ -310,6 +367,10 @@ export class InputHost {
     this.typing.toggleStyle(type, wasActive, start !== end);
     this.render();
     this.emitFormattingChanged();
+  }
+
+  insertText(text: string): void {
+    this.replaceSelection(text);
   }
 
   private replaceSelection(insertedText: string): void {

--- a/packages/react-native-enriched-markdown/src/web/input/measureElement.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/measureElement.ts
@@ -1,0 +1,46 @@
+import type {
+  MeasureCallback,
+  MeasureInWindowCallback,
+  MeasureLayoutCallback,
+} from '../../types/MarkdownTextInputInstance';
+
+export function measure(element: HTMLElement, callback: MeasureCallback): void {
+  const rect = element.getBoundingClientRect();
+  const parent = element.offsetParent?.getBoundingClientRect();
+  callback(
+    rect.left - (parent?.left ?? 0),
+    rect.top - (parent?.top ?? 0),
+    rect.width,
+    rect.height,
+    rect.left + window.scrollX,
+    rect.top + window.scrollY
+  );
+}
+
+export function measureInWindow(
+  element: HTMLElement,
+  callback: MeasureInWindowCallback
+): void {
+  const rect = element.getBoundingClientRect();
+  callback(rect.left, rect.top, rect.width, rect.height);
+}
+
+export function measureLayout(
+  element: HTMLElement,
+  relativeTo: unknown,
+  onSuccess: MeasureLayoutCallback,
+  onFail?: () => void
+): void {
+  if (!(relativeTo instanceof Element)) {
+    onFail?.();
+    return;
+  }
+  const rect = element.getBoundingClientRect();
+  const other = relativeTo.getBoundingClientRect();
+  onSuccess(
+    rect.left - other.left,
+    rect.top - other.top,
+    rect.width,
+    rect.height
+  );
+}

--- a/packages/react-native-enriched-markdown/src/web/input/render/inputStyles.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/inputStyles.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_LINK_COLOR,
   DEFAULT_SPOILER_BG_COLOR,
   DEFAULT_SPOILER_COLOR,
-} from '../../../normalizeMarkdownTextInputStyle';
+} from '../../../inputStyleDefaults';
 import { injectStyleOnce } from '../../injectStyle';
 import {
   HEADING_BLOCK_TYPES,

--- a/packages/react-native-enriched-markdown/src/web/input/render/inputStyles.ts
+++ b/packages/react-native-enriched-markdown/src/web/input/render/inputStyles.ts
@@ -50,11 +50,22 @@ function listRules(): string {
 const INPUT_CSS = `
 .${ENRM_INPUT_CLASS} {
   white-space: pre-wrap;
+  position: relative;
   overflow-wrap: break-word;
   font-family: ${defaults.paragraph.fontFamily};
   font-size: ${defaults.paragraph.fontSize}px;
   line-height: ${defaults.paragraph.lineHeight}px;
   color: ${defaults.paragraph.color};
+}
+.${ENRM_INPUT_CLASS}[data-empty]::before {
+  content: attr(data-placeholder);
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: inherit;
+  color: var(--enrm-placeholder-color, #9ca3af);
+  pointer-events: none;
+  white-space: pre-wrap;
 }
 .${ENRM_INPUT_CLASS} [data-block] {
   position: relative;


### PR DESCRIPTION
Adds the React component over the input host, so the web input exposes the same API as the native one, plus an editor screen in the web example.

* `MarkdownTextInputInstance` and `StyleState` move to a platform-neutral module shared by both components; the input style types and default colors follow, so the web code no longer imports from files that depend on React Native. The native exports are unchanged.
* `InputHost`: reports markdown alongside the formatting state, gains the commands the wrapper needs (`setSelection`, `insertText`, `setEditable`, `focus`/`blur`, `caretRect`), shows the placeholder while the document is empty and no longer leaves a DOM selection stretched over an empty line after deleting everything.
* `EnrichedMarkdownTextInput.web`: the web counterpart of the native component. It creates the host once, forwards the props and events to it and builds the same imperative handle, with `measure*` in React Native's coordinate spaces. Commands issued while `setValue` is still parsing wait for it (`ImportQueue`). Links, mentions and clipboard warn once as not implemented on web.
* Web example: an editor screen with a formatting toolbar (inline styles, headings, lists) and a live markdown pane.

Stacked on [#747](https://github.com/software-mansion/enriched-markdown/pull/747).