### PR TITLE
feat: add numberOfLines and ellipsizeMode for CommonMark

### DIFF
--- a/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/props/NumberOfLines.stories.tsx
+++ b/apps/react-native-example/.rnstorybook/stories/components/EnrichedMarkdownText/props/NumberOfLines.stories.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { EnrichedMarkdownTextStory } from '../EnrichedMarkdownTextStory';
+import { storyMeta } from '../shared/storyMeta';
+import { numberControl } from '../shared/storybookMarkdownStyles';
+import type { TextStory } from '../shared/storyTypes';
+
+type EllipsizeMode = 'head' | 'middle' | 'tail' | 'clip';
+
+type NumberOfLinesStoryExtra = {
+  numberOfLines: number;
+  ellipsizeMode: EllipsizeMode;
+};
+
+const MARKDOWN = `This is a longer message **preview** that should fill the available width and then be clamped to a fixed number of lines, ending with an ellipsis when it overflows.
+
+A second paragraph with a [link](https://swmansion.com) and some \`inline code\` so truncation is visible across mixed inline styles.
+
+- A list item that also participates in the line count
+- Another list item further down the block`;
+
+const ELLIPSIZE_OPTIONS: EllipsizeMode[] = ['head', 'middle', 'tail', 'clip'];
+
+const argTypes = {
+  numberOfLines: numberControl(
+    'numberOfLines — clamp the rendered markdown to N lines. 0 means unlimited.',
+    { min: 0, max: 6, step: 1 }
+  ),
+  ellipsizeMode: {
+    options: ELLIPSIZE_OPTIONS,
+    control: { type: 'inline-radio' as const },
+    description:
+      "Where the ellipsis is placed when truncated by numberOfLines. 'clip' cuts at the line boundary with no ellipsis. Only takes effect when numberOfLines > 0.",
+  },
+};
+
+export default storyMeta('Props', 'Number Of Lines');
+
+export const Default: TextStory<NumberOfLinesStoryExtra> = {
+  args: {
+    markdown: MARKDOWN,
+    numberOfLines: 2,
+    ellipsizeMode: 'tail',
+    containerStyle: {
+      borderWidth: 1,
+      borderColor: '#c9c9c9',
+      borderRadius: 8,
+      padding: 8,
+    },
+  },
+  argTypes,
+  render: ({ numberOfLines, ellipsizeMode, ...args }) => (
+    <EnrichedMarkdownTextStory
+      title="Number Of Lines"
+      description="CommonMark only. Clamp the content to numberOfLines and pick where the ellipsis goes with ellipsizeMode ('clip' = no glyph). Set numberOfLines to 0 for unlimited. The bordered box shows the text filling the full width before it wraps and truncates."
+      {...args}
+      numberOfLines={numberOfLines}
+      ellipsizeMode={ellipsizeMode}
+    />
+  ),
+};

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -325,7 +325,7 @@ Clamps the rendered markdown to a maximum number of lines, truncating with an el
 
 Only applies to CommonMark (the default flavor). When [`flavor`](#flavor) is `'github'` the content is laid out as independent block segments that cannot honor a document-wide line cap, so the prop is ignored - see [issue #786](https://github.com/software-mansion/enriched-markdown/issues/786).
 
-> **Android note:** while a view is clamped (`numberOfLines > 0`) it is not selectable and its links are not tappable, regardless of [`isSelectable`](#isselectable). This is a platform constraint, not a choice: Android draws the truncation ellipsis only through `StaticLayout`, but enabling text selection or a link movement method promotes the text to a `Spannable`, which forces `TextView` onto `DynamicLayout` - and `DynamicLayout` has no `maxLines` support, so the clamp and its ellipsis are silently dropped (confirmed against AOSP `TextView`/`DynamicLayout` on API 35/36; React Native's own `Text` hits the same limitation). Selection and links are restored automatically once the clamp is removed. iOS keeps selection and links while clamped.
+> **Android note:** while a view is clamped (`numberOfLines > 0`) it is not selectable and its links are not tappable, regardless of [`selectable`](#selectable). This is a platform constraint, not a choice: Android draws the truncation ellipsis only through `StaticLayout`, but enabling text selection or a link movement method promotes the text to a `Spannable`, which forces `TextView` onto `DynamicLayout` - and `DynamicLayout` has no `maxLines` support, so the clamp and its ellipsis are silently dropped (confirmed against AOSP `TextView`/`DynamicLayout` on API 35/36; React Native's own `Text` hits the same limitation). Selection and links are restored automatically once the clamp is removed. iOS keeps selection and links while clamped.
 
 | Type     | Default Value | Platform |
 | -------- | ------------- | -------- |
@@ -339,7 +339,7 @@ Controls where the ellipsis is placed when the text is truncated by [`numberOfLi
 | ------------------------------------------- | ------------- | -------- |
 | `'head' \| 'middle' \| 'tail' \| 'clip'`    | `'tail'`      | Both     |
 
-- **`'head'`**: ellipsis at the start (`...allel to the end`).
+- **`'head'`**: ellipsis at the start (`...d of the text`).
 - **`'middle'`**: ellipsis in the middle (`start...end`).
 - **`'tail'`** (default): ellipsis at the end (`start of the...`).
 - **`'clip'`**: truncate at the line boundary with no ellipsis glyph.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -319,6 +319,31 @@ Whether to preserve the bottom margin of the last block element.
 | --------- | ------------- | -------- |
 | `boolean` | `false`        | Both     |
 
+### `numberOfLines`
+
+Clamps the rendered markdown to a maximum number of lines, truncating with an ellipsis (see [`ellipsizeMode`](#ellipsizemode)) when it overflows. `0` (the default) means unlimited. Mirrors the prop of the same name on React Native's core `Text`, and is handy for previews such as chat-list rows or reply quotes. The clamp is applied to both the measurement pass and the rendered view, so the measured and rendered heights stay in sync.
+
+Only applies to CommonMark (the default flavor). When [`flavor`](#flavor) is `'github'` the content is laid out as independent block segments that cannot honor a document-wide line cap, so the prop is ignored - see [issue #786](https://github.com/software-mansion/enriched-markdown/issues/786).
+
+| Type     | Default Value | Platform |
+| -------- | ------------- | -------- |
+| `number` | `0`           | Both     |
+
+### `ellipsizeMode`
+
+Controls where the ellipsis is placed when the text is truncated by [`numberOfLines`](#numberoflines). Only takes effect when `numberOfLines` is set. Mirrors the prop of the same name on React Native's core `Text`.
+
+| Type                                        | Default Value | Platform |
+| ------------------------------------------- | ------------- | -------- |
+| `'head' \| 'middle' \| 'tail' \| 'clip'`    | `'tail'`      | Both     |
+
+- **`'head'`**: ellipsis at the start (`...allel to the end`).
+- **`'middle'`**: ellipsis in the middle (`start...end`).
+- **`'tail'`** (default): ellipsis at the end (`start of the...`).
+- **`'clip'`**: truncate at the line boundary with no ellipsis glyph.
+
+Ignored when [`flavor`](#flavor) is `'github'` (see [`numberOfLines`](#numberoflines)).
+
 ### `textBreakStrategy`
 
 Controls how Android breaks lines within paragraphs. Mirrors the prop of the same name on React Native's core `Text`. The same value is used for both the measurement pass (`StaticLayout.Builder`) and the rendered `TextView`, so measured and rendered line counts stay in sync. Requires API 23+; ignored on older Android versions.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -325,6 +325,8 @@ Clamps the rendered markdown to a maximum number of lines, truncating with an el
 
 Only applies to CommonMark (the default flavor). When [`flavor`](#flavor) is `'github'` the content is laid out as independent block segments that cannot honor a document-wide line cap, so the prop is ignored - see [issue #786](https://github.com/software-mansion/enriched-markdown/issues/786).
 
+> **Android note:** while a view is clamped (`numberOfLines > 0`) it is not selectable and its links are not tappable, regardless of [`isSelectable`](#isselectable). This is a platform constraint, not a choice: Android draws the truncation ellipsis only through `StaticLayout`, but enabling text selection or a link movement method promotes the text to a `Spannable`, which forces `TextView` onto `DynamicLayout` - and `DynamicLayout` has no `maxLines` support, so the clamp and its ellipsis are silently dropped (confirmed against AOSP `TextView`/`DynamicLayout` on API 35/36; React Native's own `Text` hits the same limitation). Selection and links are restored automatically once the clamp is removed. iOS keeps selection and links while clamped.
+
 | Type     | Default Value | Platform |
 | -------- | ------------- | -------- |
 | `number` | `0`           | Both     |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -344,6 +344,8 @@ Controls where the ellipsis is placed when the text is truncated by [`numberOfLi
 - **`'tail'`** (default): ellipsis at the end (`start of the...`).
 - **`'clip'`**: truncate at the line boundary with no ellipsis glyph.
 
+> **Multi-line note:** `'head'` and `'middle'` are single-line truncation modes. They only place the ellipsis as described when [`numberOfLines`](#numberoflines) is `1`. With `numberOfLines > 1`, Android only truncates through `StaticLayout`'s `TruncateAt.END`, so `'head'` and `'middle'` fall back to tail-style behavior; iOS multi-line truncation with these modes is likewise unreliable. This mirrors React Native's core `Text`, where only `'tail'` is documented to work correctly past one line. Use `'tail'` (or `'clip'`) for multi-line clamps.
+
 Ignored when [`flavor`](#flavor) is `'github'` (see [`numberOfLines`](#numberoflines)).
 
 ### `textBreakStrategy`

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -281,6 +281,22 @@ class EnrichedMarkdownManager :
     view?.setTextBreakStrategy(strategy ?: "highQuality")
   }
 
+  @ReactProp(name = "numberOfLines", defaultInt = 0)
+  override fun setNumberOfLines(
+    view: EnrichedMarkdown?,
+    value: Int,
+  ) {
+    // No-op for GFM — block segments cannot honor a document-wide line cap. See the GFM tracking issue.
+  }
+
+  @ReactProp(name = "ellipsizeMode")
+  override fun setEllipsizeMode(
+    view: EnrichedMarkdown?,
+    value: String?,
+  ) {
+    // No-op for GFM — see setNumberOfLines.
+  }
+
   @ReactProp(name = "contextMenuItems")
   override fun setContextMenuItems(
     view: EnrichedMarkdown?,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -24,6 +24,7 @@ import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlayDrawer
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.BreakStrategyUtils
+import com.swmansion.enriched.markdown.utils.common.EllipsizeUtils
 import com.swmansion.enriched.markdown.utils.common.emitCodeBlockPress
 import com.swmansion.enriched.markdown.utils.text.TailFadeInAnimator
 import com.swmansion.enriched.markdown.utils.text.interaction.CheckboxTouchHelper
@@ -112,6 +113,9 @@ class EnrichedMarkdownText
     var spoilerOverlay: SpoilerOverlay = SpoilerOverlay.PARTICLES
 
     private var pendingStyledText: CharSequence? = null
+
+    private var mdNumberOfLines: Int = 0
+    private var mdEllipsizeMode: String = EllipsizeUtils.DEFAULT_MODE
 
     private var selectionColor: Int? = null
     private var selectionHandleColor: Int? = null
@@ -358,6 +362,37 @@ class EnrichedMarkdownText
       }
       MeasurementStore.invalidate(id)
       scheduleRenderIfNeeded()
+    }
+
+    fun setMarkdownNumberOfLines(value: Int) {
+      val normalized = value.coerceAtLeast(0)
+      if (mdNumberOfLines == normalized) return
+      mdNumberOfLines = normalized
+      MeasurementStore.updateNumberOfLines(id, normalized)
+      applyLineLimitToView()
+      MeasurementStore.invalidate(id)
+      scheduleRenderIfNeeded()
+    }
+
+    fun setMarkdownEllipsizeMode(value: String) {
+      if (mdEllipsizeMode == value) return
+      mdEllipsizeMode = value
+      MeasurementStore.updateEllipsizeMode(id, value)
+      applyLineLimitToView()
+      MeasurementStore.invalidate(id)
+      scheduleRenderIfNeeded()
+    }
+
+    // Mirrors RN's ReactTextView.updateView: only ellipsize when a line limit is
+    // set; unlimited restores the default unbounded, non-ellipsized state.
+    private fun applyLineLimitToView() {
+      if (mdNumberOfLines > 0) {
+        maxLines = mdNumberOfLines
+        ellipsize = EllipsizeUtils.resolveTruncateAt(mdEllipsizeMode)
+      } else {
+        maxLines = Integer.MAX_VALUE
+        ellipsize = null
+      }
     }
 
     fun emitOnLinkPress(url: String) {

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownText.kt
@@ -116,6 +116,7 @@ class EnrichedMarkdownText
 
     private var mdNumberOfLines: Int = 0
     private var mdEllipsizeMode: String = EllipsizeUtils.DEFAULT_MODE
+    private var mdSelectable: Boolean = true
 
     private var selectionColor: Int? = null
     private var selectionHandleColor: Int? = null
@@ -298,9 +299,7 @@ class EnrichedMarkdownText
 
       text = styledText
 
-      if (movementMethod !is LinkLongPressMovementMethod) {
-        movementMethod = LinkLongPressMovementMethod.createInstance()
-      }
+      applyInteractivity()
 
       renderer.getCollectedImageSpans().forEach { span ->
         span.registerTextView(this)
@@ -340,7 +339,8 @@ class EnrichedMarkdownText
     }
 
     fun setIsSelectable(selectable: Boolean) {
-      applySelectableState(selectable)
+      mdSelectable = selectable
+      applyInteractivity()
     }
 
     fun setSelectionColor(color: Int?) {
@@ -392,6 +392,28 @@ class EnrichedMarkdownText
       } else {
         maxLines = Integer.MAX_VALUE
         ellipsize = null
+      }
+      applyInteractivity()
+    }
+
+    // The numberOfLines ellipsis and text selection / link taps are mutually
+    // exclusive on Android and cannot be reconciled. Both setTextIsSelectable(true)
+    // and a non-null movementMethod force the display text to a Spannable, which
+    // makes TextView pick DynamicLayout (TextView.useDynamicLayout). DynamicLayout
+    // has no setMaxLines, so the clamp is never baked into the layout and no
+    // ellipsis glyph is drawn (verified against AOSP TextView/DynamicLayout on
+    // API 35/36). To keep the ellipsis, a clamped view must be non-selectable AND
+    // drop its movement method; both are restored to the user's preference once
+    // the clamp is removed.
+    private fun applyInteractivity() {
+      if (mdNumberOfLines > 0) {
+        if (isTextSelectable) setTextIsSelectable(false)
+        movementMethod = null
+      } else {
+        applySelectableState(mdSelectable)
+        if (movementMethod !is LinkLongPressMovementMethod) {
+          movementMethod = LinkLongPressMovementMethod.createInstance()
+        }
       }
     }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -267,6 +267,22 @@ class EnrichedMarkdownTextManager :
     view?.setTextBreakStrategy(strategy ?: "highQuality")
   }
 
+  @ReactProp(name = "numberOfLines", defaultInt = 0)
+  override fun setNumberOfLines(
+    view: EnrichedMarkdownText?,
+    value: Int,
+  ) {
+    view?.setMarkdownNumberOfLines(value)
+  }
+
+  @ReactProp(name = "ellipsizeMode")
+  override fun setEllipsizeMode(
+    view: EnrichedMarkdownText?,
+    value: String?,
+  ) {
+    view?.setMarkdownEllipsizeMode(value ?: "tail")
+  }
+
   @ReactProp(name = "contextMenuItems")
   override fun setContextMenuItems(
     view: EnrichedMarkdownText?,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -72,9 +72,7 @@ object MeasurementStore {
 
   private val breakStrategies = ConcurrentHashMap<Int, String>()
 
-  // numberOfLines / ellipsizeMode are per-view layout props (CommonMark only).
-  // Stored per viewId like breakStrategies so the measure path and the display
-  // TextView resolve the same clamp. 0 means unlimited.
+  // The measure path and the display TextView resolve the same clamp. 0 means unlimited.
   private val numberOfLinesByViewId = ConcurrentHashMap<Int, Int>()
 
   private val ellipsizeModeByViewId = ConcurrentHashMap<Int, String>()
@@ -749,9 +747,6 @@ object MeasurementStore {
     return if (maxLines > 0) minOf(maxLines, layout.lineCount) else layout.lineCount
   }
 
-  // StaticLayout only shrinks its reported height for maxLines when ellipsizing, so
-  // truncate to the last visible line explicitly (mirrors RN's calculateHeight).
-  // Guards against a 0-line layout so getLineBottom(-1) can never be called.
   private fun truncatedHeight(
     layout: StaticLayout,
     visibleLineCount: Int,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -751,10 +751,11 @@ object MeasurementStore {
 
   // StaticLayout only shrinks its reported height for maxLines when ellipsizing, so
   // truncate to the last visible line explicitly (mirrors RN's calculateHeight).
+  // Guards against a 0-line layout so getLineBottom(-1) can never be called.
   private fun truncatedHeight(
     layout: StaticLayout,
     visibleLineCount: Int,
-  ): Float = layout.getLineBottom(visibleLineCount - 1).toFloat()
+  ): Float = if (visibleLineCount <= 0) 0f else layout.getLineBottom(visibleLineCount - 1).toFloat()
 
   /**
    * Measures text and returns both the size and the layout for calculating last line descent.

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.text.SpannableString
 import android.text.StaticLayout
 import android.text.TextPaint
+import android.text.TextUtils.TruncateAt
 import android.util.Log
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil
@@ -26,6 +27,7 @@ import com.swmansion.enriched.markdown.spans.MathRenderMode
 import com.swmansion.enriched.markdown.styles.StyleConfig
 import com.swmansion.enriched.markdown.utils.common.BreakStrategyUtils
 import com.swmansion.enriched.markdown.utils.common.CodeBlockStreamingMode
+import com.swmansion.enriched.markdown.utils.common.EllipsizeUtils
 import com.swmansion.enriched.markdown.utils.common.FeatureFlags
 import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
 import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
@@ -69,6 +71,13 @@ object MeasurementStore {
   private val fontScalingSettings = ConcurrentHashMap<Int, FontScalingSettings>()
 
   private val breakStrategies = ConcurrentHashMap<Int, String>()
+
+  // numberOfLines / ellipsizeMode are per-view layout props (CommonMark only).
+  // Stored per viewId like breakStrategies so the measure path and the display
+  // TextView resolve the same clamp. 0 means unlimited.
+  private val numberOfLinesByViewId = ConcurrentHashMap<Int, Int>()
+
+  private val ellipsizeModeByViewId = ConcurrentHashMap<Int, String>()
 
   private val streamingTableModes = ConcurrentHashMap<Int, TableStreamingMode>()
 
@@ -124,6 +133,8 @@ object MeasurementStore {
 
   fun release(id: Int) {
     data.remove(id)
+    numberOfLinesByViewId.remove(id)
+    ellipsizeModeByViewId.remove(id)
   }
 
   fun invalidate(id: Int) {
@@ -200,6 +211,33 @@ object MeasurementStore {
   }
 
   private fun resolveBreakStrategy(viewId: Int?): Int = BreakStrategyUtils.resolveBreakStrategy(viewId?.let { breakStrategies[it] })
+
+  fun updateNumberOfLines(
+    viewId: Int,
+    numberOfLines: Int,
+  ) {
+    numberOfLinesByViewId[viewId] = numberOfLines
+  }
+
+  fun clearNumberOfLines(viewId: Int) {
+    numberOfLinesByViewId.remove(viewId)
+  }
+
+  fun updateEllipsizeMode(
+    viewId: Int,
+    mode: String,
+  ) {
+    ellipsizeModeByViewId[viewId] = mode
+  }
+
+  fun clearEllipsizeMode(viewId: Int) {
+    ellipsizeModeByViewId.remove(viewId)
+  }
+
+  private fun resolveMaxLines(viewId: Int?): Int = viewId?.let { numberOfLinesByViewId[it] } ?: 0
+
+  private fun resolveEllipsize(viewId: Int?): TruncateAt? =
+    EllipsizeUtils.resolveTruncateAt(viewId?.let { ellipsizeModeByViewId[it] } ?: EllipsizeUtils.DEFAULT_MODE)
 
   fun updateStreamingTableMode(
     viewId: Int,
@@ -676,17 +714,47 @@ object MeasurementStore {
       builder.setUseLineSpacingFromFallbacks(true)
     }
 
-    val layout = builder.build()
-    val measuredHeight = layout.height.toFloat()
+    applyLineLimit(builder, viewId)
 
-    // Calculate actual content width (widest line)
-    val measuredWidth = (0 until layout.lineCount).maxOfOrNull { layout.getLineWidth(it) } ?: 0f
+    val layout = builder.build()
+    val visibleLineCount = visibleLineCount(layout, viewId)
+    val measuredHeight = truncatedHeight(layout, visibleLineCount)
+
+    // Calculate actual content width (widest visible line)
+    val measuredWidth = (0 until visibleLineCount).maxOfOrNull { layout.getLineWidth(it) } ?: 0f
 
     return YogaMeasureOutput.make(
       PixelUtil.toDIPFromPixel(ceil(measuredWidth)),
       PixelUtil.toDIPFromPixel(measuredHeight),
     )
   }
+
+  // Applies the per-view numberOfLines / ellipsizeMode clamp to a builder, matching
+  // RN's TextLayoutManager.buildLayout: only when a line limit is set.
+  private fun applyLineLimit(
+    builder: StaticLayout.Builder,
+    viewId: Int?,
+  ) {
+    val maxLines = resolveMaxLines(viewId)
+    if (maxLines > 0) {
+      builder.setMaxLines(maxLines).setEllipsize(resolveEllipsize(viewId))
+    }
+  }
+
+  private fun visibleLineCount(
+    layout: StaticLayout,
+    viewId: Int?,
+  ): Int {
+    val maxLines = resolveMaxLines(viewId)
+    return if (maxLines > 0) minOf(maxLines, layout.lineCount) else layout.lineCount
+  }
+
+  // StaticLayout only shrinks its reported height for maxLines when ellipsizing, so
+  // truncate to the last visible line explicitly (mirrors RN's calculateHeight).
+  private fun truncatedHeight(
+    layout: StaticLayout,
+    visibleLineCount: Int,
+  ): Float = layout.getLineBottom(visibleLineCount - 1).toFloat()
 
   /**
    * Measures text and returns both the size and the layout for calculating last line descent.
@@ -714,17 +782,20 @@ object MeasurementStore {
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             setUseLineSpacingFromFallbacks(true)
           }
+          applyLineLimit(this, viewId)
         }.build()
 
-    // Find the widest line to get the actual content width
+    val visibleLineCount = visibleLineCount(layout, viewId)
+
+    // Find the widest visible line to get the actual content width
     val maxLineWidth =
-      (0 until layout.lineCount)
+      (0 until visibleLineCount)
         .maxOfOrNull { layout.getLineWidth(it) } ?: 0f
 
     val size =
       YogaMeasureOutput.make(
         PixelUtil.toDIPFromPixel(ceil(maxLineWidth)),
-        PixelUtil.toDIPFromPixel(layout.height.toFloat()),
+        PixelUtil.toDIPFromPixel(truncatedHeight(layout, visibleLineCount)),
       )
 
     return size to layout

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -230,19 +230,11 @@ object MeasurementStore {
     numberOfLinesByViewId[viewId] = numberOfLines
   }
 
-  fun clearNumberOfLines(viewId: Int) {
-    numberOfLinesByViewId.remove(viewId)
-  }
-
   fun updateEllipsizeMode(
     viewId: Int,
     mode: String,
   ) {
     ellipsizeModeByViewId[viewId] = mode
-  }
-
-  fun clearEllipsizeMode(viewId: Int) {
-    ellipsizeModeByViewId.remove(viewId)
   }
 
   private fun resolveMaxLines(viewId: Int?): Int = viewId?.let { numberOfLinesByViewId[it] } ?: 0

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -33,6 +33,7 @@ import com.swmansion.enriched.markdown.utils.common.StreamingMarkdownFilter
 import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
 import com.swmansion.enriched.markdown.utils.common.getArrayOrNull
 import com.swmansion.enriched.markdown.utils.common.getBooleanOrDefault
+import com.swmansion.enriched.markdown.utils.common.getIntOrDefault
 import com.swmansion.enriched.markdown.utils.common.getMapOrNull
 import com.swmansion.enriched.markdown.utils.common.getStringOrDefault
 import com.swmansion.enriched.markdown.utils.common.parseImageRequestHeaders
@@ -157,6 +158,18 @@ object MeasurementStore {
     if (markdown.isEmpty()) {
       val emptyWidth = if (widthMode === YogaMeasureMode.EXACTLY) PixelUtil.toDIPFromPixel(width) else 0f
       return YogaMeasureOutput.make(emptyWidth, 0f)
+    }
+
+    // Resolve the line clamp from props here so the (background) measure pass and
+    // the (main-thread) display TextView never race on the per-viewId cache. Only
+    // overwrite when the key is present so we never clobber the view's value.
+    if (id != null && props != null) {
+      if (props.hasKey("numberOfLines")) {
+        numberOfLinesByViewId[id] = props.getDouble("numberOfLines").toInt()
+      }
+      if (props.hasKey("ellipsizeMode")) {
+        ellipsizeModeByViewId[id] = props.getString("ellipsizeMode") ?: EllipsizeUtils.DEFAULT_MODE
+      }
     }
 
     val size = getMeasureByIdInternal(context, id, width, props, splitTableSegments)
@@ -323,6 +336,8 @@ object MeasurementStore {
     result = 31 * result + maxFontSizeMultiplier.toBits()
     result = 31 * result + allowTrailingMargin.hashCode()
     result = 31 * result + imageRequestHeaders.hashCode()
+    result = 31 * result + props.getIntOrDefault("numberOfLines", 0)
+    result = 31 * result + props.getStringOrDefault("ellipsizeMode", EllipsizeUtils.DEFAULT_MODE).hashCode()
     return result
   }
 

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/EllipsizeUtils.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/EllipsizeUtils.kt
@@ -1,0 +1,27 @@
+package com.swmansion.enriched.markdown.utils.common
+
+import android.text.TextUtils.TruncateAt
+
+/**
+ * Resolves an ellipsizeMode prop value (string) to the TruncateAt used by
+ * StaticLayout.Builder.setEllipsize() and TextView.setEllipsize().
+ *
+ * "clip" maps to null: with maxLines set, the layout still truncates but draws
+ * no ellipsis glyph. Mirrors React Native's TextAttributeProps.getEllipsizeMode.
+ *
+ * Stateless like [BreakStrategyUtils]: the mode is a per-view prop stored per
+ * viewId in [com.swmansion.enriched.markdown.MeasurementStore]. Measurement and
+ * render paths must resolve the same value, or the measured line count diverges
+ * from the rendered one and the view is sized incorrectly.
+ */
+object EllipsizeUtils {
+  const val DEFAULT_MODE = "tail"
+
+  fun resolveTruncateAt(mode: String?): TruncateAt? =
+    when (mode) {
+      "head" -> TruncateAt.START
+      "middle" -> TruncateAt.MIDDLE
+      "clip" -> null
+      else -> TruncateAt.END
+    }
+}

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/ReadableMapExtensions.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/ReadableMapExtensions.kt
@@ -16,10 +16,7 @@ fun ReadableMap?.getFloatOrDefault(
 fun ReadableMap?.getIntOrDefault(
   key: String,
   default: Int,
-): Int =
-  // Read through getDouble: numeric props cross the bridge as JS doubles, and
-  // ReadableMap.getInt throws on a double-typed value.
-  if (this?.hasKey(key) == true) getDouble(key).toInt() else default
+): Int = if (this?.hasKey(key) == true) getDouble(key).toInt() else default
 
 fun ReadableMap?.getStringOrDefault(
   key: String,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/ReadableMapExtensions.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/ReadableMapExtensions.kt
@@ -13,6 +13,14 @@ fun ReadableMap?.getFloatOrDefault(
   default: Float,
 ): Float = if (this?.hasKey(key) == true) getDouble(key).toFloat() else default
 
+fun ReadableMap?.getIntOrDefault(
+  key: String,
+  default: Int,
+): Int =
+  // Read through getDouble: numeric props cross the bridge as JS doubles, and
+  // ReadableMap.getInt throws on a double-typed value.
+  if (this?.hasKey(key) == true) getDouble(key).toInt() else default
+
 fun ReadableMap?.getStringOrDefault(
   key: String,
   default: String,

--- a/packages/react-native-enriched-markdown/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
+++ b/packages/react-native-enriched-markdown/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
@@ -16,10 +16,6 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownTextProps &props) {
   serializedProps["maxFontSizeMultiplier"] = props.maxFontSizeMultiplier;
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
   serializedProps["streamingAnimation"] = props.streamingAnimation;
-  // Required by the measure pass to clamp height to numberOfLines. Without these
-  // the props map reaching MeasurementStore lacks the keys, so the measured
-  // height stays unclamped while the display TextView clamps - leaving the view
-  // sized for the full document. CommonMark only; GFM ignores the clamp.
   serializedProps["numberOfLines"] = props.numberOfLines;
   serializedProps["ellipsizeMode"] = props.ellipsizeMode;
 

--- a/packages/react-native-enriched-markdown/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
+++ b/packages/react-native-enriched-markdown/android/src/main/jni/react/renderer/components/EnrichedMarkdownTextSpec/conversions.h
@@ -16,6 +16,12 @@ inline folly::dynamic toDynamic(const EnrichedMarkdownTextProps &props) {
   serializedProps["maxFontSizeMultiplier"] = props.maxFontSizeMultiplier;
   serializedProps["allowTrailingMargin"] = props.allowTrailingMargin;
   serializedProps["streamingAnimation"] = props.streamingAnimation;
+  // Required by the measure pass to clamp height to numberOfLines. Without these
+  // the props map reaching MeasurementStore lacks the keys, so the measured
+  // height stays unclamped while the display TextView clamps - leaving the view
+  // sized for the full document. CommonMark only; GFM ignores the clamp.
+  serializedProps["numberOfLines"] = props.numberOfLines;
+  serializedProps["ellipsizeMode"] = props.ellipsizeMode;
 
   folly::dynamic imageRequestHeaders = folly::dynamic::array();
   for (const auto &header : props.imageRequestHeaders) {

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -336,11 +336,7 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   };
 #endif
 
-  ENRMTapRecognizer *tapRecognizer = [[ENRMTapRecognize  serializedProps["streamingAnimation"] = props.streamingAnimation;
-  // Required by the measure pass to clamp height to numberOfLines. Without these
-  // the props map reaching MeasurementStore lacks the keys, so the measured
-  // height stays unclamped while the display TextView clamps - leaving the view
-  // sized for the full document. CommonMark only; GFM ignores the clamp.r alloc] initWithTarget:self action:@selector(textTapped:)];
+  ENRMTapRecognizer *tapRecognizer = [[ENRMTapRecognizer alloc] initWithTarget:self action:@selector(textTapped:)];
   [_textView addGestureRecognizer:tapRecognizer];
 
   self.contentView = _textView;

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -443,7 +443,6 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   _renderedStyleFingerprint = _pendingStyleFingerprint;
 }
 
-// Applies the numberOfLines / ellipsizeMode clamp to the visible text container.
 // Kept in sync with the view-free measurement so the rendered line count matches
 // the measured height. numberOfLines == 0 restores the unlimited default.
 - (void)applyLineClampToTextContainer

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -444,11 +444,23 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
 }
 
 // Kept in sync with the view-free measurement so the rendered line count matches
-// the measured height. numberOfLines == 0 restores the unlimited default.
+// the measured height. The clamp must be computed at the padding-inset content
+// width (the text view's own width) rather than the full component bounds, or a
+// full-width measurement pass leaves the truncation laid out too wide and fewer
+// lines render than were measured. numberOfLines == 0 restores the unlimited default.
 - (void)applyLineClampToTextContainer
 {
-  _textView.textContainer.maximumNumberOfLines = _numberOfLines > 0 ? _numberOfLines : 0;
-  _textView.textContainer.lineBreakMode = _numberOfLines > 0 ? _ellipsizeLineBreakMode : NSLineBreakByWordWrapping;
+  if (_numberOfLines > 0) {
+    CGFloat contentWidth = _textView.bounds.size.width;
+    if (contentWidth > 0) {
+      _textView.textContainer.size = CGSizeMake(contentWidth, CGFLOAT_MAX);
+    }
+    _textView.textContainer.maximumNumberOfLines = _numberOfLines;
+    _textView.textContainer.lineBreakMode = _ellipsizeLineBreakMode;
+  } else {
+    _textView.textContainer.maximumNumberOfLines = 0;
+    _textView.textContainer.lineBreakMode = NSLineBreakByWordWrapping;
+  }
 }
 
 - (void)applyRenderedText:(NSMutableAttributedString *)attributedText
@@ -504,6 +516,15 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
     CGSize measured = [self measureSize:self.bounds.size.width];
     if (forceHeightUpdate || needsHeightUpdate(measured, self.bounds)) {
       [self requestHeightUpdate];
+    }
+
+    // measureSize lays the shared display container out at the full bounds width;
+    // re-pin the clamp to the content width so the visible truncation matches the
+    // content-width line count the shadow node measured.
+    if (_numberOfLines > 0) {
+      [self applyLineClampToTextContainer];
+      [_textView.layoutManager ensureLayoutForTextContainer:_textView.textContainer];
+      ENRMSetNeedsDisplay(_textView);
     }
   }
 

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -117,6 +117,9 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
 
   NSLineBreakStrategy _lineBreakStrategy;
 
+  NSInteger _numberOfLines;
+  NSLineBreakMode _ellipsizeLineBreakMode;
+
   ENRMWritingDirectionMode _writingDirectionMode;
   NSWritingDirection _resolvedLayoutDirection;
 
@@ -269,6 +272,8 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
     _forceHeightUpdateOnNextRender = NO;
     _selectionMenuConfig = (ENRMSelectionMenuConfig){.copyAsMarkdown = YES, .copyImageURL = YES};
     _lineBreakStrategy = NSLineBreakStrategyNone;
+    _numberOfLines = 0;
+    _ellipsizeLineBreakMode = NSLineBreakByTruncatingTail;
     _writingDirectionMode = ENRMWritingDirectionModeFirstStrong;
     _resolvedLayoutDirection =
         [[RCTI18nUtil sharedInstance] isRTL] ? NSWritingDirectionRightToLeft : NSWritingDirectionLeftToRight;
@@ -438,6 +443,15 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   _renderedStyleFingerprint = _pendingStyleFingerprint;
 }
 
+// Applies the numberOfLines / ellipsizeMode clamp to the visible text container.
+// Kept in sync with the view-free measurement so the rendered line count matches
+// the measured height. numberOfLines == 0 restores the unlimited default.
+- (void)applyLineClampToTextContainer
+{
+  _textView.textContainer.maximumNumberOfLines = _numberOfLines > 0 ? _numberOfLines : 0;
+  _textView.textContainer.lineBreakMode = _numberOfLines > 0 ? _ellipsizeLineBreakMode : NSLineBreakByWordWrapping;
+}
+
 - (void)applyRenderedText:(NSMutableAttributedString *)attributedText
 {
   NSUInteger tailStart = _previousTextLength;
@@ -457,6 +471,7 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
     containerWidth = self.bounds.size.width;
   }
   _textView.textContainer.size = CGSizeMake(containerWidth, CGFLOAT_MAX);
+  [self applyLineClampToTextContainer];
 
   _accessibilityElements = nil;
   _accessibilityNeedsRebuild = YES;
@@ -671,6 +686,21 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   if (newViewProps.writingDirection != oldViewProps.writingDirection) {
     NSString *value = [[NSString alloc] initWithUTF8String:newViewProps.writingDirection.c_str()];
     _writingDirectionMode = ENRMResolveWritingDirectionMode(value);
+    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
+  }
+
+  if (newViewProps.numberOfLines != oldViewProps.numberOfLines) {
+    _numberOfLines = (NSInteger)newViewProps.numberOfLines;
+    [self applyLineClampToTextContainer];
+    _forceHeightUpdateOnNextRender = YES;
+    _dirtyFlags |= ENRMDirtyRender;
+  }
+
+  if (newViewProps.ellipsizeMode != oldViewProps.ellipsizeMode) {
+    _ellipsizeLineBreakMode =
+        ENRMResolveEllipsizeLineBreakMode([[NSString alloc] initWithUTF8String:newViewProps.ellipsizeMode.c_str()]);
+    [self applyLineClampToTextContainer];
     _forceHeightUpdateOnNextRender = YES;
     _dirtyFlags |= ENRMDirtyRender;
   }

--- a/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
+++ b/packages/react-native-enriched-markdown/ios/EnrichedMarkdownText.mm
@@ -336,7 +336,11 @@ typedef NS_OPTIONS(NSUInteger, ENRMDirtyFlags) {
   };
 #endif
 
-  ENRMTapRecognizer *tapRecognizer = [[ENRMTapRecognizer alloc] initWithTarget:self action:@selector(textTapped:)];
+  ENRMTapRecognizer *tapRecognizer = [[ENRMTapRecognize  serializedProps["streamingAnimation"] = props.streamingAnimation;
+  // Required by the measure pass to clamp height to numberOfLines. Without these
+  // the props map reaching MeasurementStore lacks the keys, so the measured
+  // height stays unclamped while the display TextView clamps - leaving the view
+  // sized for the full document. CommonMark only; GFM ignores the clamp.r alloc] initWithTarget:self action:@selector(textTapped:)];
   [_textView addGestureRecognizer:tapRecognizer];
 
   self.contentView = _textView;

--- a/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
@@ -139,8 +139,6 @@ static inline CGSize ENRMMeasureAttributedTextViewFree(NSAttributedString *text,
 
   NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:CGSizeMake(maxWidth, CGFLOAT_MAX)];
   textContainer.lineFragmentPadding = 0;
-  // Clamp to numberOfLines so usedRect reports the truncated height, matching the
-  // visible view. lineBreakMode drives the ellipsis on the last visible line.
   if (numberOfLines > 0) {
     textContainer.maximumNumberOfLines = numberOfLines;
     textContainer.lineBreakMode = lineBreakMode;
@@ -294,7 +292,6 @@ static inline CGSize ENRMMeasureSegmentedMarkdownViewFree(const PropsT &typedPro
       const BOOL shouldAddBottomMargin = (!isLast || typedProps.allowTrailingMargin);
 
       if (segment.kind == ENRMSegmentKindText && segment.textResult) {
-        // GFM segments are never line-clamped (numberOfLines is a no-op for GFM).
         CGSize textSize = ENRMMeasureAttributedTextViewFree(
             segment.textResult.attributedText, maxWidth, config, shouldAddBottomMargin,
             segment.textResult.lastElementMarginBottom, pointScaleFactor, 0, NSLineBreakByWordWrapping);

--- a/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
+++ b/packages/react-native-enriched-markdown/ios/internals/ENRMViewFreeMeasurement.h
@@ -130,7 +130,8 @@ static inline StyleConfig *ENRMStyleConfigFromProps(const PropsT &typedProps, CG
  */
 static inline CGSize ENRMMeasureAttributedTextViewFree(NSAttributedString *text, CGFloat maxWidth, StyleConfig *config,
                                                        BOOL allowTrailingMargin, CGFloat lastElementMarginBottom,
-                                                       CGFloat pointScaleFactor)
+                                                       CGFloat pointScaleFactor, NSInteger numberOfLines,
+                                                       NSLineBreakMode lineBreakMode)
 {
   if (text.length == 0) {
     return CGSizeZero;
@@ -138,6 +139,12 @@ static inline CGSize ENRMMeasureAttributedTextViewFree(NSAttributedString *text,
 
   NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:CGSizeMake(maxWidth, CGFLOAT_MAX)];
   textContainer.lineFragmentPadding = 0;
+  // Clamp to numberOfLines so usedRect reports the truncated height, matching the
+  // visible view. lineBreakMode drives the ellipsis on the last visible line.
+  if (numberOfLines > 0) {
+    textContainer.maximumNumberOfLines = numberOfLines;
+    textContainer.lineBreakMode = lineBreakMode;
+  }
   NSLayoutManager *layoutManager = [[NSLayoutManager alloc] init];
   layoutManager.allowsNonContiguousLayout = NO;
   layoutManager.usesFontLeading = NO;
@@ -195,8 +202,12 @@ static inline CGSize ENRMMeasureMarkdownViewFree(const PropsT &typedProps, CGFlo
         ENRMResolveWritingDirectionMode([[NSString alloc] initWithUTF8String:typedProps.writingDirection.c_str()]);
     ENRMApplyWritingDirectionMode(text, writingDirectionMode, resolvedLayoutDirection);
 
+    NSInteger numberOfLines = (NSInteger)typedProps.numberOfLines;
+    NSLineBreakMode lineBreakMode =
+        ENRMResolveEllipsizeLineBreakMode([[NSString alloc] initWithUTF8String:typedProps.ellipsizeMode.c_str()]);
     CGSize size = ENRMMeasureAttributedTextViewFree(text, maxWidth, config, typedProps.allowTrailingMargin,
-                                                    result.lastElementMarginBottom, pointScaleFactor);
+                                                    result.lastElementMarginBottom, pointScaleFactor, numberOfLines,
+                                                    lineBreakMode);
     if (size.height == 0) {
       return fallback;
     }
@@ -283,9 +294,10 @@ static inline CGSize ENRMMeasureSegmentedMarkdownViewFree(const PropsT &typedPro
       const BOOL shouldAddBottomMargin = (!isLast || typedProps.allowTrailingMargin);
 
       if (segment.kind == ENRMSegmentKindText && segment.textResult) {
+        // GFM segments are never line-clamped (numberOfLines is a no-op for GFM).
         CGSize textSize = ENRMMeasureAttributedTextViewFree(
             segment.textResult.attributedText, maxWidth, config, shouldAddBottomMargin,
-            segment.textResult.lastElementMarginBottom, pointScaleFactor);
+            segment.textResult.lastElementMarginBottom, pointScaleFactor, 0, NSLineBreakByWordWrapping);
         yOffset += textSize.height;
         maxContentWidth = MAX(maxContentWidth, textSize.width);
       } else if (segment.kind == ENRMSegmentKindTable && segment.tableSegment) {

--- a/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
+++ b/packages/react-native-enriched-markdown/ios/internals/MeasurementCache.h
@@ -48,19 +48,22 @@ struct MeasurementCacheKey {
   MarkdownFlavor flavor;
   std::string lineBreakStrategyIOS;
   std::string writingDirection;
+  int numberOfLines;
+  std::string ellipsizeMode;
 
   bool operator==(const MeasurementCacheKey &other) const
   {
     return std::tie(markdown, maxWidth, allowTrailingMargin, allowFontScaling, maxFontSizeMultiplier,
                     md4cFlagsUnderline, md4cFlagsSuperscript, md4cFlagsSubscript, md4cFlagsHighlight,
                     md4cFlagsLatexMath, md4cFlagsHardSoftBreaks, md4cFlagsPreserveBlankLines, md4cFlagsAdmonitions,
-                    styleFingerprint, fontScale, flavor, lineBreakStrategyIOS, writingDirection) ==
+                    styleFingerprint, fontScale, flavor, lineBreakStrategyIOS, writingDirection, numberOfLines,
+                    ellipsizeMode) ==
            std::tie(other.markdown, other.maxWidth, other.allowTrailingMargin, other.allowFontScaling,
                     other.maxFontSizeMultiplier, other.md4cFlagsUnderline, other.md4cFlagsSuperscript,
                     other.md4cFlagsSubscript, other.md4cFlagsHighlight, other.md4cFlagsLatexMath,
                     other.md4cFlagsHardSoftBreaks, other.md4cFlagsPreserveBlankLines, other.md4cFlagsAdmonitions,
                     other.styleFingerprint, other.fontScale, other.flavor, other.lineBreakStrategyIOS,
-                    other.writingDirection);
+                    other.writingDirection, other.numberOfLines, other.ellipsizeMode);
   }
 };
 
@@ -86,6 +89,8 @@ struct MeasurementCacheKeyHash {
     HashUtils::hash_one(h, static_cast<uint8_t>(key.flavor));
     HashUtils::hash_one(h, key.lineBreakStrategyIOS);
     HashUtils::hash_one(h, key.writingDirection);
+    HashUtils::hash_one(h, key.numberOfLines);
+    HashUtils::hash_one(h, key.ellipsizeMode);
     return h;
   }
 };
@@ -173,6 +178,8 @@ inline MeasurementCacheKey buildMeasurementCacheKey(const PropsType &props, CGFl
       .flavor = flavor,
       .lineBreakStrategyIOS = props.lineBreakStrategyIOS,
       .writingDirection = props.writingDirection,
+      .numberOfLines = props.numberOfLines,
+      .ellipsizeMode = props.ellipsizeMode,
   };
 }
 

--- a/packages/react-native-enriched-markdown/ios/segments/ENRMSegmentHeightMeasurer.mm
+++ b/packages/react-native-enriched-markdown/ios/segments/ENRMSegmentHeightMeasurer.mm
@@ -28,9 +28,10 @@ CGFloat ENRMMeasureSegmentsHeightViewFree(NSArray<ENRMRenderedSegment *> *segmen
     const BOOL shouldAddBottomMargin = (!isLast || allowTrailingMargin);
 
     if (segment.kind == ENRMSegmentKindText && segment.textResult) {
-      CGSize textSize = ENRMMeasureAttributedTextViewFree(segment.textResult.attributedText, contentWidth, config,
-                                                          shouldAddBottomMargin,
-                                                          segment.textResult.lastElementMarginBottom, pointScaleFactor);
+      // GFM segments are never line-clamped (numberOfLines is a no-op for GFM).
+      CGSize textSize = ENRMMeasureAttributedTextViewFree(
+          segment.textResult.attributedText, contentWidth, config, shouldAddBottomMargin,
+          segment.textResult.lastElementMarginBottom, pointScaleFactor, 0, NSLineBreakByWordWrapping);
       totalHeight += textSize.height;
     } else if (segment.kind == ENRMSegmentKindTable && segment.tableSegment) {
       totalHeight += config.tableMarginTop;

--- a/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.h
+++ b/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.h
@@ -11,6 +11,12 @@ NSLineBreakStrategy ENRMResolveLineBreakStrategy(NSString *_Nullable strategy);
 void ENRMApplyLineBreakStrategyToParagraphStyles(NSMutableAttributedString *output,
                                                  NSLineBreakStrategy lineBreakStrategy);
 
+/// Resolves an ellipsizeMode prop value to the NSLineBreakMode used for
+/// truncation on the text container (with maximumNumberOfLines). 'clip' maps to
+/// NSLineBreakByClipping (truncate with no ellipsis). Defaults to tail. Mirrors
+/// React Native Text's ellipsizeMode.
+NSLineBreakMode ENRMResolveEllipsizeLineBreakMode(NSString *_Nullable mode);
+
 /// Auto/LTR/RTL match React Native's writingDirection prop.
 /// FirstStrong is the library extension: resolve each paragraph from its first strong
 /// directional character (matches Android's TEXT_DIRECTION_FIRST_STRONG).

--- a/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
+++ b/packages/react-native-enriched-markdown/ios/utils/ParagraphStyleUtils.m
@@ -23,6 +23,18 @@ NSLineBreakStrategy ENRMResolveLineBreakStrategy(NSString *strategy)
   return NSLineBreakStrategyNone;
 }
 
+NSLineBreakMode ENRMResolveEllipsizeLineBreakMode(NSString *mode)
+{
+  if ([mode isEqualToString:@"head"]) {
+    return NSLineBreakByTruncatingHead;
+  } else if ([mode isEqualToString:@"middle"]) {
+    return NSLineBreakByTruncatingMiddle;
+  } else if ([mode isEqualToString:@"clip"]) {
+    return NSLineBreakByClipping;
+  }
+  return NSLineBreakByTruncatingTail;
+}
+
 __attribute__((constructor)) static void initParagraphStyleUtils(void)
 {
   kNewlineAttributedString = [[NSAttributedString alloc] initWithString:@"\n"];

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownNativeComponent.ts
@@ -601,6 +601,19 @@ export interface NativeProps extends ViewProps {
    * @platform ios
    */
   writingDirection?: CodegenTypes.WithDefault<string, 'first-strong'>;
+  /**
+   * No-op for the GFM backend. Declared for parity with the CommonMark
+   * component so the shared JS props can be forwarded uniformly. GFM renders
+   * independent block segments and cannot honor a document-wide line cap, so
+   * this is ignored - see the GFM tracking issue.
+   * @default 0
+   */
+  numberOfLines?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;
+  /**
+   * No-op for the GFM backend. See `numberOfLines`.
+   * @default 'tail'
+   */
+  ellipsizeMode?: CodegenTypes.WithDefault<string, 'tail'>;
 }
 
 export default codegenNativeComponent<NativeProps>('EnrichedMarkdown', {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -601,6 +601,21 @@ export interface NativeProps extends ViewProps {
    * @platform ios
    */
   writingDirection?: CodegenTypes.WithDefault<string, 'first-strong'>;
+  /**
+   * Maximum number of lines to display before the text is truncated. 0 (the
+   * default) means unlimited. Matches React Native Text's `numberOfLines`.
+   * Only applies to CommonMark; ignored when the flavor is 'github'.
+   * @default 0
+   */
+  numberOfLines?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;
+  /**
+   * Where to place the ellipsis when text is truncated by `numberOfLines`:
+   * 'head' | 'middle' | 'tail' | 'clip' ('clip' cuts with no ellipsis). Only
+   * takes effect when `numberOfLines` is set. Matches React Native Text's
+   * `ellipsizeMode`. Ignored when the flavor is 'github'.
+   * @default 'tail'
+   */
+  ellipsizeMode?: CodegenTypes.WithDefault<string, 'tail'>;
 }
 
 export default codegenNativeComponent<NativeProps>('EnrichedMarkdownText', {

--- a/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
+++ b/packages/react-native-enriched-markdown/src/EnrichedMarkdownTextNativeComponent.ts
@@ -605,6 +605,9 @@ export interface NativeProps extends ViewProps {
    * Maximum number of lines to display before the text is truncated. 0 (the
    * default) means unlimited. Matches React Native Text's `numberOfLines`.
    * Only applies to CommonMark; ignored when the flavor is 'github'.
+   * Android: while clamped the view is not selectable and links are not tappable
+   * (DynamicLayout has no maxLines support, so selection/links would drop the
+   * ellipsis); both are restored once the clamp is removed. iOS is unaffected.
    * @default 0
    */
   numberOfLines?: CodegenTypes.WithDefault<CodegenTypes.Int32, 0>;

--- a/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
+++ b/packages/react-native-enriched-markdown/src/native/EnrichedMarkdownText.tsx
@@ -150,6 +150,8 @@ export const EnrichedMarkdownText = ({
   textBreakStrategy,
   lineBreakStrategyIOS,
   writingDirection = 'first-strong',
+  numberOfLines,
+  ellipsizeMode,
   ...rest
 }: EnrichedMarkdownTextProps) => {
   const normalizedStyleRef = useRef<MarkdownStyleInternal | null>(null);
@@ -372,6 +374,8 @@ export const EnrichedMarkdownText = ({
     textBreakStrategy,
     lineBreakStrategyIOS,
     writingDirection,
+    numberOfLines,
+    ellipsizeMode,
     ...rest,
   };
 

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
@@ -418,4 +418,23 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * @platform ios
    */
   writingDirection?: 'auto' | 'ltr' | 'rtl' | 'first-strong';
+  /**
+   * Maximum number of lines to display before the text is truncated. `0` (the
+   * default) means unlimited. Matches React Native `Text`'s `numberOfLines`.
+   *
+   * Only supported for CommonMark (the default flavor). When `flavor` is
+   * `'github'` the content is laid out as independent block segments and this
+   * prop is ignored - see the GFM tracking issue.
+   * @default 0
+   */
+  numberOfLines?: number;
+  /**
+   * Where to place the ellipsis when text is truncated by `numberOfLines`.
+   * `'clip'` truncates with no ellipsis glyph. Only takes effect when
+   * `numberOfLines` is set. Matches React Native `Text`'s `ellipsizeMode`.
+   *
+   * Ignored when `flavor` is `'github'` (see `numberOfLines`).
+   * @default 'tail'
+   */
+  ellipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
 }

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
@@ -425,6 +425,13 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * Only supported for CommonMark (the default flavor). When `flavor` is
    * `'github'` the content is laid out as independent block segments and this
    * prop is ignored - see the GFM tracking issue.
+   *
+   * Android: while clamped (`numberOfLines > 0`) the view is not selectable and
+   * its links are not tappable, regardless of `isSelectable`. Android only draws
+   * the truncation ellipsis through `StaticLayout`; enabling selection or a link
+   * movement method promotes the text to a `Spannable`, forcing `DynamicLayout`,
+   * which has no `maxLines` support and drops the clamp/ellipsis. Both are
+   * restored once the clamp is removed. iOS keeps selection and links.
    * @default 0
    */
   numberOfLines?: number;

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
@@ -427,7 +427,7 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * prop is ignored - see the GFM tracking issue.
    *
    * Android: while clamped (`numberOfLines > 0`) the view is not selectable and
-   * its links are not tappable, regardless of `isSelectable`. Android only draws
+   * its links are not tappable, regardless of `selectable`. Android only draws
    * the truncation ellipsis through `StaticLayout`; enabling selection or a link
    * movement method promotes the text to a `Spannable`, forcing `DynamicLayout`,
    * which has no `maxLines` support and drops the clamp/ellipsis. Both are

--- a/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
+++ b/packages/react-native-enriched-markdown/src/types/MarkdownTextProps.ts
@@ -440,6 +440,12 @@ export interface EnrichedMarkdownTextProps extends Omit<ViewProps, 'style'> {
    * `'clip'` truncates with no ellipsis glyph. Only takes effect when
    * `numberOfLines` is set. Matches React Native `Text`'s `ellipsizeMode`.
    *
+   * `'head'` and `'middle'` are single-line truncation modes: they only place
+   * the ellipsis as described when `numberOfLines` is `1`. With
+   * `numberOfLines > 1` Android falls back to tail-style truncation (only
+   * `TruncateAt.END` works past one line) and iOS is likewise unreliable, so
+   * use `'tail'` or `'clip'` for multi-line clamps. Same limitation as RN `Text`.
+   *
    * Ignored when `flavor` is `'github'` (see `numberOfLines`).
    * @default 'tail'
    */


### PR DESCRIPTION
### What/Why?

Closes #761.

Adds React Native `Text` parity props to `EnrichedMarkdownText` for the CommonMark flavor (issue #761):

- `numberOfLines` - clamps the rendered text to N lines (`0` = unlimited).
- `ellipsizeMode` - `'head' | 'middle' | 'tail' | 'clip'` (default `'tail'`), controls where the ellipsis goes; `'clip'` truncates with no glyph.

Ellipsis is only applied when `numberOfLines` is set, matching RN. This makes the component usable for single-line / truncated previews (chat rows, reply quotes).

**Implementation**
- **JS**: both native specs declare the props (forwarded uniformly via `sharedProps`); public `EnrichedMarkdownTextProps` typed as `number` / a string union.
- **Android**: `MeasurementStore` applies `setMaxLines` + `setEllipsize` and reports the truncated height (`getLineBottom` of the last visible line) in both CommonMark builders; the display `TextView` mirrors the clamp. Stored per viewId like `textBreakStrategy` via the new `EllipsizeUtils`. The C++ measurement bridge (`conversions.h`) also serializes the two props, otherwise the background measure pass never sees the clamp and reserves the full-document height.
- **iOS**: the view-free measurement and the visible text container both set `maximumNumberOfLines` + `lineBreakMode` (new `ENRMResolveEllipsizeLineBreakMode`).

> [!WARNING]
> **Android limitation - selection/links vs. ellipsis:** while a view is clamped (`numberOfLines > 0`) it is **not selectable and its links are not tappable**, regardless of `isSelectable`; both are restored automatically once the clamp is removed. This is a hard platform constraint, not a design choice. Android only draws the truncation ellipsis through `StaticLayout`, but enabling text selection (`setTextIsSelectable`) or keeping a link movement method promotes the display text to a `Spannable`, which makes `TextView` pick `DynamicLayout` (`TextView.useDynamicLayout`). `DynamicLayout.Builder` has no `setMaxLines`, so the clamp is never baked into the layout and no ellipsis glyph is drawn. Verified against AOSP `TextView`/`DynamicLayout` on API 35/36; React Native's own core `Text` hits the same limitation (it applies `setTextIsSelectable` + `setMaxLines` + `setEllipsize` with no guard). iOS keeps selection and links while clamped.

**GFM**: the segmented backend renders independent block segments and cannot honor a document-wide line cap, so both props are no-ops there - declared for prop parity only. Tracked in #786.

Stacked on top of #787 (which makes a clamped one-line preview fill its container).

### Testing

- `numberOfLines={1}` inside a `flex: 1` container: single line that fills the width and ends in an ellipsis.
- `numberOfLines={2}` with each `ellipsizeMode` (`head` / `middle` / `tail` / `clip`) - ellipsis position is correct; `clip` cuts with no glyph.
- `numberOfLines={0}` (or unset): unchanged, unlimited.
- `flavor="github"`: both props are ignored (no-op), content renders in full.
- Android: confirmed on an API 36 emulator that the measured height matches the rendered clamp, and that a clamped view is non-selectable/non-tappable (required for the ellipsis to render) and reverts when the clamp is removed.

<!-- #### Screenshots -->

| iOS | Android |
| - | - |
| <video src="https://github.com/user-attachments/assets/b0328022-f2b4-4a35-9f03-2e4211ce1f7c" width=300 /> | <video src="https://github.com/user-attachments/assets/32c48804-9236-4f31-9e93-97c0d9de57d5" width=300 /> 

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
