### PR TITLE
feat: include applybaseline offset for every block element

### DIFF
--- a/packages/react-native-enriched-markdown/ios/renderer/BlockquoteRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/BlockquoteRenderer.m
@@ -158,6 +158,7 @@ static NSString *const kNestedInfoRangeKey = @"range";
                         }
                         [output addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:nonListRange];
                         applyLineHeight(output, nonListRange, lineHeight);
+                        applyBaselineOffset(output, nonListRange);
                       }];
 
   if (padding > 0) {

--- a/packages/react-native-enriched-markdown/ios/renderer/ENRMBlockquoteTextRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/ENRMBlockquoteTextRenderer.m
@@ -40,6 +40,7 @@
   while (location < text.length) {
     NSRange paragraph = [string paragraphRangeForRange:NSMakeRange(location, 0)];
     applyLineHeight(text, paragraph, lineHeight);
+    applyBaselineOffset(text, paragraph);
     location = NSMaxRange(paragraph);
   }
 }

--- a/packages/react-native-enriched-markdown/ios/renderer/HeadingRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/HeadingRenderer.m
@@ -65,6 +65,7 @@ static NSString *const kHeadingTypes[] = {nil,          @"heading-1", @"heading-
   [output addAttribute:MarkdownTypeAttributeName value:kHeadingTypes[level] range:range];
 
   applyLineHeight(output, range, style.lineHeight);
+  applyBaselineOffset(output, range);
   applyTextAlignment(output, range, style.textAlign);
 
   // Skip marginTop for the first block — already handled by applyBlockSpacingBefore above

--- a/packages/react-native-enriched-markdown/ios/renderer/ListItemRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/ListItemRenderer.m
@@ -137,6 +137,9 @@ NSString *const TaskIndexAttribute = @"TaskIndex";
     NSMutableDictionary *attributesToApply = [metadata mutableCopy];
     attributesToApply[NSParagraphStyleAttributeName] = style;
     [output addAttributes:attributesToApply range:range];
+    if (lineHeightConfig > 0) {
+      applyBaselineOffset(output, range);
+    }
   };
 
   NSUInteger pos = itemRange.location;

--- a/packages/react-native-enriched-markdown/ios/renderer/ParagraphRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/ParagraphRenderer.m
@@ -61,12 +61,7 @@
   // Avoid standard line height on block images to prevent vertical alignment issues
   if (!isBlockImage) {
     applyLineHeight(output, range, _config.paragraphLineHeight);
-    // A blockquote re-stamps its own (usually different) line height over this
-    // content afterwards and applies the matching baseline offset itself. Applying
-    // the paragraph-line-height offset here would lock in a stale value the
-    // blockquote pass can't override (applyBaselineOffset skips ranges that already
-    // carry an offset), leaving the text mis-centered inside the quote's line box.
-    if (context.currentBlockType != BlockTypeBlockquote) {
+    if (!ENRMBlockTypeReappliesBaselineOffset(context.currentBlockType)) {
       applyBaselineOffset(output, range);
     }
   }

--- a/packages/react-native-enriched-markdown/ios/renderer/ParagraphRenderer.m
+++ b/packages/react-native-enriched-markdown/ios/renderer/ParagraphRenderer.m
@@ -61,7 +61,14 @@
   // Avoid standard line height on block images to prevent vertical alignment issues
   if (!isBlockImage) {
     applyLineHeight(output, range, _config.paragraphLineHeight);
-    applyBaselineOffset(output, range);
+    // A blockquote re-stamps its own (usually different) line height over this
+    // content afterwards and applies the matching baseline offset itself. Applying
+    // the paragraph-line-height offset here would lock in a stale value the
+    // blockquote pass can't override (applyBaselineOffset skips ranges that already
+    // carry an offset), leaving the text mis-centered inside the quote's line box.
+    if (context.currentBlockType != BlockTypeBlockquote) {
+      applyBaselineOffset(output, range);
+    }
   }
 
   applyTextAlignment(output, range, _config.paragraphTextAlign);

--- a/packages/react-native-enriched-markdown/ios/renderer/RenderContext.h
+++ b/packages/react-native-enriched-markdown/ios/renderer/RenderContext.h
@@ -11,6 +11,16 @@ typedef NS_ENUM(NSInteger, BlockType) {
   BlockTypeCodeBlock
 };
 
+/// YES when the enclosing block re-stamps its own line height over paragraph content and applies the
+/// matching baseline offset itself, so a paragraph nested inside it must not apply its own (the outer
+/// block's line height wins, and applyBaselineOffset skips ranges that already carry an offset).
+/// TODO: loose list items have the same shape (ParagraphRenderer runs, then the list re-stamps its
+/// line height); add BlockTypeUnorderedList/BlockTypeOrderedList here once lists own their offset too.
+static inline BOOL ENRMBlockTypeReappliesBaselineOffset(BlockType type)
+{
+  return type == BlockTypeBlockquote;
+}
+
 typedef NS_ENUM(NSInteger, ListType) { ListTypeUnordered, ListTypeOrdered };
 
 @interface BlockStyle : NSObject

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMCodeBlockContent.mm
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMCodeBlockContent.mm
@@ -76,4 +76,8 @@ void ENRMApplyCodeBlockTextAttributes(NSMutableAttributedString *string, NSRange
   paragraphStyle.baseWritingDirection = NSWritingDirectionLeftToRight;
   paragraphStyle.alignment = NSTextAlignmentLeft;
   [string addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:range];
+
+  if (lineHeight > 0) {
+    applyBaselineOffset(string, range);
+  }
 }

--- a/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
@@ -297,10 +297,14 @@ void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat l
   [output addAttribute:NSParagraphStyleAttributeName value:style range:range];
 }
 
