### PR TITLE
feat(ios): bring VoiceOver support to parity with the React Native renderer

### DIFF
--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -293,6 +293,40 @@ Configures the custom items added to the text-selection edit menu:
 - **Copy Image URL** / **Copy N Image URLs** appears when the selection contains images with http(s) URLs.
 - **Select All** is provided when the system omits it for non-editable text views.
 
+### `.markdownAccessibilityLabels`
+
+```swift
+public struct MarkdownAccessibilityLabels: Equatable, Sendable {
+  public var list: List             // top / nested, each: bulletPoint, orderedItem "List item {n}",
+                                    // checkedTask, uncheckedTask
+  public var blockquote: Blockquote // quote, nestedQuote
+  public var table: Table           // row "Row {n}: {content}"
+  public var image: Image           // fallback "Image" (no alt text)
+  public var codeBlock: CodeBlock   // copy "Copy code" (custom action name)
+  public var rotor: Rotor           // headings, links, images
+
+  public static let `default`: MarkdownAccessibilityLabels
+}
+
+extension View {
+  func markdownAccessibilityLabels(_ labels: MarkdownAccessibilityLabels) -> some View
+}
+```
+
+Overrides the strings VoiceOver speaks. Every field defaults to English, so set only what you localize:
+
+```swift
+var labels = MarkdownAccessibilityLabels()
+labels.list.top.bulletPoint = "Punkt"
+labels.list.top.orderedItem = "Listenelement {n}"
+labels.rotor.headings = "Überschriften"
+
+EnrichedMarkdownText(markdown)
+    .markdownAccessibilityLabels(labels)
+```
+
+`{n}` is a 1-based index and `{content}` the comma-joined cell text of a table row; translations must keep the placeholder names. Defaults use the cardinal form ("List item 2") so one template works in every language without plural rules. The math label lives in the LaTeX module: `.markdownLaTeX(accessibilityLabel: "Formel: {latex}")`.
+
 ### `.markdownImageRequestHeaders`
 
 ```swift
@@ -340,10 +374,17 @@ All decodes are downsampled to the screen's pixel width, so large images never d
 
 VoiceOver walks the rendered markdown as individual elements rather than one text blob:
 
-- Headings announce "heading, level N"
-- Links are activatable elements that invoke `.onLinkPress`
+- Headings announce "heading, level N"; a link inside a heading stays its own element and keeps the heading trait
+- Links are activatable elements that invoke `.onLinkPress`; a linked image (`[![alt](img)](url)`) reads its alt text with both the image and link traits
 - Images read their alt text ("Image" when absent)
-- List items announce their position ("bullet point", "list item N", with a "nested" prefix)
+- List items announce their position ("Bullet point", "List item N", "Task, checked", with "Nested" variants)
+- Content inside a blockquote appends "Blockquote" or "Nested blockquote"
+- Tables read one element per row ("Row N: cell, cell"); the header row carries the heading trait
+- Fenced code blocks are one element each, with a "Copy code" custom action (swipe up/down on the element)
+- Math from `EnrichedMarkdownLaTeX` reads "Math: " followed by the raw LaTeX
+- Rotors (two-finger twist) jump between Headings, Links, and Images
+
+Every spoken string can be localized with `.markdownAccessibilityLabels` (see the API reference); the math template is a parameter of `.markdownLaTeX`. Element frames are resolved from the live layout on each query, so they stay correct inside a scrolling container and after Dynamic Type changes.
 
 Dynamic Type is supported throughout via text styles in the default theme.
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElement.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElement.swift
@@ -2,16 +2,19 @@ import UIKit
 
 /// VoiceOver element for one segment of the rendered markdown. The frame is
 /// resolved lazily from TextKit 2 layout on every query, so scrolling and
-/// Dynamic Type changes never leave stale bounds.
-class MarkdownAccessibilityElement: UIAccessibilityElement {
+/// Dynamic Type changes never leave stale bounds. Elements with a `url`
+/// (links, linked images) activate the text view's press handler.
+final class MarkdownAccessibilityElement: UIAccessibilityElement {
     private(set) weak var textView: MarkdownTextView?
     let range: NSRange
+    let url: URL?
     /// For table rows: vertical slice of the attachment frame.
     private let rowSlice: (offset: CGFloat, height: CGFloat)?
 
     init(textView: MarkdownTextView, spec: MarkdownAccessibilityElementSpec) {
         self.textView = textView
         self.range = spec.range
+        self.url = spec.linkURL
         if case .tableRow(let offset, let height, _) = spec.kind {
             self.rowSlice = (offset, height)
         } else {
@@ -20,24 +23,39 @@ class MarkdownAccessibilityElement: UIAccessibilityElement {
         super.init(accessibilityContainer: textView)
 
         accessibilityLabel = spec.label
-        accessibilityValue = spec.listAnnouncement
+        accessibilityValue = spec.value
+        accessibilityTraits = Self.traits(for: spec)
 
-        switch spec.kind {
-        case .text:
-            accessibilityTraits = .staticText
-        case .heading(let level):
-            accessibilityTraits = [.staticText, .header]
+        if let level = spec.headingLevel {
             accessibilityAttributedLabel = NSAttributedString(
                 string: spec.label,
                 attributes: [.accessibilityTextHeadingLevel: level]
             )
-        case .link:
-            accessibilityTraits = .link
-        case .image:
-            accessibilityTraits = .image
-        case .tableRow(_, _, let isHeader):
-            accessibilityTraits = isHeader ? [.staticText, .header] : .staticText
         }
+
+        if case .codeBlock(let copyAction) = spec.kind {
+            let code = spec.label
+            accessibilityCustomActions = [
+                UIAccessibilityCustomAction(name: copyAction) { [weak textView] _ in
+                    guard let textView else { return false }
+                    textView.pasteboard.string = code
+                    return true
+                }
+            ]
+        }
+    }
+
+    private static func traits(for spec: MarkdownAccessibilityElementSpec) -> UIAccessibilityTraits {
+        var traits: UIAccessibilityTraits = switch spec.kind {
+        case .text, .codeBlock: .staticText
+        case .link: .link
+        case .image(let link): link == nil ? .image : [.image, .link]
+        case .tableRow(_, _, let isHeader): isHeader ? [.staticText, .header] : .staticText
+        }
+        if spec.headingLevel != nil {
+            traits.insert(.header)
+        }
+        return traits
     }
 
     override var accessibilityFrame: CGRect {
@@ -53,18 +71,9 @@ class MarkdownAccessibilityElement: UIAccessibilityElement {
         }
         set { super.accessibilityFrame = newValue }
     }
-}
-
-final class MarkdownLinkAccessibilityElement: MarkdownAccessibilityElement {
-    let url: URL
-
-    init(textView: MarkdownTextView, spec: MarkdownAccessibilityElementSpec, url: URL) {
-        self.url = url
-        super.init(textView: textView, spec: spec)
-    }
 
     override func accessibilityActivate() -> Bool {
-        guard let textView, let onLinkPress = textView.onLinkPress else { return false }
+        guard let url, let onLinkPress = textView?.onLinkPress else { return false }
         onLinkPress(url)
         return true
     }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElementBuilder.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityElementBuilder.swift
@@ -1,14 +1,17 @@
 import UIKit
 
 /// A VoiceOver element description derived from the rendered attributed
-/// string. Pure data so the segmentation logic is unit-testable; frames are
-/// resolved lazily by `MarkdownAccessibilityElement` at query time.
+/// string, with every spoken string already resolved. Pure data so the
+/// segmentation logic is unit-testable; frames are resolved lazily by
+/// `MarkdownAccessibilityElement` at query time.
 struct MarkdownAccessibilityElementSpec: Equatable {
     enum Kind: Equatable {
         case text
-        case heading(level: Int)
         case link(URL)
-        case image
+        /// `link` is the wrapping link's target for `[![alt](img)](url)`.
+        case image(link: URL?)
+        /// One fenced block; the label is the code itself.
+        case codeBlock(copyAction: String)
         case tableRow(offset: CGFloat, height: CGFloat, isHeader: Bool)
     }
 
@@ -16,14 +19,39 @@ struct MarkdownAccessibilityElementSpec: Equatable {
     let label: String
     /// Trimmed character range used for frame calculation.
     let range: NSRange
-    /// Spoken list context ("bullet point", "list item 2", "nested …").
-    let listAnnouncement: String?
+    /// Set for text and link segments inside a heading.
+    let headingLevel: Int?
+    /// Spoken after the label: list position and/or blockquote context.
+    let value: String?
+
+    /// Target URL for elements that activate a link press.
+    var linkURL: URL? {
+        switch kind {
+        case .link(let url):
+            return url
+        case .image(let link):
+            return link
+        case .text, .codeBlock, .tableRow:
+            return nil
+        }
+    }
 }
 
-/// Segments the rendered attributed string into VoiceOver elements: split
-/// into paragraphs, drop spacer-only paragraphs, and carve heading/link/
-/// image runs into their own elements with plain text between them.
-enum MarkdownAccessibilityElementBuilder {
+/// Segments the rendered attributed string into VoiceOver elements: one
+/// element per fenced code block, otherwise split into paragraphs, drop
+/// spacer-only paragraphs, and carve link/image/attachment runs into their
+/// own elements with plain text between them. Headings, lists, and
+/// blockquotes are context read per segment, not runs of their own, so a
+/// link inside a heading stays navigable and keeps the heading trait.
+struct MarkdownAccessibilityElementBuilder {
+    static func specs(
+        for text: NSAttributedString,
+        labels: MarkdownAccessibilityLabels = .default
+    ) -> [MarkdownAccessibilityElementSpec] {
+        var builder = MarkdownAccessibilityElementBuilder(text: text, labels: labels)
+        return builder.build()
+    }
+
     /// Zero-width space (list marker anchors) and line separator join plain
     /// whitespace as "invisible" for trimming; U+FFFC attachment characters
     /// count as content.
@@ -33,45 +61,89 @@ enum MarkdownAccessibilityElementBuilder {
         return set
     }()
 
-    static func specs(for text: NSAttributedString) -> [MarkdownAccessibilityElementSpec] {
-        let string = text.string as NSString
-        guard string.length > 0 else { return [] }
+    private static let attachmentCharacter: String = "\u{FFFC}"
 
-        var specs: [MarkdownAccessibilityElementSpec] = []
-        var paragraphStart = 0
-        while paragraphStart < string.length {
-            let searchRange = NSRange(location: paragraphStart, length: string.length - paragraphStart)
+    private let text: NSAttributedString
+    private let string: NSString
+    private let labels: MarkdownAccessibilityLabels
+    private var specs: [MarkdownAccessibilityElementSpec] = []
+
+    private init(text: NSAttributedString, labels: MarkdownAccessibilityLabels) {
+        self.text = text
+        self.string = text.string as NSString
+        self.labels = labels
+    }
+
+    private mutating func build() -> [MarkdownAccessibilityElementSpec] {
+        var cursor = 0
+        while cursor < string.length {
+            if let block = codeBlockRange(at: cursor) {
+                appendCodeBlockSpec(for: block)
+                cursor = block.location + block.length
+                continue
+            }
+
+            let searchRange = NSRange(location: cursor, length: string.length - cursor)
             let newline = string.range(of: "\n", options: [], range: searchRange)
             let paragraphEnd = newline.location == NSNotFound ? string.length : newline.location + 1
-            appendSpecs(
-                for: NSRange(location: paragraphStart, length: paragraphEnd - paragraphStart),
-                in: text,
-                to: &specs
-            )
-            paragraphStart = paragraphEnd
+            appendParagraphSpecs(for: NSRange(location: cursor, length: paragraphEnd - cursor))
+            cursor = paragraphEnd
         }
         return specs
     }
 
-    // MARK: - Paragraph segmentation
+    // MARK: - Code blocks
 
-    private struct SemanticRun {
-        let range: NSRange
-        let kind: MarkdownAccessibilityElementSpec.Kind
-        let imageLabel: String?
-        var table: TableAttachment?
+    /// The full range of the fenced code block that starts at `position`,
+    /// spacer lines included.
+    private func codeBlockRange(at position: Int) -> NSRange? {
+        guard MarkdownAttributeValue.boolValue(from: attribute(MarkdownAttribute.codeBlock, at: position)) else {
+            return nil
+        }
+        var range = NSRange()
+        _ = text.attribute(
+            MarkdownAttribute.codeBlock,
+            at: position,
+            longestEffectiveRange: &range,
+            in: NSRange(location: position, length: string.length - position)
+        )
+        return range
     }
 
-    private static func appendSpecs(
-        for paragraphRange: NSRange,
-        in text: NSAttributedString,
-        to specs: inout [MarkdownAccessibilityElementSpec]
-    ) {
-        guard trimmedRange(of: paragraphRange, in: text) != nil else { return }
+    private mutating func appendCodeBlockSpec(for range: NSRange) {
+        guard let (visible, code) = visibleText(in: range) else { return }
+        specs.append(MarkdownAccessibilityElementSpec(
+            kind: .codeBlock(copyAction: labels.codeBlock.copy),
+            label: code,
+            range: visible,
+            headingLevel: nil,
+            value: nil
+        ))
+    }
 
-        let runs = semanticRuns(in: paragraphRange, of: text)
+    // MARK: - Paragraph segmentation
+
+    private enum SemanticRun {
+        case image(NSRange, label: String, link: URL?)
+        /// A plugin attachment that carries its own spoken label.
+        case attachment(NSRange, label: String)
+        case table(NSRange, TableAttachment)
+        case link(NSRange, URL)
+
+        var range: NSRange {
+            switch self {
+            case .image(let range, _, _), .attachment(let range, _), .table(let range, _), .link(let range, _):
+                return range
+            }
+        }
+    }
+
+    private mutating func appendParagraphSpecs(for paragraphRange: NSRange) {
+        guard trimmedRange(of: paragraphRange) != nil else { return }
+
+        let runs = semanticRuns(in: paragraphRange)
         guard !runs.isEmpty else {
-            appendTextSpec(for: paragraphRange, in: text, to: &specs)
+            appendTextSpec(for: paragraphRange)
             return
         }
 
@@ -82,13 +154,11 @@ enum MarkdownAccessibilityElementBuilder {
             if run.range.location > segmentStart {
                 appendTextSpec(
                     for: NSRange(location: segmentStart, length: run.range.location - segmentStart),
-                    in: text,
-                    to: &specs,
                     requireLetterOrDigit: true
                 )
             }
 
-            appendRunSpec(run, in: text, to: &specs)
+            appendRunSpec(run)
             segmentStart = run.range.location + run.range.length
         }
 
@@ -96,177 +166,206 @@ enum MarkdownAccessibilityElementBuilder {
         if segmentStart < paragraphEnd {
             appendTextSpec(
                 for: NSRange(location: segmentStart, length: paragraphEnd - segmentStart),
-                in: text,
-                to: &specs,
                 requireLetterOrDigit: true
             )
         }
     }
 
-    private static func semanticRuns(in range: NSRange, of text: NSAttributedString) -> [SemanticRun] {
-        var runs: [SemanticRun] = []
-
-        text.enumerateAttribute(MarkdownAttribute.headingLevel, in: range) { value, runRange, _ in
-            guard let level = value as? Int else { return }
-            runs.append(SemanticRun(range: runRange, kind: .heading(level: level), imageLabel: nil))
-        }
-        text.enumerateAttribute(.link, in: range) { value, runRange, _ in
-            let url = value as? URL ?? (value as? String).flatMap(URL.init(string:))
-            guard let url else { return }
-            runs.append(SemanticRun(range: runRange, kind: .link(url), imageLabel: nil))
-        }
+    /// Attachments that stand on their own (images, tables, labelled plugin
+    /// attachments) plus link runs carved around them, in document order.
+    private func semanticRuns(in range: NSRange) -> [SemanticRun] {
+        var attachments: [SemanticRun] = []
         text.enumerateAttribute(.attachment, in: range) { value, runRange, _ in
-            if let attachment = value as? MarkdownImageAttachment {
-                let label = attachment.accessibilityLabel.flatMap { $0.isEmpty ? nil : $0 } ?? "Image"
-                runs.append(SemanticRun(range: runRange, kind: .image, imageLabel: label))
-            } else if let table = value as? TableAttachment {
-                runs.append(SemanticRun(range: runRange, kind: .text, imageLabel: nil, table: table))
+            guard let attachment = value as? NSTextAttachment else { return }
+            if let image = attachment as? MarkdownImageAttachment {
+                attachments.append(.image(
+                    runRange,
+                    label: image.accessibilityLabel ?? labels.image.fallback,
+                    link: url(from: attribute(.link, at: runRange.location))
+                ))
+            } else if let table = attachment as? TableAttachment {
+                attachments.append(.table(runRange, table))
+            } else if let label = attachment.accessibilityLabel, !label.isEmpty {
+                attachments.append(.attachment(runRange, label: label))
             }
         }
 
-        return runs.sorted { $0.range.location < $1.range.location }
-    }
-
-    private static func appendRunSpec(
-        _ run: SemanticRun,
-        in text: NSAttributedString,
-        to specs: inout [MarkdownAccessibilityElementSpec]
-    ) {
-        if let table = run.table {
-            appendTableRowSpecs(for: table, range: run.range, to: &specs)
-            return
+        let holes = attachments.map(\.range)
+        var links: [SemanticRun] = []
+        text.enumerateAttribute(.link, in: range) { value, runRange, _ in
+            guard let url = url(from: value) else { return }
+            for piece in Self.subtracting(holes, from: runRange) {
+                links.append(.link(piece, url))
+            }
         }
 
-        let label: String
-        let announcement: String?
+        return (attachments + links).sorted { $0.range.location < $1.range.location }
+    }
 
-        switch run.kind {
-        case .image:
-            label = run.imageLabel ?? "Image"
-            announcement = nil
-        case .heading:
-            guard let visible = trimmedRange(of: run.range, in: text) else { return }
-            label = (text.string as NSString).substring(with: visible)
-            announcement = nil
-        case .link:
-            guard let visible = trimmedRange(of: run.range, in: text) else { return }
-            label = (text.string as NSString).substring(with: visible)
+    private func url(from value: Any?) -> URL? {
+        value as? URL ?? (value as? String).flatMap(URL.init(string:))
+    }
+
+    /// The parts of `range` not covered by `holes` (in document order).
+    private static func subtracting(_ holes: [NSRange], from range: NSRange) -> [NSRange] {
+        var pieces: [NSRange] = []
+        var start = range.location
+        let end = range.location + range.length
+        for hole in holes where TextLayoutHelpers.rangesIntersect(hole, range) {
+            if hole.location > start {
+                pieces.append(NSRange(location: start, length: hole.location - start))
+            }
+            start = max(start, hole.location + hole.length)
+        }
+        if start < end {
+            pieces.append(NSRange(location: start, length: end - start))
+        }
+        return pieces
+    }
+
+    private mutating func appendRunSpec(_ run: SemanticRun) {
+        switch run {
+        case .table(let range, let table):
+            appendTableRowSpecs(for: table, range: range)
+        case .image(let range, let label, let link):
+            specs.append(MarkdownAccessibilityElementSpec(
+                kind: .image(link: link),
+                label: label,
+                range: range,
+                headingLevel: nil,
+                value: nil
+            ))
+        case .attachment(let range, let label):
+            specs.append(contextSpec(kind: .text, label: label, range: range, requireListStart: false))
+        case .link(let range, let url):
             // Links announce their list context even mid-item.
-            announcement = listAnnouncement(in: text, at: run.range.location, requireStart: false)
-        case .text, .tableRow:
-            return
+            guard let (visible, label) = visibleText(in: range) else { return }
+            specs.append(contextSpec(kind: .link(url), label: label, range: visible, requireListStart: false))
         }
-
-        specs.append(MarkdownAccessibilityElementSpec(
-            kind: run.kind,
-            label: label,
-            range: trimmedRange(of: run.range, in: text) ?? run.range,
-            listAnnouncement: announcement
-        ))
     }
 
-    /// One element per table row, RN-style: "Row {n}: {cells}", the header
-    /// row carrying the header trait. Frames are the attachment's frame
-    /// sliced by the precomputed row offsets.
-    private static func appendTableRowSpecs(
-        for table: TableAttachment,
-        range: NSRange,
-        to specs: inout [MarkdownAccessibilityElementSpec]
-    ) {
+    /// One element per table row: "Row {n}: {cells}", the header row
+    /// carrying the header trait. Frames are the attachment's frame sliced
+    /// by the precomputed row offsets.
+    private mutating func appendTableRowSpecs(for table: TableAttachment, range: NSRange) {
         var offset: CGFloat = 0
         for (index, row) in table.model.rows.enumerated() {
             let height = table.layout.rowHeights[index]
             let content = row.map(\.plainText).joined(separator: ", ")
+            let label = labels.table.row
+                .replacingOccurrences(of: "{n}", with: String(index + 1))
+                .replacingOccurrences(of: "{content}", with: content)
             specs.append(MarkdownAccessibilityElementSpec(
                 kind: .tableRow(offset: offset, height: height, isHeader: row.first?.isHeader ?? false),
-                label: "Row \(index + 1): \(content)",
+                label: label,
                 range: range,
-                listAnnouncement: nil
+                headingLevel: nil,
+                value: nil
             ))
             offset += height
         }
     }
 
-    private static func appendTextSpec(
-        for range: NSRange,
-        in text: NSAttributedString,
-        to specs: inout [MarkdownAccessibilityElementSpec],
-        requireLetterOrDigit: Bool = false
-    ) {
-        guard let visible = trimmedRange(of: range, in: text) else { return }
-        let label = (text.string as NSString).substring(with: visible)
-
+    private mutating func appendTextSpec(for range: NSRange, requireLetterOrDigit: Bool = false) {
+        guard let (visible, label) = visibleText(in: range) else { return }
         if requireLetterOrDigit, label.rangeOfCharacter(from: .alphanumerics) == nil {
             return
         }
-
-        specs.append(MarkdownAccessibilityElementSpec(
-            kind: .text,
-            label: label,
-            range: visible,
-            listAnnouncement: listAnnouncement(in: text, at: visible.location, requireStart: true)
-        ))
+        specs.append(contextSpec(kind: .text, label: label, range: visible, requireListStart: true))
     }
 
-    // MARK: - List context
+    /// A spec with the heading, list, and blockquote context at the start
+    /// of `range`. `requireListStart` limits the list announcement to the
+    /// item's first segment.
+    private func contextSpec(
+        kind: MarkdownAccessibilityElementSpec.Kind,
+        label: String,
+        range: NSRange,
+        requireListStart: Bool
+    ) -> MarkdownAccessibilityElementSpec {
+        let position = range.location
+        let parts = [
+            listAnnouncement(at: position, requireStart: requireListStart),
+            blockquoteAnnouncement(at: position)
+        ].compactMap { $0 }
+        return MarkdownAccessibilityElementSpec(
+            kind: kind,
+            label: label,
+            range: range,
+            headingLevel: MarkdownAttributeValue.intValue(from: attribute(MarkdownAttribute.headingLevel, at: position)),
+            value: parts.isEmpty ? nil : parts.joined(separator: ", ")
+        )
+    }
 
-    private static func listAnnouncement(
-        in text: NSAttributedString,
-        at position: Int,
-        requireStart: Bool
-    ) -> String? {
+    /// The trimmed range and its spoken text, with attachment placeholders
+    /// removed (an attachment without its own element would otherwise be
+    /// read as "object replacement character"); nil when nothing speakable
+    /// remains.
+    private func visibleText(in range: NSRange) -> (range: NSRange, label: String)? {
+        guard let visible = trimmedRange(of: range) else { return nil }
+        var label = string.substring(with: visible)
+        if string.range(of: Self.attachmentCharacter, options: [], range: visible).location != NSNotFound {
+            label = label
+                .replacingOccurrences(of: Self.attachmentCharacter, with: "")
+                .trimmingCharacters(in: Self.skippable)
+        }
+        return label.isEmpty ? nil : (visible, label)
+    }
+
+    // MARK: - Context
+
+    private func attribute(_ key: NSAttributedString.Key, at position: Int) -> Any? {
         guard position < text.length else { return nil }
+        return text.attribute(key, at: position, effectiveRange: nil)
+    }
 
-        var numberRun = NSRange()
-        let fullRange = NSRange(location: 0, length: text.length)
-        guard let number = MarkdownAttributeValue.intValue(from: text.attribute(
-            MarkdownAttribute.listItemNumber,
-            at: position,
-            longestEffectiveRange: &numberRun,
-            in: fullRange
-        )) else {
+    private func blockquoteAnnouncement(at position: Int) -> String? {
+        guard let depth = MarkdownAttributeValue.intValue(
+            from: attribute(MarkdownAttribute.blockquoteDepth, at: position)
+        ) else { return nil }
+        return depth >= 1 ? labels.blockquote.nestedQuote : labels.blockquote.quote
+    }
+
+    private func listAnnouncement(at position: Int, requireStart: Bool) -> String? {
+        guard let number = MarkdownAttributeValue.intValue(
+            from: attribute(MarkdownAttribute.listItemNumber, at: position)
+        ) else { return nil }
+        let depth = MarkdownAttributeValue.intValue(from: attribute(MarkdownAttribute.listDepth, at: position)) ?? 0
+        if requireStart, !isListItemStart(position) {
             return nil
         }
-        var depthRun = numberRun
-        let depth = MarkdownAttributeValue.intValue(from: text.attribute(
-            MarkdownAttribute.listDepth,
-            at: position,
-            longestEffectiveRange: &depthRun,
-            in: fullRange
-        )) ?? 0
-        let type = MarkdownAttributeValue.intValue(
-            from: text.attribute(MarkdownAttribute.listType, at: position, effectiveRange: nil)
-        )
 
-        if requireStart {
-            // Only the first segment of a list item announces its position:
-            // the item's first visible character must be at, or just before,
-            // this position. The item's
-            // extent is where BOTH number and depth are constant — number
-            // alone merges across nesting levels (outer item 1 / inner item
-            // 1 are adjacent equal values), depth alone merges siblings.
-            let itemRange = NSIntersectionRange(numberRun, depthRun)
-            let firstVisible = trimmedRange(of: itemRange, in: text)?.location ?? itemRange.location
-            if position > firstVisible + 1 {
-                return nil
-            }
+        let level = depth > 0 ? labels.list.nested : labels.list.top
+        if let taskValue = attribute(MarkdownAttribute.taskListItem, at: position) {
+            return MarkdownAttributeValue.boolValue(from: taskValue) ? level.checkedTask : level.uncheckedTask
         }
-
-        let prefix = depth > 0 ? "nested " : ""
-        if let taskValue = text.attribute(MarkdownAttribute.taskListItem, at: position, effectiveRange: nil) {
-            let state = MarkdownAttributeValue.boolValue(from: taskValue) ? "checked" : "not checked"
-            return "\(prefix)task, \(state)"
-        }
+        let type = MarkdownAttributeValue.intValue(from: attribute(MarkdownAttribute.listType, at: position))
         if type == ListType.ordered.rawValue {
-            return "\(prefix)list item \(number)"
+            return level.orderedItem.replacingOccurrences(of: "{n}", with: String(number))
         }
-        return "\(prefix)bullet point"
+        return level.bulletPoint
+    }
+
+    /// Whether `position` is at (or just after) the first visible character
+    /// of its list item. The item's extent is where BOTH number and depth
+    /// are constant — number alone merges across nesting levels (outer item
+    /// 1 / inner item 1 are adjacent equal values), depth alone merges
+    /// siblings.
+    private func isListItemStart(_ position: Int) -> Bool {
+        let fullRange = NSRange(location: 0, length: text.length)
+        var numberRun = NSRange()
+        _ = text.attribute(MarkdownAttribute.listItemNumber, at: position, longestEffectiveRange: &numberRun, in: fullRange)
+        var depthRun = numberRun
+        _ = text.attribute(MarkdownAttribute.listDepth, at: position, longestEffectiveRange: &depthRun, in: fullRange)
+
+        let itemRange = NSIntersectionRange(numberRun, depthRun)
+        let firstVisible = trimmedRange(of: itemRange)?.location ?? itemRange.location
+        return position <= firstVisible + 1
     }
 
     // MARK: - Trimming
 
-    private static func trimmedRange(of range: NSRange, in text: NSAttributedString) -> NSRange? {
-        let string = text.string as NSString
+    private func trimmedRange(of range: NSRange) -> NSRange? {
         var start = range.location
         var end = range.location + range.length
 
@@ -281,8 +380,8 @@ enum MarkdownAccessibilityElementBuilder {
         return NSRange(location: start, length: end - start)
     }
 
-    private static func isSkippable(_ character: unichar) -> Bool {
+    private func isSkippable(_ character: unichar) -> Bool {
         guard let scalar = Unicode.Scalar(character) else { return false }
-        return skippable.contains(scalar)
+        return Self.skippable.contains(scalar)
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityLabels.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityLabels.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Strings VoiceOver speaks while navigating rendered markdown. Every
+/// field defaults to English; override the ones your app localizes.
+///
+/// Templates use `{n}` for a 1-based index (list item number, table row),
+/// `{content}` for a table row's comma-joined cell text. Translations must
+/// keep the placeholder names. Defaults use the cardinal form ("List item
+/// 2") so a single template works without per-language plural rules.
+public struct MarkdownAccessibilityLabels: Equatable, Sendable {
+    /// Spoken after a list item's text (VoiceOver value) at one nesting
+    /// level.
+    public struct ListLevel: Equatable, Sendable {
+        public var bulletPoint: String
+        /// `{n}` → 1-based item number.
+        public var orderedItem: String
+        public var checkedTask: String
+        public var uncheckedTask: String
+
+        public init(bulletPoint: String, orderedItem: String, checkedTask: String, uncheckedTask: String) {
+            self.bulletPoint = bulletPoint
+            self.orderedItem = orderedItem
+            self.checkedTask = checkedTask
+            self.uncheckedTask = uncheckedTask
+        }
+    }
+
+    /// One set of list labels for top-level items and one for items inside
+    /// another list.
+    public struct List: Equatable, Sendable {
+        public var top: ListLevel
+        public var nested: ListLevel
+
+        public init(
+            top: ListLevel = ListLevel(
+                bulletPoint: "Bullet point",
+                orderedItem: "List item {n}",
+                checkedTask: "Task, checked",
+                uncheckedTask: "Task, not checked"
+            ),
+            nested: ListLevel = ListLevel(
+                bulletPoint: "Nested bullet point",
+                orderedItem: "Nested list item {n}",
+                checkedTask: "Nested task, checked",
+                uncheckedTask: "Nested task, not checked"
+            )
+        ) {
+            self.top = top
+            self.nested = nested
+        }
+    }
+
+    /// Spoken after content inside a blockquote.
+    public struct Blockquote: Equatable, Sendable {
+        public var quote: String
+        public var nestedQuote: String
+
+        public init(quote: String = "Blockquote", nestedQuote: String = "Nested blockquote") {
+            self.quote = quote
+            self.nestedQuote = nestedQuote
+        }
+    }
+
+    public struct Table: Equatable, Sendable {
+        /// `{n}` → 1-based row index, `{content}` → comma-joined cell text.
+        public var row: String
+
+        public init(row: String = "Row {n}: {content}") {
+            self.row = row
+        }
+    }
+
+    public struct Image: Equatable, Sendable {
+        /// Spoken for an image whose markdown has no alt text.
+        public var fallback: String
+
+        public init(fallback: String = "Image") {
+            self.fallback = fallback
+        }
+    }
+
+    public struct CodeBlock: Equatable, Sendable {
+        /// Name of the VoiceOver custom action that copies the block.
+        public var copy: String
+
+        public init(copy: String = "Copy code") {
+            self.copy = copy
+        }
+    }
+
+    /// Names of the VoiceOver rotors (the jump-by-type navigator).
+    public struct Rotor: Equatable, Sendable {
+        public var headings: String
+        public var links: String
+        public var images: String
+
+        public init(headings: String = "Headings", links: String = "Links", images: String = "Images") {
+            self.headings = headings
+            self.links = links
+            self.images = images
+        }
+    }
+
+    public var list: List
+    public var blockquote: Blockquote
+    public var table: Table
+    public var image: Image
+    public var codeBlock: CodeBlock
+    public var rotor: Rotor
+
+    public init(
+        list: List = List(),
+        blockquote: Blockquote = Blockquote(),
+        table: Table = Table(),
+        image: Image = Image(),
+        codeBlock: CodeBlock = CodeBlock(),
+        rotor: Rotor = Rotor()
+    ) {
+        self.list = list
+        self.blockquote = blockquote
+        self.table = table
+        self.image = image
+        self.codeBlock = codeBlock
+        self.rotor = rotor
+    }
+
+    public static let `default` = MarkdownAccessibilityLabels()
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityRotors.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Accessibility/MarkdownAccessibilityRotors.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+/// VoiceOver rotors that jump between headings, links, and images of one
+/// rendered document. A rotor is only offered when it has somewhere to go.
+enum MarkdownAccessibilityRotors {
+    static func rotors(
+        for elements: [UIAccessibilityElement],
+        labels: MarkdownAccessibilityLabels
+    ) -> [UIAccessibilityCustomRotor] {
+        let groups: [(name: String, trait: UIAccessibilityTraits)] = [
+            (labels.rotor.headings, .header),
+            (labels.rotor.links, .link),
+            (labels.rotor.images, .image)
+        ]
+        return groups.compactMap { group in
+            let members = elements.filter { $0.accessibilityTraits.contains(group.trait) }
+            guard !members.isEmpty else { return nil }
+            return rotor(named: group.name, over: members)
+        }
+    }
+
+    private static func rotor(named name: String, over elements: [UIAccessibilityElement]) -> UIAccessibilityCustomRotor {
+        UIAccessibilityCustomRotor(name: name) { predicate in
+            let current = (predicate.currentItem.targetElement as? UIAccessibilityElement)
+                .flatMap { element in elements.firstIndex { $0 === element } }
+            let next: Int
+            switch predicate.searchDirection {
+            case .next:
+                next = current.map { $0 + 1 } ?? 0
+            case .previous:
+                next = current.map { $0 - 1 } ?? elements.count - 1
+            @unknown default:
+                return nil
+            }
+            guard elements.indices.contains(next) else { return nil }
+            return UIAccessibilityCustomRotorItemResult(targetElement: elements[next], targetRange: nil)
+        }
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -17,6 +17,7 @@ public struct EnrichedMarkdownText: View {
     @Environment(\.markdownRenderPlugins) private var renderPlugins
     @Environment(\.markdownTaskListItemPressHandler) private var onTaskListItemPress
     @Environment(\.markdownTaskListItemToggleEnabled) private var isTaskListToggleEnabled
+    @Environment(\.markdownAccessibilityLabels) private var accessibilityLabels
     @StateObject private var renderStore = MarkdownRenderStore()
 
     public init(_ markdown: String, flags: Md4cFlags = .commonMark) {
@@ -52,7 +53,8 @@ public struct EnrichedMarkdownText: View {
                 onTaskListItemPress?(
                     TaskListItemPressEvent(index: hit.index, checked: checked, text: hit.itemText)
                 )
-            } : nil
+            } : nil,
+            accessibilityLabels: accessibilityLabels
         )
         .fixedSize(horizontal: false, vertical: true)
         .onAppear {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/Environment+AccessibilityLabels.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/Environment+AccessibilityLabels.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+private struct MarkdownAccessibilityLabelsKey: EnvironmentKey {
+    static let defaultValue: MarkdownAccessibilityLabels = .default
+}
+
+public extension EnvironmentValues {
+    var markdownAccessibilityLabels: MarkdownAccessibilityLabels {
+        get { self[MarkdownAccessibilityLabelsKey.self] }
+        set { self[MarkdownAccessibilityLabelsKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Overrides the strings VoiceOver speaks for list items, blockquotes,
+    /// table rows, images without alt text, the code block copy action, and
+    /// rotor names. Defaults are English.
+    func markdownAccessibilityLabels(_ labels: MarkdownAccessibilityLabels) -> some View {
+        environment(\.markdownAccessibilityLabels, labels)
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -11,6 +11,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
     let isSelectionEnabled: Bool
     let selectionColor: Color?
     let onTaskListItemTap: ((TaskListInteraction.Hit) -> Void)?
+    let accessibilityLabels: MarkdownAccessibilityLabels
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -33,6 +34,7 @@ struct MarkdownTextViewRepresentable: UIViewRepresentable {
         textView.isSelectionEnabled = isSelectionEnabled
         textView.tintColor = selectionColor.map { UIColor($0) }
         textView.onTaskListItemTap = onTaskListItemTap
+        textView.accessibilityLabels = accessibilityLabels
         textView.setMarkdownAttributedText(attributedText)
     }
 
@@ -239,18 +241,38 @@ final class MarkdownTextView: UITextView {
 
     private let tapGestureDelegate = SimultaneousGestureDelegate()
 
-    /// VoiceOver elements built from the attributed string; frames resolve
-    /// lazily against TextKit 2 layout.
-    private var markdownAccessibilityElements: [UIAccessibilityElement] = []
+    /// VoiceOver elements and rotors, built on the first query after the
+    /// text or labels change so streaming re-renders never pay for them.
+    private var markdownAccessibilityElements: [MarkdownAccessibilityElement] = []
+    private var markdownAccessibilityRotors: [UIAccessibilityCustomRotor] = []
+    private var accessibilityTreeIsStale: Bool = true
+
+    var accessibilityLabels: MarkdownAccessibilityLabels = .default {
+        didSet {
+            guard accessibilityLabels != oldValue else { return }
+            accessibilityTreeIsStale = true
+        }
+    }
 
     override var accessibilityElements: [Any]? {
-        get { markdownAccessibilityElements.isEmpty ? super.accessibilityElements : markdownAccessibilityElements }
+        get {
+            let elements = accessibilityTree().elements
+            return elements.isEmpty ? super.accessibilityElements : elements
+        }
         set { super.accessibilityElements = newValue }
     }
 
     override var isAccessibilityElement: Bool {
-        get { markdownAccessibilityElements.isEmpty ? super.isAccessibilityElement : false }
+        get { accessibilityTree().elements.isEmpty ? super.isAccessibilityElement : false }
         set { super.isAccessibilityElement = newValue }
+    }
+
+    override var accessibilityCustomRotors: [UIAccessibilityCustomRotor]? {
+        get {
+            let rotors = accessibilityTree().rotors
+            return rotors.isEmpty ? super.accessibilityCustomRotors : rotors
+        }
+        set { super.accessibilityCustomRotors = newValue }
     }
 
     /// Gates the selection UI while keeping `isSelectable` on, so link taps
@@ -385,17 +407,23 @@ final class MarkdownTextView: UITextView {
         self.attributedText = attributedText
         invalidateIntrinsicContentSize()
         setDecorationNeedsDisplay()
-        rebuildAccessibilityElements()
+        accessibilityTreeIsStale = true
     }
 
-    private func rebuildAccessibilityElements() {
-        let specs = MarkdownAccessibilityElementBuilder.specs(for: attributedText ?? NSAttributedString())
-        markdownAccessibilityElements = specs.map { spec in
-            if case .link(let url) = spec.kind {
-                return MarkdownLinkAccessibilityElement(textView: self, spec: spec, url: url)
-            }
-            return MarkdownAccessibilityElement(textView: self, spec: spec)
+    private func accessibilityTree() -> (elements: [MarkdownAccessibilityElement], rotors: [UIAccessibilityCustomRotor]) {
+        if accessibilityTreeIsStale {
+            accessibilityTreeIsStale = false
+            let specs = MarkdownAccessibilityElementBuilder.specs(
+                for: attributedText ?? NSAttributedString(),
+                labels: accessibilityLabels
+            )
+            markdownAccessibilityElements = specs.map { MarkdownAccessibilityElement(textView: self, spec: $0) }
+            markdownAccessibilityRotors = MarkdownAccessibilityRotors.rotors(
+                for: markdownAccessibilityElements,
+                labels: accessibilityLabels
+            )
         }
+        return (markdownAccessibilityElements, markdownAccessibilityRotors)
     }
 
     /// Screen-coordinate frame for a character range, unioned over its

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/LaTeXRenderPlugin.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/LaTeXRenderPlugin.swift
@@ -5,21 +5,36 @@ import UIKit
 /// Enables `$…$`/`$$…$$` parsing and claims the math node types with
 /// RaTeX-backed rendering.
 package struct LaTeXRenderPlugin: MarkdownRenderPlugin {
-    private let typeset: MathRenderer.Typeset
+    /// VoiceOver label for a formula; `{latex}` is replaced by its source.
+    /// The public entry points repeat the literal: a package-level constant
+    /// cannot be used as a public default argument.
+    package static let defaultAccessibilityLabel: String = "Math: {latex}"
 
-    package init() {
-        self.init(typeset: MathRenderer.raTeXTypeset)
+    private let typeset: MathRenderer.Typeset
+    private let accessibilityLabel: String
+
+    package init(accessibilityLabel: String = LaTeXRenderPlugin.defaultAccessibilityLabel) {
+        self.init(typeset: MathRenderer.raTeXTypeset, accessibilityLabel: accessibilityLabel)
     }
 
     /// Tests inject a deterministic typesetter.
-    init(typeset: @escaping MathRenderer.Typeset) {
+    init(
+        typeset: @escaping MathRenderer.Typeset,
+        accessibilityLabel: String = LaTeXRenderPlugin.defaultAccessibilityLabel
+    ) {
         self.typeset = typeset
+        self.accessibilityLabel = accessibilityLabel
     }
 
     package func renderer(for type: NodeType, config: MarkdownStyleConfig) -> NodeRenderer? {
         switch type {
         case .latexMathInline, .latexMathDisplay:
-            return MathRenderer(typeset: typeset, blockStyle: config.mathBlock, inlineStyle: config.inlineMath)
+            return MathRenderer(
+                typeset: typeset,
+                blockStyle: config.mathBlock,
+                inlineStyle: config.inlineMath,
+                accessibilityLabel: accessibilityLabel
+            )
         default:
             return nil
         }
@@ -44,10 +59,14 @@ public extension View {
     /// Parses and renders LaTeX math (`$…$` inline, `$$…$$` display) with
     /// the bundled RaTeX engine, styled by `MarkdownTheme.latexDefault`
     /// underneath the themes applied around this view.
-    func markdownLaTeX() -> some View {
+    ///
+    /// `accessibilityLabel` is what VoiceOver speaks for a formula, with
+    /// `{latex}` replaced by the source (the raw LaTeX is read verbatim; no
+    /// speech conversion is attempted). The innermost modifier wins.
+    func markdownLaTeX(accessibilityLabel: String = "Math: {latex}") -> some View {
         transformEnvironment(\.markdownRenderPlugins) { plugins in
-            guard !plugins.contains(where: { $0 is LaTeXRenderPlugin }) else { return }
-            plugins.append(LaTeXRenderPlugin())
+            plugins.removeAll { $0 is LaTeXRenderPlugin }
+            plugins.append(LaTeXRenderPlugin(accessibilityLabel: accessibilityLabel))
         }
     }
 }
@@ -58,14 +77,15 @@ public extension MarkdownRenderer {
         _ markdown: String,
         config: MarkdownStyleConfig,
         flags: Md4cFlags = .commonMark,
-        imageRequestHeaders: [String: String] = [:]
+        imageRequestHeaders: [String: String] = [:],
+        accessibilityLabel: String = "Math: {latex}"
     ) -> NSAttributedString {
         render(
             markdown,
             config: config,
             flags: flags,
             imageRequestHeaders: imageRequestHeaders,
-            plugins: [LaTeXRenderPlugin()]
+            plugins: [LaTeXRenderPlugin(accessibilityLabel: accessibilityLabel)]
         )
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathAttachment.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathAttachment.swift
@@ -81,7 +81,15 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         isDisplay ? "$$" : "$"
     }
 
-    init(latex: String, isDisplay: Bool, result: MathTypesetResult, panel: MathPanelStyle? = nil) {
+    /// `accessibilityLabel` is fully resolved here because the base
+    /// package's element builder reads it generically.
+    init(
+        latex: String,
+        isDisplay: Bool,
+        result: MathTypesetResult,
+        panel: MathPanelStyle? = nil,
+        accessibilityLabel: String
+    ) {
         self.latex = latex
         self.isDisplay = isDisplay
         self.result = result
@@ -93,7 +101,7 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         } else {
             super.init(data: nil, ofType: nil)
         }
-        accessibilityLabel = latex
+        self.accessibilityLabel = accessibilityLabel
     }
 
     @available(*, unavailable)

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathRenderer.swift
@@ -17,8 +17,15 @@ final class MathRenderer: NodeRenderer {
     private let blockStyle: MathBlockStyle
     private let inlineStyle: InlineMathStyle
     private let panel: MathPanelStyle
+    /// `{latex}` template for the attachment's VoiceOver label.
+    private let accessibilityLabel: String
 
-    init(typeset: @escaping Typeset, blockStyle: MathBlockStyle, inlineStyle: InlineMathStyle) {
+    init(
+        typeset: @escaping Typeset,
+        blockStyle: MathBlockStyle,
+        inlineStyle: InlineMathStyle,
+        accessibilityLabel: String
+    ) {
         self.typeset = typeset
         self.blockStyle = blockStyle
         self.inlineStyle = inlineStyle
@@ -27,6 +34,7 @@ final class MathRenderer: NodeRenderer {
             padding: blockStyle.padding ?? 0,
             textAlignment: blockStyle.textAlignment ?? .natural
         )
+        self.accessibilityLabel = accessibilityLabel
     }
 
     func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
@@ -53,7 +61,8 @@ final class MathRenderer: NodeRenderer {
             latex: latex,
             isDisplay: isDisplay,
             result: result,
-            panel: isBlock ? panel : nil
+            panel: isBlock ? panel : nil,
+            accessibilityLabel: accessibilityLabel.replacingOccurrences(of: "{latex}", with: latex)
         )
         SourceOffsetAnnotator.tagSourceRange(in: &attributes, of: node)
         output.append(NSAttributedString(string: "\u{FFFC}", attributes: attributes))

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXRenderingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXRenderingTests.swift
@@ -20,6 +20,7 @@ final class LaTeXRenderingTests: XCTestCase {
 
     private func renderWithStub(
         _ markdown: String,
+        accessibilityLabel: String = "Math: {latex}",
         typeset: @escaping MathRenderer.Typeset
     ) -> NSAttributedString {
         MarkdownRenderer.render(
@@ -27,7 +28,7 @@ final class LaTeXRenderingTests: XCTestCase {
             config: config,
             flags: .commonMark,
             imageRequestHeaders: [:],
-            plugins: [LaTeXRenderPlugin(typeset: typeset)]
+            plugins: [LaTeXRenderPlugin(typeset: typeset, accessibilityLabel: accessibilityLabel)]
         )
     }
 
@@ -95,6 +96,14 @@ final class LaTeXRenderingTests: XCTestCase {
         XCTAssertFalse(rendered.string.contains("$"))
     }
 
+    // MARK: - Accessibility
+
+    func testAccessibilityLabelTemplateReachesTheVoiceOverElement() {
+        let rendered = renderWithStub("$x^2$", accessibilityLabel: "Formel: {latex}") { _, _, _, _ in self.stubResult() }
+
+        XCTAssertEqual(MarkdownAccessibilityElementBuilder.specs(for: rendered).first?.label, "Formel: x^2")
+    }
+
     // MARK: - Renderer behavior (stubbed typesetting)
 
     func testInlineAttachmentMetricsAndDelimiters() {
@@ -111,7 +120,7 @@ final class LaTeXRenderingTests: XCTestCase {
         XCTAssertEqual(math.latex, "x^2")
         XCTAssertFalse(math.isDisplay)
         XCTAssertFalse(math.isBlock)
-        XCTAssertEqual(math.accessibilityLabel, "x^2")
+        XCTAssertEqual(math.accessibilityLabel, "Math: x^2")
         XCTAssertEqual(math.markdownText(), "$x^2$")
 
         let expectedFontSize = (config.paragraph.font ?? UIFont.preferredFont(forTextStyle: .body)).pointSize

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathBlockViewTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathBlockViewTests.swift
@@ -16,7 +16,8 @@ final class MathBlockViewTests: XCTestCase {
             latex: "x",
             isDisplay: true,
             result: stubResult(),
-            panel: MathPanelStyle(backgroundColor: background, padding: padding, textAlignment: alignment)
+            panel: MathPanelStyle(backgroundColor: background, padding: padding, textAlignment: alignment),
+            accessibilityLabel: "Math: x"
         )
     }
 
@@ -41,7 +42,9 @@ final class MathBlockViewTests: XCTestCase {
 
     func testOnlyBlockMathDeclaresTheProviderFileType() {
         XCTAssertEqual(blockAttachment().fileType, MathAttachment.fileType)
-        XCTAssertNil(MathAttachment(latex: "x", isDisplay: false, result: stubResult()).fileType)
+        XCTAssertNil(
+            MathAttachment(latex: "x", isDisplay: false, result: stubResult(), accessibilityLabel: "Math: x").fileType
+        )
     }
 
     // MARK: - Layout

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathThemingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathThemingTests.swift
@@ -170,7 +170,8 @@ final class MathThemingTests: XCTestCase {
             latex: "x",
             isDisplay: true,
             result: stubResult(),
-            panel: MathPanelStyle(padding: 12, textAlignment: .center)
+            panel: MathPanelStyle(padding: 12, textAlignment: .center),
+            accessibilityLabel: "Math: x"
         )
 
         XCTAssertEqual(bounds(of: attachment, lineWidth: 300), CGRect(x: 0, y: -16, width: 300, height: 40))
@@ -195,7 +196,8 @@ final class MathThemingTests: XCTestCase {
                 latex: "x",
                 isDisplay: true,
                 result: stubResult(),
-                panel: MathPanelStyle(backgroundColor: background, padding: 12)
+                panel: MathPanelStyle(backgroundColor: background, padding: 12),
+                accessibilityLabel: "Math: x"
             )
             let size = CGSize(width: width, height: 40)
             return attachment.image(forBounds: CGRect(origin: .zero, size: size), textContainer: nil, characterIndex: 0)
@@ -204,7 +206,13 @@ final class MathThemingTests: XCTestCase {
         XCTAssertEqual(image(background: nil, width: 300).map(isBlank), true)
         XCTAssertEqual(image(background: .systemRed, width: 300).map(isBlank), false)
 
-        let attachment = MathAttachment(latex: "x", isDisplay: true, result: stubResult(), panel: MathPanelStyle())
+        let attachment = MathAttachment(
+            latex: "x",
+            isDisplay: true,
+            result: stubResult(),
+            panel: MathPanelStyle(),
+            accessibilityLabel: "Math: x"
+        )
         let narrow = attachment.image(forBounds: CGRect(x: 0, y: 0, width: 100, height: 16), textContainer: nil, characterIndex: 0)
         let wide = attachment.image(forBounds: CGRect(x: 0, y: 0, width: 200, height: 16), textContainer: nil, characterIndex: 0)
         XCTAssertEqual(narrow?.size.width, 100)

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/AccessibilityElementBuilderTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/AccessibilityElementBuilderTests.swift
@@ -11,29 +11,54 @@ final class AccessibilityElementBuilderTests: XCTestCase {
         config = MarkdownStyleConfig.resolve(layers: [.default], traitCollection: .current)
     }
 
-    private func specs(for markdown: String) -> [MarkdownAccessibilityElementSpec] {
-        MarkdownAccessibilityElementBuilder.specs(for: MarkdownRenderer.render(markdown, config: config))
+    private func specs(
+        for markdown: String,
+        labels: MarkdownAccessibilityLabels = .default
+    ) -> [MarkdownAccessibilityElementSpec] {
+        MarkdownAccessibilityElementBuilder.specs(for: MarkdownRenderer.render(markdown, config: config), labels: labels)
     }
 
     func testEmptyStringYieldsNoSpecs() {
         XCTAssertTrue(MarkdownAccessibilityElementBuilder.specs(for: NSAttributedString()).isEmpty)
     }
 
+    // MARK: - Headings
+
     func testHeadingBecomesSingleHeadingSpec() {
         let result = specs(for: "# Title\n\nBody paragraph")
 
         XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].kind, .heading(level: 1))
+        XCTAssertEqual(result[0].kind, .text)
+        XCTAssertEqual(result[0].headingLevel, 1)
         XCTAssertEqual(result[0].label, "Title")
         XCTAssertEqual(result[1].kind, .text)
+        XCTAssertNil(result[1].headingLevel)
         XCTAssertEqual(result[1].label, "Body paragraph")
     }
 
     func testHeadingLevelsAreReported() {
         let result = specs(for: "### Third level")
 
-        XCTAssertEqual(result.first?.kind, .heading(level: 3))
+        XCTAssertEqual(result.first?.headingLevel, 3)
     }
+
+    func testLinkInsideHeadingStaysNavigableAndKeepsLevel() {
+        let result = specs(for: "# Hello [world](https://w.example) again")
+
+        XCTAssertEqual(result.map(\.label), ["Hello", "world", "again"])
+        XCTAssertEqual(result[1].kind, .link(URL(string: "https://w.example")!))
+        XCTAssertEqual(result.map(\.headingLevel), [1, 1, 1])
+    }
+
+    func testHeadingThatIsEntirelyALinkIsALinkWithHeadingLevel() {
+        let result = specs(for: "## [Docs](https://d.example)")
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].kind, .link(URL(string: "https://d.example")!))
+        XCTAssertEqual(result[0].headingLevel, 2)
+    }
+
+    // MARK: - Paragraphs, links, images
 
     func testSpacerParagraphsAreSkipped() {
         let result = specs(for: "First\n\nSecond\n\nThird")
@@ -58,89 +83,198 @@ final class AccessibilityElementBuilderTests: XCTestCase {
         let result = specs(for: "![company logo](https://example.invalid/logo.png)")
 
         XCTAssertEqual(result.count, 1)
-        XCTAssertEqual(result[0].kind, .image)
+        XCTAssertEqual(result[0].kind, .image(link: nil))
         XCTAssertEqual(result[0].label, "company logo")
     }
 
     func testImageWithoutAltTextFallsBackToImage() {
         let result = specs(for: "![](https://example.invalid/logo.png)")
 
-        XCTAssertEqual(result.first?.kind, .image)
+        XCTAssertEqual(result.first?.kind, .image(link: nil))
         XCTAssertEqual(result.first?.label, "Image")
     }
+
+    func testLinkedImageKeepsAltTextAndCarriesLinkTarget() {
+        let result = specs(for: "[![Logo](https://example.invalid/logo.png)](https://swmansion.com)")
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].kind, .image(link: URL(string: "https://swmansion.com")!))
+        XCTAssertEqual(result[0].label, "Logo")
+    }
+
+    func testInlineLinkedImageSplitsSurroundingText() {
+        let result = specs(for: "See [![Logo](https://example.invalid/logo.png)](https://swmansion.com) here")
+
+        XCTAssertEqual(result.map(\.label), ["See", "Logo", "here"])
+        XCTAssertEqual(result[1].kind, .image(link: URL(string: "https://swmansion.com")!))
+    }
+
+    func testLinkWrappingTextAndImageSplitsAroundTheImage() {
+        let result = specs(for: "[docs ![Logo](https://example.invalid/logo.png) site](https://swmansion.com)")
+        let target = URL(string: "https://swmansion.com")!
+
+        XCTAssertEqual(result.map(\.label), ["docs", "Logo", "site"])
+        XCTAssertEqual(result[0].kind, .link(target))
+        XCTAssertEqual(result[1].kind, .image(link: target))
+        XCTAssertEqual(result[2].kind, .link(target))
+    }
+
+    // MARK: - Attachments
+
+    func testLabelledAttachmentBecomesItsOwnElement() {
+        let text = NSMutableAttributedString(string: "Euler says ")
+        let formula = NSTextAttachment()
+        formula.accessibilityLabel = "Math: e^{i\\pi}"
+        text.append(NSAttributedString(attachment: formula))
+        text.append(NSAttributedString(string: " is neat."))
+
+        let result = MarkdownAccessibilityElementBuilder.specs(for: text)
+
+        XCTAssertEqual(result.map(\.label), ["Euler says", "Math: e^{i\\pi}", "is neat."])
+        XCTAssertEqual(result[1].kind, .text)
+    }
+
+    func testUnlabelledAttachmentIsNotSpokenAsReplacementCharacter() {
+        let text = NSMutableAttributedString(string: "before ")
+        text.append(NSAttributedString(attachment: NSTextAttachment()))
+        text.append(NSAttributedString(string: " after"))
+
+        let result = MarkdownAccessibilityElementBuilder.specs(for: text)
+
+        XCTAssertEqual(result.map(\.label), ["before  after"])
+    }
+
+    // MARK: - Code blocks
+
+    func testCodeBlockIsOneElementWithTheCodeAsLabel() {
+        let result = specs(for: "Intro\n\n```swift\nlet a = 1\nlet b = 2\n```\n\nOutro")
+
+        XCTAssertEqual(result.map(\.label), ["Intro", "let a = 1\nlet b = 2", "Outro"])
+        XCTAssertEqual(result[1].kind, .codeBlock(copyAction: "Copy code"))
+    }
+
+    // MARK: - Lists
 
     func testUnorderedListItemsAnnounceBulletPoint() {
         let result = specs(for: "- one\n- two")
 
         XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].listAnnouncement, "bullet point")
-        XCTAssertEqual(result[1].listAnnouncement, "bullet point")
+        XCTAssertEqual(result[0].value, "Bullet point")
+        XCTAssertEqual(result[1].value, "Bullet point")
     }
 
     func testOrderedListItemsAnnouncePosition() {
         let result = specs(for: "1. one\n2. two\n3. three")
 
-        XCTAssertEqual(result.map(\.listAnnouncement), ["list item 1", "list item 2", "list item 3"])
+        XCTAssertEqual(result.map(\.value), ["List item 1", "List item 2", "List item 3"])
     }
 
     func testNestedListItemsAnnounceNesting() {
         let result = specs(for: "- outer\n  - inner")
 
         XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].listAnnouncement, "bullet point")
-        XCTAssertEqual(result[1].listAnnouncement, "nested bullet point")
+        XCTAssertEqual(result[0].value, "Bullet point")
+        XCTAssertEqual(result[1].value, "Nested bullet point")
     }
 
     func testTaskListItemsAnnounceCheckedState() {
         let result = specs(for: "- [x] done\n- [ ] todo")
 
         XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].listAnnouncement, "task, checked")
-        XCTAssertEqual(result[1].listAnnouncement, "task, not checked")
+        XCTAssertEqual(result[0].value, "Task, checked")
+        XCTAssertEqual(result[1].value, "Task, not checked")
     }
 
     func testNestedTaskItemsAnnounceNesting() {
         let result = specs(for: "- outer\n  - [ ] inner task")
 
         XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[1].listAnnouncement, "nested task, not checked")
+        XCTAssertEqual(result[1].value, "Nested task, not checked")
     }
 
     func testLinkInsideListItemCarriesListContext() {
         let result = specs(for: "- see [docs](https://d.example) here")
 
-        let link = result.first { spec in
-            if case .link = spec.kind { return true }
-            return false
-        }
-        XCTAssertEqual(link?.listAnnouncement, "bullet point")
+        XCTAssertEqual(result.first { $0.kind == .link(URL(string: "https://d.example")!) }?.value, "Bullet point")
     }
 
     func testNonListParagraphHasNoAnnouncement() {
         let result = specs(for: "Plain paragraph")
 
-        XCTAssertNil(result.first?.listAnnouncement)
+        XCTAssertNil(result.first?.value)
     }
 
-    func testBlockquoteContentIsStillRepresented() {
+    // MARK: - Blockquotes
+
+    func testBlockquoteContentAnnouncesBlockquote() {
         let result = specs(for: "> quoted words")
 
         XCTAssertEqual(result.first?.label, "quoted words")
+        XCTAssertEqual(result.first?.value, "Blockquote")
+    }
+
+    func testNestedBlockquoteAnnouncesNesting() {
+        let result = specs(for: "> outer\n>\n> > inner")
+
+        XCTAssertEqual(result.map(\.value), ["Blockquote", "Nested blockquote"])
+    }
+
+    func testListInsideBlockquoteAnnouncesBoth() {
+        let result = specs(for: "> - item")
+
+        XCTAssertEqual(result.first?.value, "Bullet point, Blockquote")
+    }
+
+    // MARK: - Custom labels
+
+    func testCustomLabelsReplaceDefaults() {
+        var labels = MarkdownAccessibilityLabels()
+        labels.list.top.bulletPoint = "Punkt"
+        labels.list.nested.orderedItem = "Unterelement {n}"
+        labels.blockquote.quote = "Zitat"
+        labels.image.fallback = "Bild"
+
+        XCTAssertEqual(specs(for: "- eins", labels: labels).first?.value, "Punkt")
+        XCTAssertEqual(specs(for: "- eins\n  1. zwei", labels: labels).last?.value, "Unterelement 1")
+        XCTAssertEqual(specs(for: "> Wort", labels: labels).first?.value, "Zitat")
+        XCTAssertEqual(specs(for: "![](https://example.invalid/a.png)", labels: labels).first?.label, "Bild")
+    }
+
+    func testTableRowLabelUsesTemplate() {
+        var labels = MarkdownAccessibilityLabels()
+        labels.table.row = "Zeile {n}: {content}"
+
+        let result = specs(for: "| A | B |\n|---|---|\n| 1 | 2 |", labels: labels)
+
+        XCTAssertEqual(result.map(\.label), ["Zeile 1: A, B", "Zeile 2: 1, 2"])
     }
 }
 
 final class MarkdownTextViewAccessibilityTests: XCTestCase {
     private var config: MarkdownStyleConfig!
+    private var pasteboard: UIPasteboard!
 
     override func setUp() {
         super.setUp()
         config = MarkdownStyleConfig.resolve(layers: [.default], traitCollection: .current)
+        // UIPasteboard.general is not accessible from a headless test process.
+        pasteboard = UIPasteboard.withUniqueName()
+    }
+
+    override func tearDown() {
+        UIPasteboard.remove(withName: pasteboard.name)
+        super.tearDown()
     }
 
     private func makeTextView(markdown: String) -> MarkdownTextView {
         let textView = MarkdownTextView()
+        textView.pasteboard = pasteboard
         textView.setMarkdownAttributedText(MarkdownRenderer.render(markdown, config: config))
         return textView
+    }
+
+    private func elements(of textView: MarkdownTextView) -> [MarkdownAccessibilityElement] {
+        textView.accessibilityElements?.compactMap { $0 as? MarkdownAccessibilityElement } ?? []
     }
 
     func testElementsReplaceHostAccessibility() {
@@ -153,10 +287,25 @@ final class MarkdownTextViewAccessibilityTests: XCTestCase {
     func testHeadingElementCarriesHeaderTrait() {
         let textView = makeTextView(markdown: "## Section")
 
-        let element = textView.accessibilityElements?.first as? MarkdownAccessibilityElement
+        let element = elements(of: textView).first
         XCTAssertNotNil(element)
         XCTAssertTrue(element!.accessibilityTraits.contains(.header))
         XCTAssertEqual(element!.accessibilityLabel, "Section")
+        let level = element!.accessibilityAttributedLabel?.attribute(
+            .accessibilityTextHeadingLevel,
+            at: 0,
+            effectiveRange: nil
+        ) as? Int
+        XCTAssertEqual(level, 2)
+    }
+
+    func testLinkInsideHeadingIsAnActivatableHeaderLink() {
+        let textView = makeTextView(markdown: "## [Docs](https://swmansion.com)")
+
+        let link = elements(of: textView).first
+        XCTAssertEqual(link?.url, URL(string: "https://swmansion.com"))
+        XCTAssertTrue(link!.accessibilityTraits.contains(.link))
+        XCTAssertTrue(link!.accessibilityTraits.contains(.header))
     }
 
     func testLinkElementActivatesPressHandler() {
@@ -164,21 +313,92 @@ final class MarkdownTextViewAccessibilityTests: XCTestCase {
         var pressedURL: URL?
         textView.onLinkPress = { pressedURL = $0 }
 
-        let link = textView.accessibilityElements?
-            .compactMap { $0 as? MarkdownLinkAccessibilityElement }
-            .first
-        XCTAssertNotNil(link)
-        XCTAssertTrue(link!.accessibilityActivate())
+        XCTAssertEqual(elements(of: textView).first?.accessibilityActivate(), true)
         XCTAssertEqual(pressedURL, URL(string: "https://swmansion.com"))
     }
 
     func testLinkElementWithoutHandlerDoesNotActivate() {
         let textView = makeTextView(markdown: "[press me](https://swmansion.com)")
 
-        let link = textView.accessibilityElements?
-            .compactMap { $0 as? MarkdownLinkAccessibilityElement }
-            .first
-        XCTAssertEqual(link?.accessibilityActivate(), false)
+        XCTAssertEqual(elements(of: textView).first?.accessibilityActivate(), false)
+    }
+
+    func testPlainTextElementDoesNotActivate() {
+        let textView = makeTextView(markdown: "plain")
+        textView.onLinkPress = { _ in XCTFail("no link to press") }
+
+        XCTAssertEqual(elements(of: textView).first?.accessibilityActivate(), false)
+    }
+
+    func testLinkedImageIsAnActivatableImageLink() {
+        let textView = makeTextView(markdown: "[![Logo](https://example.invalid/logo.png)](https://swmansion.com)")
+        var pressedURL: URL?
+        textView.onLinkPress = { pressedURL = $0 }
+
+        let image = elements(of: textView).first
+        XCTAssertEqual(image?.accessibilityLabel, "Logo")
+        XCTAssertTrue(image!.accessibilityTraits.contains(.image))
+        XCTAssertTrue(image!.accessibilityTraits.contains(.link))
+        XCTAssertTrue(image!.accessibilityActivate())
+        XCTAssertEqual(pressedURL, URL(string: "https://swmansion.com"))
+    }
+
+    func testCodeBlockOffersCopyCustomAction() {
+        let textView = makeTextView(markdown: "```\nlet a = 1\n```")
+
+        let block = elements(of: textView).first
+        let copy = block?.accessibilityCustomActions?.first
+        XCTAssertEqual(copy?.name, "Copy code")
+        XCTAssertEqual(copy?.actionHandler?(copy!), true)
+        XCTAssertEqual(pasteboard.string, "let a = 1")
+    }
+
+    func testRotorsCoverHeadingsLinksAndImages() {
+        let textView = makeTextView(
+            markdown: "# Title\n\n[link](https://swmansion.com)\n\n![Logo](https://example.invalid/logo.png)"
+        )
+
+        XCTAssertEqual(textView.accessibilityCustomRotors?.map(\.name), ["Headings", "Links", "Images"])
+    }
+
+    func testRotorsAreOnlyOfferedWhenTheyHaveTargets() {
+        let textView = makeTextView(markdown: "Plain paragraph\n\n[link](https://swmansion.com)")
+
+        XCTAssertEqual(textView.accessibilityCustomRotors?.map(\.name), ["Links"])
+    }
+
+    func testRotorWalksItsElementsInBothDirections() {
+        let textView = makeTextView(markdown: "# One\n\n## Two")
+        guard let rotor = textView.accessibilityCustomRotors?.first else { return XCTFail("no rotor") }
+        let headings = elements(of: textView)
+
+        let predicate = UIAccessibilityCustomRotorSearchPredicate()
+        predicate.searchDirection = .next
+        let first = rotor.itemSearchBlock(predicate)?.targetElement as? MarkdownAccessibilityElement
+        XCTAssertTrue(first === headings[0])
+
+        predicate.currentItem = UIAccessibilityCustomRotorItemResult(targetElement: headings[0], targetRange: nil)
+        let second = rotor.itemSearchBlock(predicate)?.targetElement as? MarkdownAccessibilityElement
+        XCTAssertTrue(second === headings[1])
+
+        predicate.currentItem = UIAccessibilityCustomRotorItemResult(targetElement: headings[1], targetRange: nil)
+        XCTAssertNil(rotor.itemSearchBlock(predicate))
+
+        predicate.searchDirection = .previous
+        let back = rotor.itemSearchBlock(predicate)?.targetElement as? MarkdownAccessibilityElement
+        XCTAssertTrue(back === headings[0])
+    }
+
+    func testChangingLabelsRebuildsElementsAndRotors() {
+        let textView = makeTextView(markdown: "- item\n\n# Title")
+        var labels = MarkdownAccessibilityLabels()
+        labels.list.top.bulletPoint = "Punkt"
+        labels.rotor.headings = "Überschriften"
+
+        textView.accessibilityLabels = labels
+
+        XCTAssertEqual(elements(of: textView).first?.accessibilityValue, "Punkt")
+        XCTAssertEqual(textView.accessibilityCustomRotors?.map(\.name), ["Überschriften"])
     }
 
     func testEmptyContentKeepsDefaultAccessibility() {


### PR DESCRIPTION
Fix three announcement bugs and close the remaining feature gaps between the iOS package and the RN implementation:

- Linked images read their alt text with the image and link traits and activate the link handler; previously they were a link labelled with the U+FFFC attachment character.
- Links inside headings stay their own elements, carrying the link and header traits plus the heading level, instead of being swallowed by the heading run.
- Any attachment with an accessibilityLabel (math from the LaTeX module) becomes its own element; unlabelled attachments are no longer spoken as "object replacement character". The base package stays math-free.
- Add Headings/Links/Images rotors, blockquote announcements, and a single element per fenced code block with a "Copy code" custom action.
- Add MarkdownAccessibilityLabels and .markdownAccessibilityLabels() so every spoken string can be localized; the math template is a parameter of .markdownLaTeX(). Defaults match the RN strings.

Headings are now per-segment context in the element builder rather than a run kind, and the element tree is built lazily on the first accessibility query after the text or labels change, so streaming re-renders do not pay for it.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

