### PR TITLE
fix: dont crash on liststylemarker being null

### DIFF
--- a/packages/react-native-enriched-markdown/__tests__/markdown-style-colors.test.ts
+++ b/packages/react-native-enriched-markdown/__tests__/markdown-style-colors.test.ts
@@ -1,0 +1,36 @@
+import { normalizeMarkdownStyle } from '../src/normalizeMarkdownStyle';
+import { normalizeColor } from '../src/styleUtils';
+
+const defaultMarkerColor = normalizeColor('#6B7280');
+
+it('keeps the default marker color when an invalid color string is passed', () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  const result = normalizeMarkdownStyle({
+    list: { markerColor: 'not-a-real-color' },
+  });
+
+  expect(result.list.markerColor).toBe(defaultMarkerColor);
+  expect(result.list.markerColor).toBeDefined();
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('not-a-real-color')
+  );
+
+  warn.mockRestore();
+});
+
+it('keeps the default marker color when the color is explicitly undefined', () => {
+  const result = normalizeMarkdownStyle({
+    list: { markerColor: undefined },
+  });
+
+  expect(result.list.markerColor).toBe(defaultMarkerColor);
+});
+
+it('passes a valid marker color through unchanged', () => {
+  const result = normalizeMarkdownStyle({
+    list: { markerColor: '#123456' },
+  });
+
+  expect(result.list.markerColor).toBe(normalizeColor('#123456'));
+});

--- a/packages/react-native-enriched-markdown/__tests__/markdown-style-colors.test.ts
+++ b/packages/react-native-enriched-markdown/__tests__/markdown-style-colors.test.ts
@@ -27,6 +27,15 @@ it('keeps the default marker color when the color is explicitly undefined', () =
   expect(result.list.markerColor).toBe(defaultMarkerColor);
 });
 
+it('keeps the default marker color when the color is explicitly null', () => {
+  const result = normalizeMarkdownStyle({
+    list: { markerColor: null as unknown as string },
+  });
+
+  expect(result.list.markerColor).toBe(defaultMarkerColor);
+  expect(result.list.markerColor).not.toBeNull();
+});
+
 it('passes a valid marker color through unchanged', () => {
   const result = normalizeMarkdownStyle({
     list: { markerColor: '#123456' },

--- a/packages/react-native-enriched-markdown/src/styleUtils.ts
+++ b/packages/react-native-enriched-markdown/src/styleUtils.ts
@@ -6,7 +6,16 @@ export const normalizeColor = (
 ): ColorValue | undefined => {
   if (!color) return undefined;
   if (Platform.OS === 'web') return color;
-  return processColor(color) ?? undefined;
+  const processed = processColor(color);
+  if (processed === null || processed === undefined) {
+    if (__DEV__) {
+      console.warn(
+        `[MarkdownStyle] Ignoring invalid color value "${color}"; falling back to the default.`
+      );
+    }
+    return undefined;
+  }
+  return processed;
 };
 
 export function mergeSubStyle<T extends Record<string, unknown>>(
@@ -31,11 +40,13 @@ export function mergeSubStyle<T extends Record<string, unknown>>(
         ...(userValue as Record<string, unknown>),
       };
     }
-    if (
-      key.toLowerCase().includes('color') &&
-      typeof result[key] === 'string'
-    ) {
-      result[key] = normalizeColor(result[key] as string);
+    if (key.toLowerCase().includes('color')) {
+      const value = result[key];
+      if (typeof value === 'string') {
+        result[key] = normalizeColor(value) ?? defaultValue;
+      } else if (value === undefined) {
+        result[key] = defaultValue;
+      }
     }
   }
   return result as T;

--- a/packages/react-native-enriched-markdown/src/styleUtils.ts
+++ b/packages/react-native-enriched-markdown/src/styleUtils.ts
@@ -44,7 +44,7 @@ export function mergeSubStyle<T extends Record<string, unknown>>(
       const value = result[key];
       if (typeof value === 'string') {
         result[key] = normalizeColor(value) ?? defaultValue;
-      } else if (value === undefined) {
+      } else if (value === undefined || value === null) {
         result[key] = defaultValue;
       }
     }


### PR DESCRIPTION
### What/Why?

Closes #773.

Hardens the way we apply default for `listStyleMarker`. Now it fallbacks to default (and warns in dev), when the prop is invalid.

### Testing
Added test case to verify this

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)

