### PR TITLE
fix(android): fill container width when Yoga assigns an exact width

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -340,7 +340,7 @@ class EnrichedMarkdownManager :
     attachmentsPositions: FloatArray?,
   ): Long {
     val id = localData?.getInt("viewTag")
-    return MeasurementStore.getMeasureById(context, id, width, height, heightMode, props, splitTableSegments = true)
+    return MeasurementStore.getMeasureById(context, id, width, widthMode, height, heightMode, props, splitTableSegments = true)
   }
 
   companion object {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -326,7 +326,7 @@ class EnrichedMarkdownTextManager :
     attachmentsPositions: FloatArray?,
   ): Long {
     val id = localData?.getInt("viewTag")
-    return MeasurementStore.getMeasureById(context, id, width, height, heightMode, props)
+    return MeasurementStore.getMeasureById(context, id, width, widthMode, height, heightMode, props)
   }
 
   companion object {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -141,10 +141,13 @@ object MeasurementStore {
     props: ReadableMap?,
     splitTableSegments: Boolean = false,
   ): Long {
-    // Early exit for empty markdown
+    // Early exit for empty markdown. Honor widthMode here too: empty content has
+    // zero intrinsic width, so only fill when the width is EXACTLY assigned -
+    // otherwise an empty view would claim all available horizontal space.
     val markdown = props.getStringOrDefault("markdown", "")
     if (markdown.isEmpty()) {
-      return YogaMeasureOutput.make(PixelUtil.toDIPFromPixel(width), 0f)
+      val emptyWidth = if (widthMode === YogaMeasureMode.EXACTLY) PixelUtil.toDIPFromPixel(width) else 0f
+      return YogaMeasureOutput.make(emptyWidth, 0f)
     }
 
     val size = getMeasureByIdInternal(context, id, width, props, splitTableSegments)

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -135,6 +135,7 @@ object MeasurementStore {
     context: Context,
     id: Int?,
     width: Float,
+    widthMode: YogaMeasureMode?,
     height: Float,
     heightMode: YogaMeasureMode?,
     props: ReadableMap?,
@@ -147,18 +148,25 @@ object MeasurementStore {
     }
 
     val size = getMeasureByIdInternal(context, id, width, props, splitTableSegments)
-    val resultHeight = YogaMeasureOutput.getHeight(size)
 
+    // Honor the Yoga width contract. When the parent assigns an exact width
+    // (flex child, alignItems: stretch, explicit width / width: "100%"), fill it
+    // instead of reporting the content's widest line, which would make the node
+    // hug its content and wrap early. Mirrors RN's TextLayoutManager.calculateWidth;
+    // iOS already does this via ENRMClampMeasuredSize.
+    val resultWidth =
+      if (widthMode === YogaMeasureMode.EXACTLY) {
+        PixelUtil.toDIPFromPixel(width)
+      } else {
+        YogaMeasureOutput.getWidth(size)
+      }
+
+    var resultHeight = YogaMeasureOutput.getHeight(size)
     if (heightMode === YogaMeasureMode.AT_MOST) {
-      val maxHeight = PixelUtil.toDIPFromPixel(height)
-      val finalHeight = resultHeight.coerceAtMost(maxHeight)
-      return YogaMeasureOutput.make(
-        YogaMeasureOutput.getWidth(size),
-        finalHeight,
-      )
+      resultHeight = resultHeight.coerceAtMost(PixelUtil.toDIPFromPixel(height))
     }
 
-    return size
+    return YogaMeasureOutput.make(resultWidth, resultHeight)
   }
 
   fun updateFontScalingSettings(


### PR DESCRIPTION
### What/Why?

`EnrichedMarkdownText` sized itself to its content's widest line and wrapped early instead of filling the available width of its container - so a one-line preview showed a truncated first word with a large gap, and `containerStyle={{ width: "100%" }}` did not force full width on Android (issue #761, second gap).

Root cause: the Android measure callback receives the Yoga width measure mode but dropped it, and `MeasurementStore` always returned the widest measured line as the node width. React Native's text measurement returns the assigned width when the mode is `EXACTLY`.

Fix: honor `widthMode` at the `getMeasureById` chokepoint - when `EXACTLY` (flex child, `alignItems: "stretch"`, explicit `width` / `width: "100%"`), report the assigned width; otherwise keep the content-width hug for `AT_MOST` / `UNDEFINED`. This mirrors RN's `TextLayoutManager.calculateWidth` and matches what iOS already does via `ENRMClampMeasuredSize`, so both display components (CommonMark and GFM) now behave consistently across platforms.

Android-only change - iOS already honored the width constraint. Bottom of the stack; #788 builds on it.

### Testing

Render `EnrichedMarkdownText` inside a width-constrained container and confirm the text now fills the width before wrapping:

```tsx
<View style={{ flex: 1 }}>
  <EnrichedMarkdownText markdown="This is a longer message preview that should fit on one line" />
</View>
```

Before: wraps early, empty gap on the first line. After: fills the container width like RN `Text`.

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
