### PR TITLE
feat(ios): add highlight support

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Resources/sample_markdown.md
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Resources/sample_markdown.md
@@ -142,6 +142,12 @@ Scientific prefixes: 6.022 × 10^23^ (Avogadro's number), the universe is approx
 
 ---
 
+## Highlight
+
+Use ==double equals== to highlight text, and ==**combine it** with other styles== when a phrase needs to stand out.
+
+---
+
 ## Fascinating Forest Facts
 
 Did you know that trees communicate through an underground network? Scientists call this the `Wood Wide Web` — a fungal network connecting tree roots across entire forests.

--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Playground/PlaygroundScreen.swift
@@ -129,7 +129,7 @@ struct PlaygroundScreen: View {
                 } else {
                     EnrichedMarkdownText(
                         markdown,
-                        flags: Md4cFlags(underline: underlineEnabled, superscript: true, subscript: true)
+                        flags: Md4cFlags(underline: underlineEnabled, superscript: true, subscript: true, highlight: true)
                     )
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(14)

--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Text/TextScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Text/TextScreen.swift
@@ -13,7 +13,7 @@ struct TextScreen: View {
 
     var body: some View {
         ScrollView {
-            EnrichedMarkdownText(markdown, flags: Md4cFlags(superscript: true, subscript: true))
+            EnrichedMarkdownText(markdown, flags: Md4cFlags(superscript: true, subscript: true, highlight: true))
                 .markdownTheme(CustomMarkdownTheme)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 16)

--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -145,6 +145,7 @@ The `MarkdownTheme` builder supports these elements:
 | `Underline()` | Underlined text (`Md4cFlags(underline: true)`) |
 | `Superscript()` | Superscript text (`Md4cFlags(superscript: true)`) |
 | `Subscript()` | Subscript text (`Md4cFlags(subscript: true)`) |
+| `Highlight()` | Highlighted text (`Md4cFlags(highlight: true)`) |
 | `Code()` | Inline code |
 | `CodeBlock()` | Fenced code blocks |
 | `Blockquote()` | Block quotes |
@@ -162,7 +163,7 @@ For custom families, `.bold()` picks a bold face from the same `UIFont` family w
 Element-specific modifiers include:
 
 - **Link:** `.underline(_:)`
-- **Code / CodeBlock / Blockquote:** `.background` / `.backgroundStyle`
+- **Code / CodeBlock / Blockquote / Highlight:** `.background` / `.backgroundStyle`
 - **CodeBlock / Blockquote:** `.borderColor`, `.borderWidth`, `.padding` / `.gapWidth`, `.cornerRadius` / `.borderRadius`
 - **List:** `.bulletColor`, `.markerColor`, `.bulletSize`, `.markerMinWidth`, `.gapWidth`, `.marginLeft`
 - **TaskList:** `.checkedColor`, `.borderColor`, `.checkmarkColor`, `.checkboxSize`, `.checkboxBorderRadius`, `.checkedTextColor`, `.checkedStrikethrough`
@@ -199,13 +200,13 @@ public struct Md4cFlags: Equatable, Sendable {
   public var permissiveAutolinks: Bool  // bare URLs become links (default true)
   public var superscript: Bool          // ^text^ renders as superscript
   public var subscript: Bool            // ~text~ renders as subscript
-  public var highlight: Bool
+  public var highlight: Bool            // ==text== renders with a background
 
   public static let commonMark: Md4cFlags
 }
 ```
 
-`underline`, `hardSoftBreaks`, `preserveBlankLines`, `permissiveAutolinks`, `superscript`, and `subscript` affect rendering. The remaining flags gate parsing only — their content currently renders as plain text. Tables, task lists, and strikethrough are always enabled and need no flags.
+`underline`, `hardSoftBreaks`, `preserveBlankLines`, `permissiveAutolinks`, `superscript`, `subscript`, and `highlight` affect rendering. The remaining flags gate parsing only — their content currently renders as plain text. Tables, task lists, and strikethrough are always enabled and need no flags.
 
 ### `.markdownTheme`
 
@@ -369,6 +370,7 @@ and dark mode.
 - Underline (`__text__` with `Md4cFlags(underline: true)`)
 - Superscript (`^text^` with `Md4cFlags(superscript: true)`)
 - Subscript (`~text~` with `Md4cFlags(subscript: true)`)
+- Highlight (`==text==` with `Md4cFlags(highlight: true)`)
 - Fenced code blocks
 - Block quotes
 - Ordered and unordered lists

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownExtractor.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownExtractor.swift
@@ -108,6 +108,7 @@ extension MarkdownExtractor {
         let isUnderline: Bool
         let isSuperscript: Bool
         let isSubscript: Bool
+        let isHighlight: Bool
         let linkURL: String?
 
         init(attrs: [NSAttributedString.Key: Any]) {
@@ -118,6 +119,7 @@ extension MarkdownExtractor {
             isUnderline = (MarkdownAttributeValue.intValue(from: attrs[.underlineStyle]) ?? 0) != 0
             isSuperscript = MarkdownAttributeValue.boolValue(from: attrs[MarkdownAttribute.superscript])
             isSubscript = MarkdownAttributeValue.boolValue(from: attrs[MarkdownAttribute.subscript])
+            isHighlight = MarkdownAttributeValue.boolValue(from: attrs[MarkdownAttribute.highlight])
 
             switch attrs[.link] {
             case let url as URL:
@@ -455,6 +457,9 @@ private extension MarkdownExtractor {
         }
         if let linkURL = traits.linkURL {
             result = "[\(result)](\(linkURL))"
+        }
+        if traits.isHighlight {
+            result = "==\(result)=="
         }
 
         return result

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator+Styles.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator+Styles.swift
@@ -1,0 +1,124 @@
+import UIKit
+
+extension MarkdownHTMLGenerator {
+    struct CachedStyles {
+        let paragraphColor: String
+        let paragraphFontSize: Int
+        let paragraphMarginBottom: Int
+
+        let codeBlockColor: String
+        let codeBlockBgColor: String
+        let codeBlockFontSize: Int
+        let codeBlockPadding: Int
+        let codeBlockBorderRadius: Int
+        let codeBlockMarginBottom: Int
+
+        let codeColor: String
+        let codeBgColor: String
+
+        let highlightOpenTag: String
+
+        let blockquoteColor: String
+        let blockquoteBgColor: String
+        let blockquoteBorderColor: String
+        let blockquoteBorderWidth: Int
+        let blockquoteGapWidth: Int
+        let blockquoteMarginBottom: Int
+        let blockquoteFontSize: Int
+
+        let listColor: String
+        let listFontSize: Int
+        let listMarginBottom: Int
+        let listMarginLeft: Int
+
+        let linkColor: String
+        let linkUnderline: Bool
+
+        let strongColor: String?
+        let emphasisColor: String?
+
+        let imageMarginBottom: Int
+        let imageBorderRadius: Int
+
+        let headingFontSizes: [Int]
+        let headingFontWeights: [String]
+        let headingColors: [String]
+        let headingMarginBottoms: [Int]
+
+        init(config: MarkdownStyleConfig) {
+            let bodySize = Int(UIFont.preferredFont(forTextStyle: .body).pointSize)
+
+            paragraphColor = cssColor(config.paragraph.foregroundColor)
+            paragraphFontSize = config.paragraph.font.map { Int($0.pointSize) } ?? bodySize
+            paragraphMarginBottom = Int(config.paragraph.marginBottom ?? 0)
+
+            codeBlockColor = cssColor(config.codeBlock.foregroundColor)
+            codeBlockBgColor = cssColor(config.codeBlock.backgroundColor)
+            codeBlockFontSize = config.codeBlock.font.map { Int($0.pointSize) } ?? bodySize
+            codeBlockPadding = Int(config.codeBlock.padding ?? 0)
+            codeBlockBorderRadius = Int(config.codeBlock.borderRadius ?? 0)
+            codeBlockMarginBottom = Int(config.codeBlock.marginBottom ?? 0)
+
+            codeColor = cssColor(config.code.foregroundColor)
+            codeBgColor = cssColor(config.code.backgroundColor)
+
+            let highlightStyle = [
+                config.highlight.backgroundColor.map { "background-color: \(cssColor($0));" },
+                config.highlight.foregroundColor.map { "color: \(cssColor($0));" }
+            ].compactMap { $0 }.joined(separator: " ")
+            highlightOpenTag = highlightStyle.isEmpty ? "<mark>" : "<mark style=\"\(highlightStyle)\">"
+
+            blockquoteColor = cssColor(config.blockquote.foregroundColor)
+            blockquoteBgColor = cssColor(config.blockquote.backgroundColor)
+            blockquoteBorderColor = cssColor(config.blockquote.borderColor)
+            blockquoteBorderWidth = Int(config.blockquote.borderWidth ?? 0)
+            blockquoteGapWidth = Int(config.blockquote.gapWidth ?? 0)
+            blockquoteMarginBottom = Int(config.blockquote.marginBottom ?? 0)
+            blockquoteFontSize = config.blockquote.font.map { Int($0.pointSize) } ?? bodySize
+
+            listColor = cssColor(config.list.foregroundColor)
+            listFontSize = config.list.font.map { Int($0.pointSize) } ?? bodySize
+            listMarginBottom = Int(config.list.marginBottom ?? 0)
+            listMarginLeft = Int(config.list.marginLeft ?? 24)
+
+            linkColor = cssColor(config.link.foregroundColor)
+            linkUnderline = config.link.underline ?? true
+
+            strongColor = config.strong.foregroundColor.map(cssColor)
+            emphasisColor = config.emphasis.foregroundColor.map(cssColor)
+
+            imageMarginBottom = Int(config.image.marginBottom ?? 0)
+            imageBorderRadius = Int(config.image.borderRadius ?? 0)
+
+            let headings = [
+                config.heading1, config.heading2, config.heading3,
+                config.heading4, config.heading5, config.heading6
+            ]
+            headingFontSizes = headings.map { $0.font.map { Int($0.pointSize) } ?? bodySize }
+            headingFontWeights = headings.map { heading in
+                let isBold = heading.font?.fontDescriptor.symbolicTraits.contains(.traitBold) ?? true
+                return isBold ? "700" : "normal"
+            }
+            headingColors = headings.map { cssColor($0.foregroundColor) }
+            headingMarginBottoms = headings.map { Int($0.marginBottom ?? 0) }
+        }
+    }
+
+    private static func cssColor(_ color: UIColor?) -> String {
+        guard let color else { return "inherit" }
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return "inherit" }
+
+        let redByte = Int(round(min(max(red, 0), 1) * 255))
+        let greenByte = Int(round(min(max(green, 0), 1) * 255))
+        let blueByte = Int(round(min(max(blue, 0), 1) * 255))
+        if alpha < 1 {
+            let alphaString = String(format: "%.2f", alpha)
+            return "rgba(\(redByte), \(greenByte), \(blueByte), \(alphaString))"
+        }
+        return String(format: "#%02X%02X%02X", redByte, greenByte, blueByte)
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownHTMLGenerator.swift
@@ -445,6 +445,9 @@ enum MarkdownHTMLGenerator {
         }
 
         var tags: [(open: String, close: String)] = []
+        if MarkdownAttributeValue.boolValue(from: attrs[MarkdownAttribute.highlight]) {
+            tags.append((open: styles.highlightOpenTag, close: "</mark>"))
+        }
         if let linkURL {
             let open = "<a href=\"\(escapeHTML(linkURL))\" style=\"color: \(styles.linkColor); "
                 + "text-decoration: \(styles.linkUnderline ? "underline" : "none");\">"
@@ -479,122 +482,4 @@ enum MarkdownHTMLGenerator {
         }
         return tags
     }
-
-    // MARK: - Styles
-
-    private struct CachedStyles {
-        let paragraphColor: String
-        let paragraphFontSize: Int
-        let paragraphMarginBottom: Int
-
-        let codeBlockColor: String
-        let codeBlockBgColor: String
-        let codeBlockFontSize: Int
-        let codeBlockPadding: Int
-        let codeBlockBorderRadius: Int
-        let codeBlockMarginBottom: Int
-
-        let codeColor: String
-        let codeBgColor: String
-
-        let blockquoteColor: String
-        let blockquoteBgColor: String
-        let blockquoteBorderColor: String
-        let blockquoteBorderWidth: Int
-        let blockquoteGapWidth: Int
-        let blockquoteMarginBottom: Int
-        let blockquoteFontSize: Int
-
-        let listColor: String
-        let listFontSize: Int
-        let listMarginBottom: Int
-        let listMarginLeft: Int
-
-        let linkColor: String
-        let linkUnderline: Bool
-
-        let strongColor: String?
-        let emphasisColor: String?
-
-        let imageMarginBottom: Int
-        let imageBorderRadius: Int
-
-        let headingFontSizes: [Int]
-        let headingFontWeights: [String]
-        let headingColors: [String]
-        let headingMarginBottoms: [Int]
-
-        init(config: MarkdownStyleConfig) {
-            let bodySize = Int(UIFont.preferredFont(forTextStyle: .body).pointSize)
-
-            paragraphColor = cssColor(config.paragraph.foregroundColor)
-            paragraphFontSize = config.paragraph.font.map { Int($0.pointSize) } ?? bodySize
-            paragraphMarginBottom = Int(config.paragraph.marginBottom ?? 0)
-
-            codeBlockColor = cssColor(config.codeBlock.foregroundColor)
-            codeBlockBgColor = cssColor(config.codeBlock.backgroundColor)
-            codeBlockFontSize = config.codeBlock.font.map { Int($0.pointSize) } ?? bodySize
-            codeBlockPadding = Int(config.codeBlock.padding ?? 0)
-            codeBlockBorderRadius = Int(config.codeBlock.borderRadius ?? 0)
-            codeBlockMarginBottom = Int(config.codeBlock.marginBottom ?? 0)
-
-            codeColor = cssColor(config.code.foregroundColor)
-            codeBgColor = cssColor(config.code.backgroundColor)
-
-            blockquoteColor = cssColor(config.blockquote.foregroundColor)
-            blockquoteBgColor = cssColor(config.blockquote.backgroundColor)
-            blockquoteBorderColor = cssColor(config.blockquote.borderColor)
-            blockquoteBorderWidth = Int(config.blockquote.borderWidth ?? 0)
-            blockquoteGapWidth = Int(config.blockquote.gapWidth ?? 0)
-            blockquoteMarginBottom = Int(config.blockquote.marginBottom ?? 0)
-            blockquoteFontSize = config.blockquote.font.map { Int($0.pointSize) } ?? bodySize
-
-            listColor = cssColor(config.list.foregroundColor)
-            listFontSize = config.list.font.map { Int($0.pointSize) } ?? bodySize
-            listMarginBottom = Int(config.list.marginBottom ?? 0)
-            listMarginLeft = Int(config.list.marginLeft ?? 24)
-
-            linkColor = cssColor(config.link.foregroundColor)
-            linkUnderline = config.link.underline ?? true
-
-            strongColor = config.strong.foregroundColor.map(cssColor)
-            emphasisColor = config.emphasis.foregroundColor.map(cssColor)
-
-            imageMarginBottom = Int(config.image.marginBottom ?? 0)
-            imageBorderRadius = Int(config.image.borderRadius ?? 0)
-
-            let headings = [
-                config.heading1, config.heading2, config.heading3,
-                config.heading4, config.heading5, config.heading6
-            ]
-            headingFontSizes = headings.map { $0.font.map { Int($0.pointSize) } ?? bodySize }
-            headingFontWeights = headings.map { heading in
-                let isBold = heading.font?.fontDescriptor.symbolicTraits.contains(.traitBold) ?? true
-                return isBold ? "700" : "normal"
-            }
-            headingColors = headings.map { cssColor($0.foregroundColor) }
-            headingMarginBottoms = headings.map { Int($0.marginBottom ?? 0) }
-        }
-    }
-
-    // MARK: - Helpers
-
-    private static func cssColor(_ color: UIColor?) -> String {
-        guard let color else { return "inherit" }
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-        guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return "inherit" }
-
-        let redByte = Int(round(min(max(red, 0), 1) * 255))
-        let greenByte = Int(round(min(max(green, 0), 1) * 255))
-        let blueByte = Int(round(min(max(blue, 0), 1) * 255))
-        if alpha < 1 {
-            let alphaString = String(format: "%.2f", alpha)
-            return "rgba(\(redByte), \(greenByte), \(blueByte), \(alphaString))"
-        }
-        return String(format: "#%02X%02X%02X", redByte, greenByte, blueByte)
-    }
-
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownSourceSlicer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Extraction/MarkdownSourceSlicer.swift
@@ -159,6 +159,7 @@ private extension MarkdownSourceSlicer {
         case underline
         case emphasis
         case strong
+        case highlight
         case link
         case image
 
@@ -169,6 +170,7 @@ private extension MarkdownSourceSlicer {
             case .underline: return .underlineStyle
             case .emphasis: return MarkdownAttribute.emphasis
             case .strong: return MarkdownAttribute.strong
+            case .highlight: return MarkdownAttribute.highlight
             case .link: return .link
             case .image: return .attachment
             }
@@ -188,6 +190,7 @@ private extension MarkdownSourceSlicer {
             case .underline: return traits.isUnderline && traits.linkURL == nil
             case .emphasis: return traits.isEmphasis
             case .strong: return traits.isStrong
+            case .highlight: return traits.isHighlight
             case .link: return traits.linkURL != nil
             case .image: return attrs[.attachment] is MarkdownImageAttachment
             }
@@ -205,6 +208,8 @@ private extension MarkdownSourceSlicer {
             case .emphasis, .strong:
                 let markers = self == .strong ? ["**", "__"] : ["*", "_"]
                 return MarkdownSourceSlicer.matchAnyBackward(markers, in: bytes, before: index)
+            case .highlight:
+                return MarkdownSourceSlicer.matchBackward("==", in: bytes, before: index)
             case .link:
                 return MarkdownSourceSlicer.matchBackward("[", in: bytes, before: index)
             case .image:
@@ -224,6 +229,8 @@ private extension MarkdownSourceSlicer {
             case .emphasis, .strong:
                 let markers = self == .strong ? ["**", "__"] : ["*", "_"]
                 return MarkdownSourceSlicer.matchAnyForward(markers, in: bytes, at: index)
+            case .highlight:
+                return MarkdownSourceSlicer.matchForward("==", in: bytes, at: index)
             case .link, .image:
                 return MarkdownSourceSlicer.consumeLinkSuffix(in: bytes, from: index)
             }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
@@ -29,6 +29,7 @@ enum MarkdownAttribute {
     static let emphasis = NSAttributedString.Key("EnrichedMarkdownEmphasis")
     static let superscript = NSAttributedString.Key("EnrichedMarkdownSuperscript")
     static let `subscript` = NSAttributedString.Key("EnrichedMarkdownSubscript")
+    static let highlight = NSAttributedString.Key("EnrichedMarkdownHighlight")
     static let blockquoteDepth = NSAttributedString.Key("EnrichedMarkdownBlockquoteDepth")
     static let blockquoteBackgroundColor = NSAttributedString.Key("EnrichedMarkdownBlockquoteBackgroundColor")
     static let listDepth = NSAttributedString.Key("EnrichedMarkdownListDepth")
@@ -120,6 +121,16 @@ package final class RenderContext {
 
     static func shouldPreserveColors(_ attributes: [NSAttributedString.Key: Any]) -> Bool {
         attributes[.link] != nil || attributes[MarkdownAttribute.inlineCode] != nil
+    }
+
+    /// Recolors `range` to `color`, leaving links and inline code on their own colors.
+    static func applyForegroundColor(_ color: UIColor, to output: NSMutableAttributedString, in range: NSRange) {
+        output.enumerateAttributes(in: range, options: []) { attributes, subrange, _ in
+            guard !shouldPreserveColors(attributes) else { return }
+            if (attributes[.foregroundColor] as? UIColor) != color {
+                output.addAttribute(.foregroundColor, value: color, range: subrange)
+            }
+        }
     }
 
     static func rangeForRenderedContent(in output: NSMutableAttributedString, start: Int) -> NSRange {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RendererFactory.swift
@@ -71,6 +71,8 @@ final class RendererFactory {
             return BaselineShiftRenderer(factory: self, attributeKey: MarkdownAttribute.superscript)
         case .subscript:
             return BaselineShiftRenderer(factory: self, attributeKey: MarkdownAttribute.subscript)
+        case .highlight:
+            return HighlightRenderer(factory: self, config: config)
         case .link:
             return LinkRenderer(factory: self, config: config)
         case .lineBreak:

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/HighlightRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/HighlightRenderer.swift
@@ -1,0 +1,37 @@
+import UIKit
+
+final class HighlightRenderer: NodeRenderer {
+    private let factory: RendererFactory
+    private let config: MarkdownStyleConfig
+
+    init(factory: RendererFactory, config: MarkdownStyleConfig) {
+        self.factory = factory
+        self.config = config
+    }
+
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        let start = output.length
+        factory.renderChildren(of: node, into: output, context: context)
+
+        let range = RenderContext.rangeForRenderedContent(in: output, start: start)
+        guard range.length > 0 else { return }
+
+        output.addAttribute(MarkdownAttribute.highlight, value: true, range: range)
+
+        if let backgroundColor = config.highlight.backgroundColor {
+            // Inline code keeps its own background box; links still sit on the highlight.
+            output.enumerateAttribute(MarkdownAttribute.inlineCode, in: range, options: []) { value, subrange, _ in
+                guard value == nil else { return }
+                output.addAttribute(.backgroundColor, value: backgroundColor, range: subrange)
+            }
+        }
+
+        let blockColor = context.getBlockStyle()?.color ?? UIColor.label
+        if let highlightColor = RenderContext.calculateStrongColor(
+            configColor: config.highlight.foregroundColor,
+            blockColor: blockColor
+        ) {
+            RenderContext.applyForegroundColor(highlightColor, to: output, in: range)
+        }
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/StrikethroughRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/StrikethroughRenderer.swift
@@ -18,15 +18,8 @@ final class StrikethroughRenderer: NodeRenderer {
 
         output.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: range)
 
-        guard let strikethroughColor = config.strikethrough.foregroundColor else { return }
-
-        output.enumerateAttributes(in: range, options: []) { attributes, subrange, _ in
-            guard !RenderContext.shouldPreserveColors(attributes) else { return }
-
-            let currentColor = attributes[.foregroundColor] as? UIColor
-            if currentColor != strikethroughColor {
-                output.addAttribute(.foregroundColor, value: strikethroughColor, range: subrange)
-            }
+        if let strikethroughColor = config.strikethrough.foregroundColor {
+            RenderContext.applyForegroundColor(strikethroughColor, to: output, in: range)
         }
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/UnderlineRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/UnderlineRenderer.swift
@@ -18,15 +18,8 @@ final class UnderlineRenderer: NodeRenderer {
 
         output.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
 
-        guard let underlineColor = config.underline.foregroundColor else { return }
-
-        output.enumerateAttributes(in: range, options: []) { attributes, subrange, _ in
-            guard !RenderContext.shouldPreserveColors(attributes) else { return }
-
-            let currentColor = attributes[.foregroundColor] as? UIColor
-            if currentColor != underlineColor {
-                output.addAttribute(.foregroundColor, value: underlineColor, range: subrange)
-            }
+        if let underlineColor = config.underline.foregroundColor {
+            RenderContext.applyForegroundColor(underlineColor, to: output, in: range)
         }
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/BackgroundThemeElement.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/BackgroundThemeElement.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+public protocol BackgroundThemeElement: MarkdownThemeContent {
+    var backgroundColorSpec: ThemeColorSpec? { get set }
+}
+
+public extension BackgroundThemeElement {
+    func backgroundStyle(_ color: Color) -> Self {
+        var copy = self
+        copy.backgroundColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    func backgroundStyle(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.backgroundColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    func background(_ color: Color) -> Self {
+        backgroundStyle(color)
+    }
+
+    func background(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        backgroundStyle(semantic)
+    }
+
+    func applyBackgroundColor(to color: inout UIColor?, traitCollection: UITraitCollection) {
+        if let backgroundColorSpec {
+            color = backgroundColorSpec.resolve(traitCollection: traitCollection)
+        }
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/DefaultMarkdownTheme.swift
@@ -56,6 +56,9 @@ enum DefaultMarkdownTheme {
             Superscript()
             Subscript()
 
+            // #FEF08A, the highlight background shared with the React Native package.
+            Highlight().background(Color(red: 254 / 255, green: 240 / 255, blue: 138 / 255))
+
             Code()
                 .fontDesign(.monospaced)
                 .foregroundStyle(Semantic.secondary)

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/Blockquote.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/Blockquote.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct Blockquote: MarkdownThemeElement {
+public struct Blockquote: MarkdownThemeElement, BackgroundThemeElement {
     public var fontSpec: ThemeFontSpec?
     public var fontWeight: Font.Weight?
     public var fontDesign: Font.Design?
@@ -15,26 +15,6 @@ public struct Blockquote: MarkdownThemeElement {
     public var gapWidth: CGFloat?
 
     public init() {}
-
-    public func backgroundStyle(_ color: Color) -> Self {
-        var copy = self
-        copy.backgroundColorSpec = ThemeColorModifiers.spec(from: color)
-        return copy
-    }
-
-    public func backgroundStyle(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
-        var copy = self
-        copy.backgroundColorSpec = ThemeColorModifiers.spec(from: semantic)
-        return copy
-    }
-
-    public func background(_ color: Color) -> Self {
-        backgroundStyle(color)
-    }
-
-    public func background(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
-        backgroundStyle(semantic)
-    }
 
     public func borderColor(_ color: Color) -> Self {
         var copy = self
@@ -73,9 +53,7 @@ public struct Blockquote: MarkdownThemeElement {
         if let foregroundColorSpec {
             config.blockquote.foregroundColor = foregroundColorSpec.resolve(traitCollection: traitCollection)
         }
-        if let backgroundColorSpec {
-            config.blockquote.backgroundColor = backgroundColorSpec.resolve(traitCollection: traitCollection)
-        }
+        applyBackgroundColor(to: &config.blockquote.backgroundColor, traitCollection: traitCollection)
         if let borderColorSpec {
             config.blockquote.borderColor = borderColorSpec.resolve(traitCollection: traitCollection)
         }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/CodeBlock.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/CodeBlock.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct CodeBlock: MarkdownThemeContent {
+public struct CodeBlock: MarkdownThemeContent, BackgroundThemeElement {
     public var fontSpec: ThemeFontSpec?
     public var fontWeight: Font.Weight?
     public var fontDesign: Font.Design?
@@ -51,26 +51,6 @@ public struct CodeBlock: MarkdownThemeContent {
         var copy = self
         copy.foregroundColorSpec = ThemeColorModifiers.spec(from: semantic)
         return copy
-    }
-
-    public func backgroundStyle(_ color: Color) -> Self {
-        var copy = self
-        copy.backgroundColorSpec = ThemeColorModifiers.spec(from: color)
-        return copy
-    }
-
-    public func backgroundStyle(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
-        var copy = self
-        copy.backgroundColorSpec = ThemeColorModifiers.spec(from: semantic)
-        return copy
-    }
-
-    public func background(_ color: Color) -> Self {
-        backgroundStyle(color)
-    }
-
-    public func background(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
-        backgroundStyle(semantic)
     }
 
     public func borderColor(_ color: Color) -> Self {
@@ -138,9 +118,7 @@ public struct CodeBlock: MarkdownThemeContent {
         if let foregroundColorSpec {
             config.codeBlock.foregroundColor = foregroundColorSpec.resolve(traitCollection: traitCollection)
         }
-        if let backgroundColorSpec {
-            config.codeBlock.backgroundColor = backgroundColorSpec.resolve(traitCollection: traitCollection)
-        }
+        applyBackgroundColor(to: &config.codeBlock.backgroundColor, traitCollection: traitCollection)
         if let borderColorSpec {
             config.codeBlock.borderColor = borderColorSpec.resolve(traitCollection: traitCollection)
         }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/Highlight.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/Elements/Highlight.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct Code: MarkdownThemeElement, BackgroundThemeElement {
+public struct Highlight: MarkdownThemeElement, BackgroundThemeElement {
     public var fontSpec: ThemeFontSpec?
     public var fontWeight: Font.Weight?
     public var fontDesign: Font.Design?
@@ -11,12 +11,10 @@ public struct Code: MarkdownThemeElement, BackgroundThemeElement {
     public var lineHeight: CGFloat?
     public var textAlignment: TextAlignment?
 
-    public init() {
-        fontDesign = .monospaced
-    }
+    public init() {}
 
     public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
-        applyElementStyle(to: &config.code, traitCollection: traitCollection)
-        applyBackgroundColor(to: &config.code.backgroundColor, traitCollection: traitCollection)
+        applyElementStyle(to: &config.highlight, traitCollection: traitCollection)
+        applyBackgroundColor(to: &config.highlight.backgroundColor, traitCollection: traitCollection)
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
@@ -407,6 +407,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
     public var underline: ElementStyle
     public var superscript: BaselineShiftStyle
     public var `subscript`: BaselineShiftStyle
+    public var highlight: ElementStyle
     public var code: ElementStyle
     public var image: ImageStyle
     public var inlineImage: InlineImageStyle
@@ -432,6 +433,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         underline: ElementStyle = ElementStyle(),
         superscript: BaselineShiftStyle = BaselineShiftStyle(),
         subscript subscriptStyle: BaselineShiftStyle = BaselineShiftStyle(),
+        highlight: ElementStyle = ElementStyle(),
         code: ElementStyle = ElementStyle(),
         image: ImageStyle = ImageStyle(),
         inlineImage: InlineImageStyle = InlineImageStyle(),
@@ -456,6 +458,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         self.underline = underline
         self.superscript = superscript
         self.subscript = subscriptStyle
+        self.highlight = highlight
         self.code = code
         self.image = image
         self.inlineImage = inlineImage
@@ -482,6 +485,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         underline.merge(other.underline)
         superscript.merge(other.superscript)
         self.subscript.merge(other.subscript)
+        highlight.merge(other.highlight)
         code.merge(other.code)
         image.merge(other.image)
         inlineImage.merge(other.inlineImage)

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/HTMLGeneratorTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/HTMLGeneratorTests.swift
@@ -86,6 +86,15 @@ final class HTMLGeneratorTests: XCTestCase {
         XCTAssertTrue(result.contains("<sub>2</sub>"))
     }
 
+    func testHighlightEmitsMarkWithBackground() {
+        config.highlight.backgroundColor = UIColor(red: 1, green: 0, blue: 0, alpha: 1)
+        config.highlight.foregroundColor = nil
+
+        let result = html(for: "==marked==", flags: Md4cFlags(highlight: true))
+
+        XCTAssertTrue(result.contains("<mark style=\"background-color: #FF0000;\">marked</mark>"))
+    }
+
     func testLinkCarriesHrefAndStyle() {
         let result = html(for: "[press](https://swmansion.com)")
 

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/InlineStyleRendererTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/InlineStyleRendererTests.swift
@@ -161,7 +161,95 @@ final class InlineStyleRendererTests: XCTestCase {
         XCTAssertEqual(baselineOffset(onWord: "t", in: result) - baseOffset, -baseSize * 0.3, accuracy: 0.001)
     }
 
+    // MARK: - Highlight
+
+    func testEqualsRenderLiterallyWithoutFlag() {
+        let result = MarkdownRenderer.render("==marked== plain", config: config)
+        XCTAssertTrue(result.string.contains("==marked=="))
+
+        let withoutFlag = Parser.shared.parseMarkdown("==marked==")
+        XCTAssertNil(withoutFlag.first(ofType: .highlight))
+    }
+
+    func testHighlightAppliesBackgroundAndMarkerOnlyToSpan() {
+        var highlightConfig = config!
+        highlightConfig.highlight.backgroundColor = .systemYellow
+
+        let result = MarkdownRenderer.render(
+            "==marked== plain",
+            config: highlightConfig,
+            flags: Md4cFlags(highlight: true)
+        )
+
+        XCTAssertEqual(backgroundColor(onWord: "marked", in: result), .systemYellow)
+        XCTAssertTrue(MarkdownAttributeValue.boolValue(from: attribute(MarkdownAttribute.highlight, onWord: "marked", in: result)))
+        XCTAssertNil(backgroundColor(onWord: "plain", in: result))
+        XCTAssertNil(attribute(MarkdownAttribute.highlight, onWord: "plain", in: result))
+    }
+
+    func testHighlightInheritsTextColorUnlessOverridden() {
+        let flags = Md4cFlags(highlight: true)
+        let inherited = MarkdownRenderer.render("==marked==", config: config, flags: flags)
+        XCTAssertEqual(foregroundColor(onWord: "marked", in: inherited), config.paragraph.foregroundColor)
+
+        var coloredConfig = config!
+        coloredConfig.highlight.foregroundColor = .systemRed
+        let overridden = MarkdownRenderer.render("==marked==", config: coloredConfig, flags: flags)
+        XCTAssertEqual(foregroundColor(onWord: "marked", in: overridden), .systemRed)
+    }
+
+    func testHighlightPreservesBoldAndInlineCode() {
+        var highlightConfig = config!
+        highlightConfig.highlight.backgroundColor = .systemYellow
+        highlightConfig.code.backgroundColor = .systemGray
+
+        let result = MarkdownRenderer.render(
+            "==**both** and `code`==",
+            config: highlightConfig,
+            flags: Md4cFlags(highlight: true)
+        )
+
+        let font = attribute(.font, onWord: "both", in: result) as? UIFont
+        XCTAssertTrue(font?.fontDescriptor.symbolicTraits.contains(.traitBold) == true)
+        XCTAssertEqual(backgroundColor(onWord: "both", in: result), .systemYellow)
+        XCTAssertEqual(backgroundColor(onWord: "code", in: result), .systemGray)
+    }
+
+    func testHighlightedLinkKeepsLinkColorOnHighlightBackground() {
+        var highlightConfig = config!
+        highlightConfig.highlight.backgroundColor = .systemYellow
+        highlightConfig.highlight.foregroundColor = .systemRed
+        highlightConfig.link.foregroundColor = .systemBlue
+
+        let result = MarkdownRenderer.render(
+            "==[press](https://swmansion.com)==",
+            config: highlightConfig,
+            flags: Md4cFlags(highlight: true)
+        )
+
+        XCTAssertEqual(backgroundColor(onWord: "press", in: result), .systemYellow)
+        XCTAssertEqual(foregroundColor(onWord: "press", in: result), .systemBlue)
+    }
+
     // MARK: - Theme resolution
+
+    func testHighlightThemeElementResolves() {
+        let theme = MarkdownTheme {
+            Highlight()
+                .foregroundStyle(Color.black)
+                .background(Color.yellow)
+        }
+        let resolved = MarkdownStyleConfig.resolve(layers: [theme], traitCollection: .current)
+
+        XCTAssertNotNil(resolved.highlight.foregroundColor)
+        XCTAssertNotNil(resolved.highlight.backgroundColor)
+    }
+
+    func testDefaultThemeGivesHighlightABackground() {
+        let resolved = MarkdownStyleConfig.baseline()
+        XCTAssertNotNil(resolved.highlight.backgroundColor)
+        XCTAssertNil(resolved.highlight.foregroundColor)
+    }
 
     func testSuperscriptAndSubscriptThemeElementsResolve() {
         let theme = MarkdownTheme {
@@ -196,15 +284,26 @@ final class InlineStyleRendererTests: XCTestCase {
     // MARK: - Helpers
 
     private func fontSize(onWord word: String, in attributed: NSAttributedString) -> CGFloat {
-        let range = rangeOfWord(word, in: attributed)
-        let font = attributed.attribute(.font, at: range.location, effectiveRange: nil) as? UIFont
+        let font = attribute(.font, onWord: word, in: attributed) as? UIFont
         XCTAssertNotNil(font, "expected a font on '\(word)'")
         return font?.pointSize ?? 0
     }
 
-    private func baselineOffset(onWord word: String, in attributed: NSAttributedString) -> CGFloat {
+    private func attribute(_ key: NSAttributedString.Key, onWord word: String, in attributed: NSAttributedString) -> Any? {
         let range = rangeOfWord(word, in: attributed)
-        let offset = attributed.attribute(.baselineOffset, at: range.location, effectiveRange: nil) as? NSNumber
+        return attributed.attribute(key, at: range.location, effectiveRange: nil)
+    }
+
+    private func backgroundColor(onWord word: String, in attributed: NSAttributedString) -> UIColor? {
+        attribute(.backgroundColor, onWord: word, in: attributed) as? UIColor
+    }
+
+    private func foregroundColor(onWord word: String, in attributed: NSAttributedString) -> UIColor? {
+        attribute(.foregroundColor, onWord: word, in: attributed) as? UIColor
+    }
+
+    private func baselineOffset(onWord word: String, in attributed: NSAttributedString) -> CGFloat {
+        let offset = attribute(.baselineOffset, onWord: word, in: attributed) as? NSNumber
         return CGFloat(offset?.doubleValue ?? 0)
     }
 

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownExtractorTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownExtractorTests.swift
@@ -248,6 +248,13 @@ final class MarkdownExtractorTests: XCTestCase {
         )
     }
 
+    func testExtractsHighlight() {
+        XCTAssertEqual(
+            extractSelecting("marked", in: "Some ==marked== text.", flags: Md4cFlags(highlight: true)),
+            "==marked=="
+        )
+    }
+
     func testLinkIsNotWrappedInUnderline() {
         XCTAssertEqual(
             extractSelecting("swmansion", in: "Visit [swmansion](https://swmansion.com) now."),

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownSourceSlicerTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownSourceSlicerTests.swift
@@ -81,6 +81,13 @@ final class MarkdownSourceSlicerTests: XCTestCase {
         )
     }
 
+    func testFullySelectedHighlightKeepsMarkers() {
+        XCTAssertEqual(
+            copyMarkdown(selecting: "marked", in: "some ==marked== text", flags: Md4cFlags(highlight: true)),
+            "==marked=="
+        )
+    }
+
     func testFullySelectedUnderlineKeepsUnderscoreMarkers() {
         let flags = Md4cFlags(underline: true)
         XCTAssertEqual(


### PR DESCRIPTION
Render ==text== (behind Md4cFlags(highlight: true)) with a background color, themeable via Highlight() and defaulting to the same #FEF08A as the React Native package. Inline code inside a highlight keeps its own background box; links keep their color but sit on the highlight. The span round-trips through copy as Markdown, source-faithful slicing, and copy as HTML (<mark>).

Along the way, share the background modifiers between Code, CodeBlock, Blockquote, and Highlight through BackgroundThemeElement, share the foreground recolor pass between underline, strikethrough, and highlight, and move the HTML generator's style cache into its own file.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

