### PR TITLE
feat(ios): speak LaTeX formulas in English for VoiceOver

### DIFF
--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -325,7 +325,7 @@ EnrichedMarkdownText(markdown)
     .markdownAccessibilityLabels(labels)
 ```
 
-`{n}` is a 1-based index and `{content}` the comma-joined cell text of a table row; translations must keep the placeholder names. Defaults use the cardinal form ("List item 2") so one template works in every language without plural rules. The math label lives in the LaTeX module: `.markdownLaTeX(accessibilityLabel: "Formel: {latex}")`.
+`{n}` is a 1-based index and `{content}` the comma-joined cell text of a table row; translations must keep the placeholder names. Defaults use the cardinal form ("List item 2") so one template works in every language without plural rules. The math label lives in the LaTeX module: `.markdownLaTeX(accessibilityLabel: "Formel: {speech}")`, or `.markdownLaTeX { latex in … }` for a custom converter.
 
 ### `.markdownImageRequestHeaders`
 
@@ -381,10 +381,10 @@ VoiceOver walks the rendered markdown as individual elements rather than one tex
 - Content inside a blockquote appends "Blockquote" or "Nested blockquote"
 - Tables read one element per row ("Row N: cell, cell"); the header row carries the heading trait
 - Fenced code blocks are one element each, with a "Copy code" custom action (swipe up/down on the element)
-- Math from `EnrichedMarkdownLaTeX` reads "Math: " followed by the raw LaTeX
+- Math from `EnrichedMarkdownLaTeX` reads an English form of the formula ("Math: x squared over 2", "integral from 0 to 1 of …"); `{latex}` in the label template gives the raw source instead, and a closure can plug in another converter
 - Rotors (two-finger twist) jump between Headings, Links, and Images
 
-Every spoken string can be localized with `.markdownAccessibilityLabels` (see the API reference); the math template is a parameter of `.markdownLaTeX`. Element frames are resolved from the live layout on each query, so they stay correct inside a scrolling container and after Dynamic Type changes.
+Every spoken string can be localized with `.markdownAccessibilityLabels` (see the API reference); the math label is a parameter of `.markdownLaTeX`, either a template (`"Formel: {speech}"`, `{latex}` for the source) or a `(String) -> String` closure receiving the LaTeX source. The built-in reading (`LaTeXSpeech.spokenForm`) is English and covers fractions, roots, powers and indices, sums/products/integrals/limits with bounds, Greek letters, common relations and functions, decorations, and `\text`; unmapped commands are read by name. Element frames are resolved from the live layout on each query, so they stay correct inside a scrolling container and after Dynamic Type changes.
 
 Dynamic Type is supported throughout via text styles in the default theme.
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/LaTeXRenderPlugin.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/LaTeXRenderPlugin.swift
@@ -5,25 +5,41 @@ import UIKit
 /// Enables `$…$`/`$$…$$` parsing and claims the math node types with
 /// RaTeX-backed rendering.
 package struct LaTeXRenderPlugin: MarkdownRenderPlugin {
-    /// VoiceOver label for a formula; `{latex}` is replaced by its source.
+    /// VoiceOver label template for a formula; see `label(template:)`.
     /// The public entry points repeat the literal: a package-level constant
     /// cannot be used as a public default argument.
-    package static let defaultAccessibilityLabel: String = "Math: {latex}"
+    package static let defaultAccessibilityLabel: String = "Math: {speech}"
 
     private let typeset: MathRenderer.Typeset
-    private let accessibilityLabel: String
+    private let accessibilityLabel: (String) -> String
 
     package init(accessibilityLabel: String = LaTeXRenderPlugin.defaultAccessibilityLabel) {
+        self.init(accessibilityLabel: Self.label(template: accessibilityLabel))
+    }
+
+    package init(accessibilityLabel: @escaping (String) -> String) {
         self.init(typeset: MathRenderer.raTeXTypeset, accessibilityLabel: accessibilityLabel)
     }
 
     /// Tests inject a deterministic typesetter.
     init(
         typeset: @escaping MathRenderer.Typeset,
-        accessibilityLabel: String = LaTeXRenderPlugin.defaultAccessibilityLabel
+        accessibilityLabel: @escaping (String) -> String = LaTeXRenderPlugin.label(
+            template: LaTeXRenderPlugin.defaultAccessibilityLabel
+        )
     ) {
         self.typeset = typeset
         self.accessibilityLabel = accessibilityLabel
+    }
+
+    /// Resolves a label template: `{speech}` becomes the spoken form of
+    /// the formula (`LaTeXSpeech`), `{latex}` its raw source.
+    static func label(template: String) -> (String) -> String {
+        let speaks = template.contains("{speech}")
+        return { latex in
+            let spoken = speaks ? template.replacingOccurrences(of: "{speech}", with: LaTeXSpeech.spokenForm(of: latex)) : template
+            return spoken.replacingOccurrences(of: "{latex}", with: latex)
+        }
     }
 
     package func renderer(for type: NodeType, config: MarkdownStyleConfig) -> NodeRenderer? {
@@ -60,10 +76,18 @@ public extension View {
     /// the bundled RaTeX engine, styled by `MarkdownTheme.latexDefault`
     /// underneath the themes applied around this view.
     ///
-    /// `accessibilityLabel` is what VoiceOver speaks for a formula, with
-    /// `{latex}` replaced by the source (the raw LaTeX is read verbatim; no
-    /// speech conversion is attempted). The innermost modifier wins.
-    func markdownLaTeX(accessibilityLabel: String = "Math: {latex}") -> some View {
+    /// `accessibilityLabel` is what VoiceOver speaks for a formula:
+    /// `{speech}` is replaced by an English reading of the source
+    /// (`LaTeXSpeech`, e.g. "x squared over 2"), `{latex}` by the raw
+    /// source. The innermost modifier wins.
+    func markdownLaTeX(accessibilityLabel: String = "Math: {speech}") -> some View {
+        markdownLaTeX(accessibilityLabel: LaTeXRenderPlugin.label(template: accessibilityLabel))
+    }
+
+    /// `markdownLaTeX()` with a custom VoiceOver label per formula, for
+    /// apps that bring their own LaTeX-to-speech conversion. The closure
+    /// receives the raw source and runs on the render queue.
+    func markdownLaTeX(accessibilityLabel: @escaping (String) -> String) -> some View {
         transformEnvironment(\.markdownRenderPlugins) { plugins in
             plugins.removeAll { $0 is LaTeXRenderPlugin }
             plugins.append(LaTeXRenderPlugin(accessibilityLabel: accessibilityLabel))
@@ -72,13 +96,30 @@ public extension View {
 }
 
 public extension MarkdownRenderer {
-    /// `MarkdownRenderer.render` with RaTeX math typesetting installed.
+    /// `MarkdownRenderer.render` with RaTeX math typesetting installed;
+    /// `accessibilityLabel` as in `.markdownLaTeX`.
     static func renderLaTeX(
         _ markdown: String,
         config: MarkdownStyleConfig,
         flags: Md4cFlags = .commonMark,
         imageRequestHeaders: [String: String] = [:],
-        accessibilityLabel: String = "Math: {latex}"
+        accessibilityLabel: String = "Math: {speech}"
+    ) -> NSAttributedString {
+        renderLaTeX(
+            markdown,
+            config: config,
+            flags: flags,
+            imageRequestHeaders: imageRequestHeaders,
+            accessibilityLabel: LaTeXRenderPlugin.label(template: accessibilityLabel)
+        )
+    }
+
+    static func renderLaTeX(
+        _ markdown: String,
+        config: MarkdownStyleConfig,
+        flags: Md4cFlags = .commonMark,
+        imageRequestHeaders: [String: String] = [:],
+        accessibilityLabel: @escaping (String) -> String
     ) -> NSAttributedString {
         render(
             markdown,

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/LaTeXSpeech.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/LaTeXSpeech.swift
@@ -1,0 +1,319 @@
+import Foundation
+
+/// Spoken English for a LaTeX formula ("x squared over 2" rather than
+/// "x caret 2 slash 2"). Covers fractions, roots, powers and indices, big
+/// operators with bounds, Greek letters, relations, decorations, and
+/// text; an unmapped command is read by name so nothing is dropped.
+/// Compound arguments are closed with "end fraction", "end power", etc.
+public enum LaTeXSpeech {
+    public static func spokenForm(of latex: String) -> String {
+        var parser = Parser(tokens: Tokenizer.tokenize(latex))
+        return parser.group(until: nil).words.joined(separator: " ")
+    }
+}
+
+// MARK: - Tokens
+
+private enum Token: Equatable {
+    /// Name without the backslash; a single non-letter for `\,`, `\{`, …
+    case command(String)
+    case symbol(Character)
+    case number(String)
+    case letters(String)
+}
+
+private enum Tokenizer {
+    static func tokenize(_ latex: String) -> [Token] {
+        var tokens: [Token] = []
+        let chars = Array(latex)
+        var index = 0
+        while index < chars.count {
+            let char = chars[index]
+            if char == "\\" {
+                index += 1
+                guard index < chars.count else { break }
+                if chars[index].isLetter {
+                    tokens.append(.command(run(in: chars, from: &index) { $0.isLetter }))
+                } else {
+                    tokens.append(.command(String(chars[index])))
+                    index += 1
+                }
+            } else if char.isNumber {
+                tokens.append(.number(run(in: chars, from: &index) { $0.isNumber || $0 == "." }))
+            } else if char.isLetter {
+                tokens.append(.letters(run(in: chars, from: &index) { $0.isLetter }))
+            } else if char.isWhitespace {
+                index += 1
+            } else {
+                tokens.append(.symbol(char))
+                index += 1
+            }
+        }
+        return tokens
+    }
+
+    private static func run(in chars: [Character], from index: inout Int, while predicate: (Character) -> Bool) -> String {
+        var text = ""
+        while index < chars.count, predicate(chars[index]) {
+            text.append(chars[index])
+            index += 1
+        }
+        return text
+    }
+}
+
+// MARK: - Parser
+
+/// Recursive descent over the token stream, producing spoken words.
+private struct Parser {
+    /// A command argument: its words plus how many items produced them, so
+    /// wording can tell `n^2` (one item) from `a+b` (three) and close the
+    /// latter with an end marker.
+    struct Argument {
+        var words: [String] = []
+        var itemCount: Int = 0
+
+        var isSimple: Bool { itemCount == 1 }
+
+        func closed(with marker: String) -> [String] {
+            itemCount > 1 ? words + [marker] : words
+        }
+    }
+
+    private enum Mode {
+        case math
+        /// Inside `\text{…}`: letter runs stay words.
+        case text
+        /// Inside a `\lim` bound: `\to` reads "approaches".
+        case limit
+    }
+
+    private let tokens: [Token]
+    private var position: Int = 0
+    private var mode: Mode = .math
+
+    init(tokens: [Token]) {
+        self.tokens = tokens
+    }
+
+    private var current: Token? {
+        position < tokens.count ? tokens[position] : nil
+    }
+
+    private mutating func advance() {
+        position += 1
+    }
+
+    /// Items up to `closer`, which is consumed; nil reads to the end.
+    mutating func group(until closer: Token?) -> Argument {
+        var group = Argument()
+        while let token = current, token != closer {
+            let words = item()
+            if !words.isEmpty {
+                group.words += words
+                group.itemCount += 1
+            }
+        }
+        advance()
+        return group
+    }
+
+    /// One atom plus its `^` / `_` scripts.
+    private mutating func item() -> [String] {
+        let base = argument().words
+        let (sub, sup) = scripts()
+        return base + Self.index(sub) + Self.power(sup)
+    }
+
+    /// A braced group or a single atom, as TeX reads command arguments.
+    private mutating func argument() -> Argument {
+        guard let token = current else { return Argument() }
+        advance()
+        if token == .symbol("{") {
+            return group(until: .symbol("}"))
+        }
+        let words = atom(token)
+        return Argument(words: words, itemCount: words.isEmpty ? 0 : 1)
+    }
+
+    private mutating func argument(in mode: Mode) -> Argument {
+        let outer = self.mode
+        self.mode = mode
+        defer { self.mode = outer }
+        return argument()
+    }
+
+    /// Trailing `^` / `_` scripts in either order.
+    private mutating func scripts() -> (sub: Argument?, sup: Argument?) {
+        var sub: Argument?
+        var sup: Argument?
+        while let script = current, script == .symbol("^") || script == .symbol("_") {
+            advance()
+            if script == .symbol("^") {
+                sup = argument()
+            } else {
+                sub = argument()
+            }
+        }
+        return (sub, sup)
+    }
+
+    private mutating func atom(_ token: Token) -> [String] {
+        switch token {
+        case .symbol(let char):
+            return Self.spoken(Self.symbolWords[char], fallback: String(char))
+        case .number(let number):
+            return [number]
+        case .letters(let run):
+            // Short runs are juxtaposed variables ("dx"); longer ones are
+            // words ("max").
+            return mode == .text || run.count > 2 ? [run] : run.map { String($0) }
+        case .command(let name):
+            return command(name)
+        }
+    }
+
+    private mutating func command(_ name: String) -> [String] {
+        switch name {
+        case "frac", "dfrac", "tfrac":
+            let numerator = argument()
+            return Self.fraction(numerator, over: argument())
+        case "binom":
+            let top = argument()
+            return top.words + ["choose"] + argument().words
+        case "sqrt":
+            let degree = current == .symbol("[") ? { advance(); return group(until: .symbol("]")) }() : Argument()
+            return Self.root(degree: degree, of: argument())
+        case "text", "textrm", "textbf", "textit", "mathrm", "mathbf", "mathit", "mathsf", "mathtt", "operatorname", "mbox":
+            return argument(in: .text).words
+        case "mathbb", "mathcal", "mathfrak", "boldsymbol", "bm":
+            return argument().words
+        case "vec":
+            return ["vector"] + argument().words
+        case "hat", "bar", "overline", "tilde", "dot", "ddot":
+            return argument().words + [Self.decorations[name] ?? name]
+        case "left", "right":
+            // The delimiter that follows is read as a plain symbol; `\left.`
+            // is the invisible one.
+            if current == .symbol(".") {
+                advance()
+            }
+            return []
+        case "sum", "prod", "int", "iint", "oint", "lim", "bigcup", "bigcap":
+            return bigOperator(name)
+        case "to" where mode == .limit, "rightarrow" where mode == .limit:
+            return ["approaches"]
+        default:
+            return Self.spoken(Self.commandWords[name], fallback: name)
+        }
+    }
+
+    /// `\sum_{a}^{b}` → "sum from a to b of"; `\lim_{x \to 0}` → "limit as
+    /// x approaches 0 of".
+    private mutating func bigOperator(_ name: String) -> [String] {
+        let outer = mode
+        mode = name == "lim" ? .limit : mode
+        let (lower, upper) = scripts()
+        mode = outer
+
+        var words = [Self.bigOperators[name] ?? name]
+        if let lower {
+            words += [name == "lim" ? "as" : "from"] + lower.words
+        }
+        if let upper {
+            words += ["to"] + upper.words
+        }
+        return words + ["of"]
+    }
+
+    // MARK: Wording
+
+    private static func power(_ exponent: Argument?) -> [String] {
+        guard let exponent, !exponent.words.isEmpty else { return [] }
+        switch exponent.words {
+        case ["2"]: return ["squared"]
+        case ["3"]: return ["cubed"]
+        default: return exponent.isSimple
+            ? ["to the power"] + exponent.words
+            : ["to the power of"] + exponent.closed(with: "end power")
+        }
+    }
+
+    private static func index(_ sub: Argument?) -> [String] {
+        guard let sub, !sub.words.isEmpty else { return [] }
+        return ["sub"] + sub.closed(with: "end sub")
+    }
+
+    private static func fraction(_ numerator: Argument, over denominator: Argument) -> [String] {
+        if numerator.isSimple, denominator.isSimple {
+            return numerator.words + ["over"] + denominator.words
+        }
+        return ["fraction"] + numerator.words + ["over"] + denominator.words + ["end fraction"]
+    }
+
+    private static func root(degree: Argument, of radicand: Argument) -> [String] {
+        let body = radicand.closed(with: "end root")
+        switch degree.words {
+        case []: return ["square root of"] + body
+        case ["3"]: return ["cube root of"] + body
+        default: return ["root"] + degree.words + ["of"] + body
+        }
+    }
+
+    /// Table lookup: an empty mapping is spoken as nothing (spacing and
+    /// layout), a missing one as the fallback.
+    private static func spoken(_ word: String?, fallback: String) -> [String] {
+        guard let word else { return [fallback] }
+        return word.isEmpty ? [] : [word]
+    }
+
+    private static let symbolWords: [Character: String] = [
+        "+": "plus", "-": "minus", "=": "equals", "<": "less than", ">": "greater than",
+        "/": "over", "*": "times", "!": "factorial", "'": "prime", ",": "comma", ".": "point",
+        "(": "open paren", ")": "close paren", "[": "open bracket", "]": "close bracket",
+        "|": "vertical bar", ":": "colon", ";": "", "&": "", "~": "", "^": "", "_": "", "}": ""
+    ]
+
+    private static let bigOperators: [String: String] = [
+        "prod": "product", "int": "integral", "iint": "double integral", "oint": "contour integral",
+        "lim": "limit", "bigcup": "union", "bigcap": "intersection"
+    ]
+
+    private static let decorations: [String: String] = ["overline": "bar", "ddot": "double dot"]
+
+    /// Commands whose spoken form differs from their name; empty = silent.
+    private static let commandWords: [String: String] = {
+        var words: [String: String] = [
+            ",": "", ";": "", ":": "", "!": "", " ": "", "\\": "", "quad": "", "qquad": "",
+            "displaystyle": "", "textstyle": "", "nonumber": "",
+            "{": "open brace", "}": "close brace", "|": "double bar", "%": "percent", "_": "underscore",
+            "infty": "infinity", "hbar": "h bar",
+            "cdots": "dot dot dot", "ldots": "dot dot dot", "dots": "dot dot dot", "vdots": "dot dot dot",
+            "degree": "degrees", "emptyset": "empty set",
+            "neq": "not equal to", "ne": "not equal to", "leq": "less than or equal to", "le": "less than or equal to",
+            "geq": "greater than or equal to", "ge": "greater than or equal to", "approx": "approximately equal to",
+            "equiv": "is equivalent to", "sim": "similar to", "propto": "proportional to",
+            "cdot": "times", "div": "divided by", "pm": "plus or minus", "mp": "minus or plus",
+            "rightarrow": "to", "leftarrow": "from", "Rightarrow": "implies", "Leftrightarrow": "if and only if",
+            "mapsto": "maps to", "notin": "not in", "subset": "subset of", "subseteq": "subset of or equal to",
+            "supset": "superset of", "cup": "union", "cap": "intersection", "forall": "for all", "exists": "there exists",
+            "perp": "perpendicular to", "parallel": "parallel to", "mid": "given", "circ": "composed with",
+            "sin": "sine", "cos": "cosine", "tan": "tangent", "cot": "cotangent", "sec": "secant", "csc": "cosecant",
+            "arcsin": "arc sine", "arccos": "arc cosine", "arctan": "arc tangent",
+            "sinh": "hyperbolic sine", "cosh": "hyperbolic cosine", "tanh": "hyperbolic tangent",
+            "ln": "natural log", "exp": "exponential", "det": "determinant", "dim": "dimension",
+            "sup": "supremum", "inf": "infimum", "ker": "kernel", "Re": "real part", "Im": "imaginary part"
+        ]
+        let greek = [
+            "alpha", "beta", "gamma", "delta", "epsilon", "varepsilon", "zeta", "eta", "theta", "vartheta", "iota",
+            "kappa", "lambda", "mu", "nu", "xi", "pi", "varpi", "rho", "varrho", "sigma", "varsigma", "tau",
+            "upsilon", "phi", "varphi", "chi", "psi", "omega"
+        ]
+        for letter in greek {
+            let spoken = letter.hasPrefix("var") ? String(letter.dropFirst(3)) : letter
+            words[letter] = spoken
+            words[letter.prefix(1).uppercased() + letter.dropFirst()] = "capital " + spoken
+        }
+        return words
+    }()
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathRenderer.swift
@@ -17,14 +17,14 @@ final class MathRenderer: NodeRenderer {
     private let blockStyle: MathBlockStyle
     private let inlineStyle: InlineMathStyle
     private let panel: MathPanelStyle
-    /// `{latex}` template for the attachment's VoiceOver label.
-    private let accessibilityLabel: String
+    /// Produces the attachment's VoiceOver label from the source.
+    private let accessibilityLabel: (String) -> String
 
     init(
         typeset: @escaping Typeset,
         blockStyle: MathBlockStyle,
         inlineStyle: InlineMathStyle,
-        accessibilityLabel: String
+        accessibilityLabel: @escaping (String) -> String
     ) {
         self.typeset = typeset
         self.blockStyle = blockStyle
@@ -62,7 +62,7 @@ final class MathRenderer: NodeRenderer {
             isDisplay: isDisplay,
             result: result,
             panel: isBlock ? panel : nil,
-            accessibilityLabel: accessibilityLabel.replacingOccurrences(of: "{latex}", with: latex)
+            accessibilityLabel: accessibilityLabel(latex)
         )
         SourceOffsetAnnotator.tagSourceRange(in: &attributes, of: node)
         output.append(NSAttributedString(string: "\u{FFFC}", attributes: attributes))

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXRenderingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXRenderingTests.swift
@@ -20,7 +20,9 @@ final class LaTeXRenderingTests: XCTestCase {
 
     private func renderWithStub(
         _ markdown: String,
-        accessibilityLabel: String = "Math: {latex}",
+        accessibilityLabel: @escaping (String) -> String = LaTeXRenderPlugin.label(
+            template: LaTeXRenderPlugin.defaultAccessibilityLabel
+        ),
         typeset: @escaping MathRenderer.Typeset
     ) -> NSAttributedString {
         MarkdownRenderer.render(
@@ -99,9 +101,20 @@ final class LaTeXRenderingTests: XCTestCase {
     // MARK: - Accessibility
 
     func testAccessibilityLabelTemplateReachesTheVoiceOverElement() {
-        let rendered = renderWithStub("$x^2$", accessibilityLabel: "Formel: {latex}") { _, _, _, _ in self.stubResult() }
+        let label = LaTeXRenderPlugin.label(template: "Formel: {speech} ({latex})")
+        let rendered = renderWithStub("$x^2$", accessibilityLabel: label) { _, _, _, _ in self.stubResult() }
 
-        XCTAssertEqual(MarkdownAccessibilityElementBuilder.specs(for: rendered).first?.label, "Formel: x^2")
+        XCTAssertEqual(MarkdownAccessibilityElementBuilder.specs(for: rendered).first?.label, "Formel: x squared (x^2)")
+    }
+
+    func testAccessibilityLabelClosureReceivesTheSource() {
+        let rendered = renderWithStub(
+            "$x^2$",
+            accessibilityLabel: { "custom " + $0 },
+            typeset: { _, _, _, _ in self.stubResult() }
+        )
+
+        XCTAssertEqual(MarkdownAccessibilityElementBuilder.specs(for: rendered).first?.label, "custom x^2")
     }
 
     // MARK: - Renderer behavior (stubbed typesetting)
@@ -120,7 +133,7 @@ final class LaTeXRenderingTests: XCTestCase {
         XCTAssertEqual(math.latex, "x^2")
         XCTAssertFalse(math.isDisplay)
         XCTAssertFalse(math.isBlock)
-        XCTAssertEqual(math.accessibilityLabel, "Math: x^2")
+        XCTAssertEqual(math.accessibilityLabel, "Math: x squared")
         XCTAssertEqual(math.markdownText(), "$x^2$")
 
         let expectedFontSize = (config.paragraph.font ?? UIFont.preferredFont(forTextStyle: .body)).pointSize

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXSpeechTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXSpeechTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import EnrichedMarkdownLaTeX
+
+final class LaTeXSpeechTests: XCTestCase {
+    private func speak(_ latex: String) -> String {
+        LaTeXSpeech.spokenForm(of: latex)
+    }
+
+    func testPowersAndIndices() {
+        XCTAssertEqual(speak("x^2"), "x squared")
+        XCTAssertEqual(speak("x^3"), "x cubed")
+        XCTAssertEqual(speak("x^n"), "x to the power n")
+        XCTAssertEqual(speak("x^{n+1}"), "x to the power of n plus 1 end power")
+        XCTAssertEqual(speak("e^{i\\pi} + 1 = 0"), "e to the power of i pi end power plus 1 equals 0")
+        XCTAssertEqual(speak("x_1 \\leq y_{max}"), "x sub 1 less than or equal to y sub max")
+        XCTAssertEqual(speak("a_{ij}"), "a sub i j")
+        XCTAssertEqual(speak("x_i^2"), "x sub i squared")
+    }
+
+    func testFractionsAndRoots() {
+        XCTAssertEqual(speak("\\frac{1}{3}"), "1 over 3")
+        XCTAssertEqual(speak("\\frac{1}{n^2}"), "1 over n squared")
+        XCTAssertEqual(speak("\\frac{a+b}{2}"), "fraction a plus b over 2 end fraction")
+        XCTAssertEqual(speak("\\sqrt{2}"), "square root of 2")
+        XCTAssertEqual(speak("\\sqrt{a^2+b^2}"), "square root of a squared plus b squared end root")
+        XCTAssertEqual(speak("\\sqrt[3]{8}"), "cube root of 8")
+        XCTAssertEqual(speak("\\sqrt[n]{x}"), "root n of x")
+        XCTAssertEqual(speak("\\binom{n}{k}"), "n choose k")
+    }
+
+    func testBigOperatorsWithBounds() {
+        XCTAssertEqual(speak("\\int_0^1 x^2 \\, dx = \\frac{1}{3}"), "integral from 0 to 1 of x squared d x equals 1 over 3")
+        XCTAssertEqual(speak("\\sum_{n=1}^{\\infty} \\frac{1}{n^2}"), "sum from n equals 1 to infinity of 1 over n squared")
+        XCTAssertEqual(speak("\\lim_{x \\to 0} \\frac{\\sin x}{x}"), "limit as x approaches 0 of fraction sine x over x end fraction")
+        XCTAssertEqual(speak("\\prod_{i} a_i"), "product from i of a sub i")
+        XCTAssertEqual(speak("f: A \\to B"), "f colon A to B")
+        XCTAssertEqual(speak("\\int f"), "integral of f")
+    }
+
+    func testSymbolsLettersAndText() {
+        XCTAssertEqual(speak("\\alpha^2 + \\Pi"), "alpha squared plus capital pi")
+        XCTAssertEqual(speak("\\varepsilon > 0"), "epsilon greater than 0")
+        XCTAssertEqual(speak("a \\neq b"), "a not equal to b")
+        XCTAssertEqual(speak("\\left( a + b \\right)^2"), "open paren a plus b close paren squared")
+        XCTAssertEqual(speak("\\left. f \\right|_0^1"), "f vertical bar sub 0 to the power 1")
+        XCTAssertEqual(speak("n! \\cdot f'(x)"), "n factorial times f prime open paren x close paren")
+        XCTAssertEqual(speak("\\vec{v} \\cdot \\hat{n}"), "vector v times n hat")
+        XCTAssertEqual(speak("\\text{speed} = 5 \\, \\mathrm{m/s}"), "speed equals 5 m over s")
+        XCTAssertEqual(speak("x \\in \\mathbb{R}"), "x in R")
+        XCTAssertEqual(speak("3.14 \\approx \\pi"), "3.14 approximately equal to pi")
+    }
+
+    func testUnknownCommandsKeepTheirName() {
+        XCTAssertEqual(speak("\\foo{x}"), "foo x")
+    }
+
+    func testScriptsReadSubBeforePowerRegardlessOfOrder() {
+        XCTAssertEqual(speak("x^2_i"), speak("x_i^2"))
+    }
+
+    func testMalformedInputDoesNotCrash() {
+        XCTAssertEqual(speak(""), "")
+        for latex in ["\\frac{1}", "x^", "}{", "\\", "{", "\\sqrt[", "^_^"] {
+            _ = speak(latex)
+        }
+    }
+}


### PR DESCRIPTION
VoiceOver read the raw source of a formula ("frac 1 3", "int underscore 0 caret 1"), which is the parity behavior but not a usable one. The LaTeX module now converts the source to spoken English: fractions, roots, powers and indices, sums/products/integrals/limits with bounds, Greek letters, common relations and functions, decorations, and \text. Compound arguments close with "end fraction" / "end power" so the structure survives being heard; unmapped commands are read by name.

The label template gains a {speech} placeholder and defaults to "Math: {speech}"; {latex} still yields the raw source. A closure overload of .markdownLaTeX and MarkdownRenderer.renderLaTeX lets apps plug in their own converter. The base package is untouched.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

