### PR TITLE
feat(input): convert typed markdown block prefixes into blocks (markdownShortcuts)

### DIFF
--- a/.maestro/enrichedMarkdownInput/flows/basic/block_elements/markdown_shortcut_heading_test.yaml
+++ b/.maestro/enrichedMarkdownInput/flows/basic/block_elements/markdown_shortcut_heading_test.yaml
@@ -1,0 +1,37 @@
+appId: swmansion.enriched.markdown.example
+tags:
+  - input
+  - heading
+  - block
+  - markdown-shortcuts
+---
+# Typing "# " at the start of a paragraph converts it into an H1 and drops the
+# prefix, so the visible text is "Title" styled as a heading — not the literal
+# "# Title" it used to stay until the markdown was reloaded.
+- launchApp:
+    clearState: true
+
+- runFlow:
+    file: '../../../../subflows/move_to_playground.yaml'
+
+- tapOn:
+    id: focus-button
+- waitForAnimationToEnd
+
+- inputText: '# Title'
+- waitForAnimationToEnd
+
+- pressKey: Enter
+- waitForAnimationToEnd
+
+# A heading does not continue onto the next line; this stays a paragraph.
+- inputText: 'Body text'
+- waitForAnimationToEnd
+
+- tapOn:
+    id: blur-button
+
+- runFlow:
+    file: '../../../subflows/capture_or_assert_screenshot.yaml'
+    env:
+      SCREENSHOT_NAME: 'markdown_shortcut_heading_input'

--- a/.maestro/enrichedMarkdownInput/flows/basic/block_elements/markdown_shortcut_list_test.yaml
+++ b/.maestro/enrichedMarkdownInput/flows/basic/block_elements/markdown_shortcut_list_test.yaml
@@ -1,0 +1,46 @@
+appId: swmansion.enriched.markdown.example
+tags:
+  - input
+  - unordered-list
+  - ordered-list
+  - block
+  - markdown-shortcuts
+---
+# "- " and "1. " typed at a paragraph start become list items with the prefix
+# removed; Return then continues the list exactly as a toolbar-toggled one does.
+- launchApp:
+    clearState: true
+
+- runFlow:
+    file: '../../../../subflows/move_to_playground.yaml'
+
+- tapOn:
+    id: focus-button
+- waitForAnimationToEnd
+
+- inputText: '- First bullet'
+- waitForAnimationToEnd
+- pressKey: Enter
+- waitForAnimationToEnd
+- inputText: 'Second bullet'
+- waitForAnimationToEnd
+
+# Two Returns exit the list, leaving a plain paragraph to start a numbered one.
+- pressKey: Enter
+- pressKey: Enter
+- waitForAnimationToEnd
+
+- inputText: '1. First step'
+- waitForAnimationToEnd
+- pressKey: Enter
+- waitForAnimationToEnd
+- inputText: 'Second step'
+- waitForAnimationToEnd
+
+- tapOn:
+    id: blur-button
+
+- runFlow:
+    file: '../../../subflows/capture_or_assert_screenshot.yaml'
+    env:
+      SCREENSHOT_NAME: 'markdown_shortcut_list_input'