-// TODO: Extend baseline offset to every block that calls applyLineHeight (headings, blockquotes,
-// code blocks, list items). Keep per-block range scoping — not a whole-document pass like RN Text,
-// since blocks can use different line heights. Optionally consolidate into a single post-pass in
-// AttributedRenderer; evaluate RN's per-line mode (enableIOSTextBaselineOffsetPerLine) if needed.
+// Centers text vertically within its line height by offsetting the baseline by half the leading,
+// matching how Android's LineHeightSpan splits extra leading evenly above and below the glyphs.
+// Every block that stamps a line height calls this per-block over its own range (paragraphs,
+// headings, blockquotes, code blocks, list items) — ranges are kept per block rather than run as a
+// whole-document pass like RN Text, since blocks can use different line heights. Ranges that already
+// carry a baseline offset are left untouched, so nesting (e.g. a blockquote wrapping list items) is
+// idempotent. Possible future cleanup: consolidate into a single post-pass in AttributedRenderer and
+// evaluate RN's per-line mode (enableIOSTextBaselineOffsetPerLine).
 void applyBaselineOffset(NSMutableAttributedString *output, NSRange range)
 {
   if (range.length == 0) {

--- a/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
@@ -297,14 +297,10 @@ void applyLineHeight(NSMutableAttributedString *output, NSRange range, CGFloat l
   [output addAttribute:NSParagraphStyleAttributeName value:style range:range];
 }
 
-// Centers text vertically within its line height by offsetting the baseline by half the leading,
-// matching how Android's LineHeightSpan splits extra leading evenly above and below the glyphs.
-// Every block that stamps a line height calls this per-block over its own range (paragraphs,
-// headings, blockquotes, code blocks, list items) — ranges are kept per block rather than run as a
-// whole-document pass like RN Text, since blocks can use different line heights. Ranges that already
-// carry a baseline offset are left untouched, so nesting (e.g. a blockquote wrapping list items) is
-// idempotent. Possible future cleanup: consolidate into a single post-pass in AttributedRenderer and
-// evaluate RN's per-line mode (enableIOSTextBaselineOffsetPerLine).
+// Centers text within its line height by offsetting the baseline by half the leading, matching how
+// Android's LineHeightSpan splits the extra leading evenly above and below the glyphs. Called per
+// block over its own range so blocks can keep different line heights. Ranges that already carry a
+// baseline offset are left untouched, keeping nesting (e.g. a blockquote wrapping list items) idempotent.
 void applyBaselineOffset(NSMutableAttributedString *output, NSRange range)
 {
   if (range.length == 0) {


### PR DESCRIPTION
### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->

Fixes #759. On iOS a heading was positioned off-center vertically compared to a paragraph with the same style, so headings and paragraphs did not line up (most visible in a fixed-height single-line row).

Only paragraphs applied `applyBaselineOffset`, which centers glyphs inside the configured `lineHeight` box by splitting the extra leading evenly above and below the text. Every other block (headings, blockquotes, code blocks, list items) stamped a line height without it, so their text sat at the top of the line box. Android was unaffected because its shared `LineHeightSpan` already splits the leading evenly for every block.

This PR extends `applyBaselineOffset` to every block that stamps a line height, matching the Android behavior. It also stops `ParagraphRenderer` from leaving a stale paragraph-line-height offset on blockquote content: a blockquote re-stamps its own (usually different) line height afterwards, and `applyBaselineOffset` skips ranges that already carry an offset, so without this the quote text stayed centered for the paragraph line height instead of the blockquote's.

Android needs no change - all blocks already route through the even-leading `LineHeightSpan`.

### Testing
<!-- How to test changed code? What testing has been done? -->

Verified in the example app storybook. For each block story (Headings, Blockquote, CodeBlock, Lists) set `lineHeight` well above `fontSize` and confirmed the text is vertically centered in each line box, matching the Paragraph story:

- Heading vs paragraph with identical style now align (the #759 repro).
- Blockquote centers correctly in both commonmark and github flavors, including wrapped lines, nested quotes, and a list inside a quote (no double offset).
- Regression: with `lineHeight <= fontSize` no offset is applied, so there is no clipping or upward shift.

<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