--- a/apps/react-native-example/src/screens/playground/PlaygroundScreen.tsx
+++ b/apps/react-native-example/src/screens/playground/PlaygroundScreen.tsx
@@ -185,6 +185,7 @@ export default function PlaygroundScreen() {
 
         <View style={styles.editorContainer} testID="editor-container">
           <EnrichedMarkdownTextInput
+            markdownShortcuts
             ref={inputRef}
             placeholder="Type markdown here..."
             placeholderTextColor="#9CA3AF"

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -668,6 +668,14 @@ Whether the input is scrollable when content exceeds the visible area.
 | --------- | ------------- | -------- |
 | `boolean` | `true`        | Both     |
 
+### `markdownShortcuts`
+
+Converts markdown block prefixes typed at the start of a paragraph into blocks and removes the prefix: `#`–`######` + space → heading, `-`/`*`/`+` + space → bullet item, `1.`/`1)` + space → numbered item. Only fires on a plain paragraph. See [INPUT — Markdown Shortcuts](INPUT.md#markdown-shortcuts).
+
+| Type      | Default Value | Platform |
+| --------- | ------------- | -------- |
+| `boolean` | `false`       | Both     |
+
 ### `autoCapitalize`
 
 Auto-capitalization behavior.

--- a/docs/INPUT.md
+++ b/docs/INPUT.md
@@ -164,6 +164,29 @@ The callback fires only for newly detected links — not for links that were alr
 
 When a manual link is applied (via `setLink` or `insertLink`) over an auto-detected link, the auto-detected link is replaced by the manual one. Auto-link detection skips ranges that already contain a manual link.
 
+## Markdown Shortcuts
+
+With `markdownShortcuts` enabled, typing a markdown block prefix at the start of a paragraph and following it with a space converts the paragraph into that block and removes the prefix — the convention Notion, Bear, Obsidian and Apple Notes users expect:
+
+| Typed | Becomes |
+|---|---|
+| `# ` … `###### ` | Heading 1 … 6 |
+| `- `, `* `, `+ ` | Bullet list item |
+| `1. `, `1) ` (any number) | Numbered list item |
+
+```tsx
+<EnrichedMarkdownTextInput markdownShortcuts />
+```
+
+It is **off by default**: an app that treats `#` or `-` as literal text (tags, channel names, dashes) sees no change unless it opts in.
+
+Behavior notes:
+
+- The shortcut only fires on a **plain paragraph**. Typing `# ` inside an existing heading or list item leaves the text alone.
+- The conversion goes through the same block pipeline as [`toggleHeading`](#headings) and the [list commands](#lists), so `onChangeState`, serialization and Return-continues-the-list behave exactly as if the block had been toggled from a toolbar.
+- Backspace at the start of a freshly converted **list item** removes the marker again (the existing list Backspace rule). A converted heading is turned off with `toggleHeading` or by deleting the line.
+- Without the shortcut a literal `# Heading` paragraph still serializes as `# Heading`, so it would become a heading the next time the markdown is loaded. Enabling shortcuts makes what the user sees while typing agree with what they get after a reload.
+
 ## Caret Position Tracking
 
 `EnrichedMarkdownTextInput` can report the caret's pixel position relative to the input, which is useful when the input is embedded in a scrollable container with `scrollEnabled={false}` and you need to keep the caret visible.

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputManager.kt
@@ -158,6 +158,14 @@ class EnrichedMarkdownTextInputManager :
     view?.isVerticalScrollBarEnabled = value
   }
 
+  @ReactProp(name = "markdownShortcuts", defaultBoolean = false)
+  override fun setMarkdownShortcuts(
+    view: EnrichedMarkdownTextInputView?,
+    value: Boolean,
+  ) {
+    view?.markdownShortcuts = value
+  }
+
   @ReactProp(name = "autoCapitalize")
   override fun setAutoCapitalize(
     view: EnrichedMarkdownTextInputView?,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/EnrichedMarkdownTextInputView.kt
@@ -106,6 +106,9 @@ class EnrichedMarkdownTextInputView(
       override fun runAsATransaction(block: () -> Unit) = this@EnrichedMarkdownTextInputView.runAsATransaction(block)
 
       override fun setViewSelection(position: Int) = setSelection(position)
+
+      override val markdownShortcutsEnabled: Boolean
+        get() = markdownShortcuts
     }
 
   val editPipeline =
@@ -122,6 +125,9 @@ class EnrichedMarkdownTextInputView(
   private var inputMethodManager: InputMethodManager? = null
   private var detectScrollMovement = false
   var scrollEnabled: Boolean = true
+
+  /** Typed `# `, `- `, `1. ` become blocks (opt-in from JS). */
+  var markdownShortcuts: Boolean = false
 
   private val clipboardCoordinator = ClipboardCoordinator(formattingStore, blockStore, detectorPipeline, formatter)
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/EditPipeline.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/EditPipeline.kt
@@ -37,6 +37,9 @@ interface EditPipelineHost {
   fun runAsATransaction(block: () -> Unit)
 
   fun setViewSelection(position: Int)
+
+  /** Whether typed markdown prefixes (`# `, `- `, `1. `) convert into blocks. */
+  val markdownShortcutsEnabled: Boolean
 }
 
 /**
@@ -64,6 +67,7 @@ class EditPipeline(
     adjustStores(context)
     pruneOrphanedAnchors()
     continueBlocks(context)
+    convertMarkdownShortcut(context)
     host.editable?.let { blockStore.normalizeToLineBounds(it) }
     applyPendingStyles(context)
 
@@ -146,6 +150,37 @@ class EditPipeline(
 
     val newLineStart = (context.editStart + context.insertedLength).coerceAtMost(editable.length)
     blockStore.setBlock(prevBlock.type, prevBlock.level, newLineStart, newLineStart, editable)
+  }
+
+  /**
+   * Markdown shortcuts: a space typed after `#`…`######`, `-`/`*`/`+` or
+   * `1.`/`1)` at the start of a plain paragraph drops the prefix and makes the
+   * paragraph that block. Mirrors [continueBlocks]: mutate inside a transaction,
+   * then re-adjust the stores for the deletion before normalization stamps spans.
+   */
+  private fun convertMarkdownShortcut(context: EditContext) {
+    if (!host.markdownShortcutsEnabled) return
+    val editable = host.editable ?: return
+    if (context.deletedLength != 0 || context.insertedLength <= 0) return
+
+    val insertedEnd = (context.editStart + context.insertedLength).coerceAtMost(editable.length)
+    val spaceIndex = (context.editStart until insertedEnd).firstOrNull { editable[it] == ' ' } ?: return
+
+    var lineStart = spaceIndex
+    while (lineStart > 0 && editable[lineStart - 1] != '\n') lineStart--
+    if (spaceIndex == lineStart || blockStore.blockStartingAt(lineStart) != null) return
+
+    val match = MarkdownShortcutMatcher.match(editable.subSequence(lineStart, spaceIndex)) ?: return
+
+    val deleteEnd = spaceIndex + 1
+    val deletedLength = deleteEnd - lineStart
+    host.runAsATransaction { editable.delete(lineStart, deleteEnd) }
+    formattingStore.adjustForEdit(lineStart, deletedLength, 0)
+    blockStore.adjustForEdit(lineStart, deletedLength, 0)
+    blockStore.setBlock(match.type, match.level, lineStart, lineStart, editable)
+
+    val caret = (context.editStart + context.insertedLength - deletedLength).coerceIn(0, editable.length)
+    host.setViewSelection(caret)
   }
 
   private fun applyPendingStyles(context: EditContext) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/MarkdownShortcutMatcher.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/editing/MarkdownShortcutMatcher.kt
@@ -1,0 +1,47 @@
+package com.swmansion.enriched.markdown.input.editing
+
+import com.swmansion.enriched.markdown.input.model.BlockType
+
+/**
+ * Recognizes the markdown block prefixes a user types at the start of a
+ * paragraph — `#`…`######`, `-`/`*`/`+`, `1.`/`1)` — so the input can turn the
+ * paragraph into the matching block and drop the prefix (Notion-style markdown
+ * shortcuts). Pure text matching; the caller owns the mutation.
+ */
+internal object MarkdownShortcutMatcher {
+  data class Match(
+    val type: BlockType,
+    val level: Int,
+  )
+
+  /** Anything longer is a number the user is writing, not a list marker. */
+  private const val MAX_ORDERED_MARKER_DIGITS = 9
+
+  /**
+   * Matches [prefix] (the paragraph text before the space the user just typed,
+   * with no leading whitespace). Ordered items match any number — the block
+   * store renumbers ordinals, so `3.` on a fresh line still starts at 1.
+   */
+  fun match(prefix: CharSequence): Match? {
+    if (prefix.isEmpty()) return null
+    val first = prefix[0]
+
+    if (first == '#') {
+      if (prefix.length > 6 || !prefix.all { it == '#' }) return null
+      val type = BlockType.forHeadingLevel(prefix.length) ?: return null
+      return Match(type, prefix.length)
+    }
+
+    if (prefix.length == 1 && (first == '-' || first == '*' || first == '+')) {
+      return Match(BlockType.UNORDERED_LIST_ITEM, 0)
+    }
+
+    val last = prefix.last()
+    if ((last == '.' || last == ')') && prefix.length >= 2 && prefix.length - 1 <= MAX_ORDERED_MARKER_DIGITS) {
+      if (prefix.subSequence(0, prefix.length - 1).all { it in '0'..'9' }) {
+        return Match(BlockType.ORDERED_LIST_ITEM, 0)
+      }
+    }
+    return null
+  }
+}

--- a/packages/react-native-enriched-markdown/ios/input/ENRMMarkdownShortcutMatcher.h
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMMarkdownShortcutMatcher.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#import "ENRMInputBlockType.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Recognizes the markdown block prefixes a user types at the start of a
+/// paragraph — `#`…`######`, `-`/`*`/`+`, `1.`/`1)` — so the input can turn the
+/// paragraph into the matching block and drop the prefix (Notion-style
+/// markdown shortcuts). Pure text matching; the caller owns the mutation.
+@interface ENRMMarkdownShortcutMatcher : NSObject
+
+/// Matches `prefix` (the paragraph text before the space the user just typed,
+/// with no leading whitespace) against the shortcut grammar. Returns YES and
+/// fills `outType`/`outLevel` on a match. Ordered items match any number —
+/// the block store renumbers ordinals, so `3.` on a fresh line still starts at 1.
++ (BOOL)matchPrefix:(NSString *)prefix outType:(ENRMInputBlockType *)outType outLevel:(NSInteger *)outLevel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native-enriched-markdown/ios/input/ENRMMarkdownShortcutMatcher.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMMarkdownShortcutMatcher.mm
@@ -1,0 +1,57 @@
+#import "ENRMMarkdownShortcutMatcher.h"
+
+/// Upper bound on the digits accepted before `.`/`)`. Anything longer is a
+/// number the user is writing, not a list marker.
+static const NSUInteger kENRMMaxOrderedMarkerDigits = 9;
+
+@implementation ENRMMarkdownShortcutMatcher
+
++ (BOOL)matchPrefix:(NSString *)prefix outType:(ENRMInputBlockType *)outType outLevel:(NSInteger *)outLevel
+{
+  NSUInteger length = prefix.length;
+  if (length == 0) {
+    return NO;
+  }
+
+  unichar first = [prefix characterAtIndex:0];
+
+  // `#`{1,6} → heading at that level.
+  if (first == '#') {
+    if (length > 6) {
+      return NO;
+    }
+    for (NSUInteger i = 1; i < length; i++) {
+      if ([prefix characterAtIndex:i] != '#') {
+        return NO;
+      }
+    }
+    *outType = ENRMBlockTypeForHeadingLevel((NSInteger)length);
+    *outLevel = (NSInteger)length;
+    return YES;
+  }
+
+  // `-`, `*`, `+` → bullet item at depth 0.
+  if (length == 1 && (first == '-' || first == '*' || first == '+')) {
+    *outType = ENRMInputBlockTypeUnorderedListItem;
+    *outLevel = 0;
+    return YES;
+  }
+
+  // digits followed by `.` or `)` → numbered item at depth 0.
+  unichar last = [prefix characterAtIndex:length - 1];
+  if ((last == '.' || last == ')') && length >= 2 && length - 1 <= kENRMMaxOrderedMarkerDigits) {
+    for (NSUInteger i = 0; i < length - 1; i++) {
+      unichar c = [prefix characterAtIndex:i];
+      if (c < '0' || c > '9') {
+        return NO;
+      }
+    }
+    *outType = ENRMInputBlockTypeOrderedListItem;
+    *outLevel = 0;
+    return YES;
+  }
+
+  return NO;
+}
+
+@end

--- a/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
+++ b/packages/react-native-enriched-markdown/ios/input/EnrichedMarkdownTextInput.mm
@@ -20,6 +20,7 @@
 #import "ENRMInputTypingAttributesController.h"
 #import "ENRMLinkCoordinator.h"
 #import "ENRMLinkRegexConfig.h"
+#import "ENRMMarkdownShortcutMatcher.h"
 #import "ENRMMentionCoordinator.h"
 #import "ENRMStyleHandler.h"
 #import "ENRMStyleMergingConfig.h"
@@ -111,6 +112,7 @@ static const NSTimeInterval kENRMAtomicSnapPollInterval = 0.1;
   ENRMLinkCoordinator *_linkCoordinator;
   ENRMClipboardCoordinator *_clipboardCoordinator;
 
+  BOOL _markdownShortcutsEnabled;
   ENRMWritingDirectionMode _writingDirectionMode;
   NSWritingDirection _resolvedLayoutDirection;
 
@@ -386,6 +388,9 @@ static const NSTimeInterval kENRMAtomicSnapPollInterval = 0.1;
 #if !TARGET_OS_OSX
   if (newViewProps.scrollEnabled != oldViewProps.scrollEnabled) {
     _textView.scrollEnabled = newViewProps.scrollEnabled;
+  }
+  if (newViewProps.markdownShortcuts != oldViewProps.markdownShortcuts) {
+    _markdownShortcutsEnabled = newViewProps.markdownShortcuts;
   }
 
   if (newViewProps.autoCapitalize != oldViewProps.autoCapitalize) {
@@ -1597,6 +1602,70 @@ static const NSTimeInterval kENRMAtomicSnapPollInterval = 0.1;
 
 #pragma mark - Text edit tracking
 
+/// Markdown shortcuts: when the user types a space after `#`…`######`,
+/// `-`/`*`/`+` or `1.`/`1)` at the start of a plain paragraph, drop the prefix
+/// and make the paragraph that block. Runs after the stores are adjusted for the
+/// edit and before scoped formatting. Returns YES when it converted, in which
+/// case the replace path has already reformatted and emitted.
+- (BOOL)applyMarkdownShortcutForEditAtLocation:(NSUInteger)editLocation
+                                insertedLength:(NSUInteger)insertedLength
+                              preEditBlockType:(ENRMInputBlockType)preEditBlockType
+{
+  if (!_markdownShortcutsEnabled || insertedLength == 0 || preEditBlockType != ENRMInputBlockTypeParagraph) {
+    return NO;
+  }
+
+  NSString *text = ENRMGetPlainText(_textView);
+  if (editLocation >= text.length) {
+    return NO;
+  }
+  NSUInteger insertedEnd = MIN(editLocation + insertedLength, text.length);
+
+  // The trigger is the first space inside the inserted run — a single
+  // keystroke in the common case, a whole token when autocorrect or an
+  // automation inserts several characters at once.
+  NSUInteger spaceIndex = NSNotFound;
+  for (NSUInteger i = editLocation; i < insertedEnd; i++) {
+    if ([text characterAtIndex:i] == ' ') {
+      spaceIndex = i;
+      break;
+    }
+  }
+  if (spaceIndex == NSNotFound) {
+    return NO;
+  }
+
+  NSUInteger lineStart = [text paragraphRangeForRange:NSMakeRange(spaceIndex, 0)].location;
+  if (spaceIndex == lineStart || [_blockCoordinator blockAtPosition:lineStart inText:text] != nil) {
+    return NO;
+  }
+
+  NSString *prefix = [text substringWithRange:NSMakeRange(lineStart, spaceIndex - lineStart)];
+  ENRMInputBlockType type = ENRMInputBlockTypeParagraph;
+  NSInteger level = 0;
+  if (![ENRMMarkdownShortcutMatcher matchPrefix:prefix outType:&type outLevel:&level]) {
+    return NO;
+  }
+
+  NSRange prefixRange = NSMakeRange(lineStart, spaceIndex + 1 - lineStart);
+  NSRange caretBefore = _textView.selectedRange;
+
+  // A zero-length range at the line start: the store expands it to the whole
+  // paragraph, and on an emptied line it persists as the block's anchor.
+  ENRMBlockRange *block = [ENRMBlockRange rangeWithType:type range:NSMakeRange(0, 0) level:level];
+  [self replaceTextInRange:prefixRange withText:@"" formattingRanges:@[] blockRanges:@[ block ]];
+
+  if (caretBefore.location >= NSMaxRange(prefixRange)) {
+    NSUInteger caret = caretBefore.location - prefixRange.length;
+    _textView.selectedRange = NSMakeRange(MIN(caret, ENRMGetPlainText(_textView).length), 0);
+  }
+  _lastSelectedRange = _textView.selectedRange;
+
+  [_typingController syncWithCursorBlock];
+  [self updateEmptyBulletMarker];
+  return YES;
+}
+
 - (void)handleTextChanged
 {
   if (_editSession.isComposing) {
@@ -1640,6 +1709,7 @@ static const NSTimeInterval kENRMAtomicSnapPollInterval = 0.1;
                                                       pendingStyleRemovals:_typingController.pendingStyleRemovals];
 
   BOOL touchedNewline = [_editPipeline processTextChangeWithContext:context];
+  ENRMInputBlockType preEditBlockType = _preEditBlockType;
 
   // Consumed: clear pre-edit state so stale values can't leak to the next edit.
   _preEditBlockType = ENRMInputBlockTypeParagraph;
@@ -1648,6 +1718,14 @@ static const NSTimeInterval kENRMAtomicSnapPollInterval = 0.1;
   _preEditReplacedNewline = NO;
 
   _lastTextLength = newLength;
+
+  // A typed markdown prefix turns the paragraph into a block; the replace path
+  // reformats and emits on its own, so the rest of this pass is redundant.
+  if ([self applyMarkdownShortcutForEditAtLocation:editLocation
+                                    insertedLength:insertedLength
+                                  preEditBlockType:preEditBlockType]) {
+    return;
+  }
 
 #if !TARGET_OS_OSX
   if (newLength == 0) {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInput.tsx
@@ -209,6 +209,16 @@ export interface EnrichedMarkdownTextInputProps extends Omit<
   editable?: boolean;
   autoFocus?: boolean;
   scrollEnabled?: boolean;
+  /**
+   * Converts markdown block prefixes typed at the start of a paragraph into
+   * blocks, the way Notion, Bear and Obsidian do: `#`–`######` + space becomes
+   * a heading, `-`/`*`/`+` + space a bullet item, `1.` (or `1)`) + space a
+   * numbered item. The prefix and its space are removed from the text.
+   * Off by default so apps that treat `#` or `-` as literal text (tags, dashes)
+   * see no change.
+   * @default false
+   */
+  markdownShortcuts?: boolean;
   autoCapitalize?: string;
   multiline?: boolean;
   cursorColor?: ColorValue;
@@ -289,6 +299,7 @@ export const EnrichedMarkdownTextInput = ({
   editable = true,
   autoFocus = false,
   scrollEnabled = true,
+  markdownShortcuts = false,
   autoCapitalize = 'sentences',
   multiline = true,
   cursorColor,
@@ -647,6 +658,7 @@ export const EnrichedMarkdownTextInput = ({
       editable={editable}
       autoFocus={autoFocus}
       scrollEnabled={scrollEnabled}
+      markdownShortcuts={markdownShortcuts}
       autoCapitalize={autoCapitalize}
       multiline={multiline}
       cursorColor={cursorColor}

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextInputNativeComponent.ts
@@ -210,6 +210,12 @@ export interface NativeProps extends ViewProps {
    */
   scrollEnabled?: boolean;
   /**
+   * Converts markdown block prefixes typed at a paragraph start (`# `, `- `, `1. `)
+   * into the matching block and removes the prefix.
+   * @default false
+   */
+  markdownShortcuts?: boolean;
+  /**
    * Auto-capitalization behavior.
    */
   autoCapitalize?: string;

--- a/packages/react-native-enriched-markdown/src/jest/index.tsx
+++ b/packages/react-native-enriched-markdown/src/jest/index.tsx
@@ -82,6 +82,7 @@ export const EnrichedMarkdownTextInput = ({
   selectionMenuConfig: _selectionMenuConfig,
   formatMenuConfig: _formatMenuConfig,
   linkRegex: _linkRegex,
+  markdownShortcuts: _markdownShortcuts,
   writingDirection: _writingDirection,
 }: EnrichedMarkdownTextInputProps) => {
   const [text, setText] = useState(defaultValue ?? '');


### PR DESCRIPTION
### What/Why?

Closes #782.

Adds an **opt-in** `markdownShortcuts` prop to `EnrichedMarkdownTextInput`. When enabled, a space typed after `#`…`######`, `-`/`*`/`+`, or `1.`/`1)` at the start of a **plain paragraph** removes the prefix and turns the paragraph into the matching heading or list block — the Notion / Bear / Obsidian / Apple Notes convention.

Why: today a typed `# Heading` stays literal text, but the serializer emits it unescaped, so the same text becomes a heading the next time the markdown is loaded. Users read that as "formatting only applies after reload" (that's how #782 was found). The toolbar commands are the only live path to a block, and `contextMenuItems` / the Format menu are only built once text is selected, so an empty line can't be formatted at all without this.

How it's built — it reuses what's there rather than adding a new mechanism:

- The conversion runs where Enter's block continuation already mutates text mid-keystroke: iOS in `handleTextChanged` right after `processTextChangeWithContext:` (via the existing `replaceTextInRange:withText:formattingRanges:blockRanges:` path), Android as a `convertMarkdownShortcut` step in `EditPipeline.processTextChange` mirroring `continueBlocks` (delete inside `runAsATransaction`, re-adjust both stores, `setBlock`). Serialization, `onChangeState`, Return-continues-the-list and the Backspace-un-lists rule all behave exactly as if the block had been toggled from a toolbar.
- Matching is a tiny pure matcher per platform (`ENRMMarkdownShortcutMatcher`, `MarkdownShortcutMatcher.kt`). Ordered markers accept any number; the store renumbers ordinals.
- The trigger is the first space inside the inserted run, so it works for a single keystroke and for multi-character inserts (autocorrect, `inputText` in Maestro).
- Only fires on a plain paragraph — never inside an existing heading or list item.
- **Off by default** so apps that treat `#` or `-` as literal text (tags, dashes) see no change. Happy to flip the default if you'd rather match auto-link.

Docs: new "Markdown Shortcuts" section in `INPUT.md` (mirrors Auto-Link Detection) and an `API_REFERENCE.md` entry. The playground enables the prop so the new flows can exercise it.

### Testing

- `yarn typecheck`, `yarn lint` (0 errors; the one warning is pre-existing in `BlockRenderers.tsx`), `yarn test` (31 passing, including the Jest mock).
- `clang-format` is clean on the three iOS files I touched. Note `yarn lint-clang:ios` fails on pristine `main` today (a `gridView.menuProvider` line in the macOS code), so it can't be used as a gate here.
- **iOS, end to end:** compiled and exercised in a real consumer app (Dexter, RN 0.86.2, Xcode 26.6) by applying this diff to the installed 1.0.2 package via patch-package and rebuilding. Typing `# Heading test`, `- bullet item`, and `1. step one` on fresh paragraphs converted live into an H1, a bullet, and a numbered item with the prefixes removed; Return after the heading started a plain paragraph and two Returns exited the bullet list, as documented.
- **Android:** not compiled here — I have no Android SDK on this machine. The Kotlin follows `continueBlocks` line for line, but it needs CI (and ktlint) to confirm. I did not run their example app; the consumer-app build stood in for it.
- Two Maestro flows added under `flows/basic/block_elements/` (`markdown_shortcut_heading_test`, `markdown_shortcut_list_test`) following `list_toggle_test`. They end in the screenshot subflow, so baselines need generating with `yarn test:e2e:ios:update-screenshots` / `…android…` — I couldn't produce them without running your example app.

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android — not verified locally (no SDK); needs CI
- [x] Updated documentation/README if applicable
- [ ] Ran example app to verify changes — verified in a consumer app instead (see Testing)
- [ ] E2E tests are passing — flows added, not run; screenshot baselines needed
- [x] Required E2E tests have been added (if applicable)