### PR TITLE
feat(ios): theme LaTeX math with MathBlock and InlineMath elements

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Math/MathScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Math/MathScreen.swift
@@ -28,14 +28,40 @@ $$\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}$$
 Source that fails to typeset falls back to plain text: $\frac{1}{$
 """#
 
+/// Overrides `MarkdownTheme.latexDefault` (20pt, centered, quaternary panel)
+/// to show the `MathBlock` / `InlineMath` modifiers.
+private let customMathTheme = MarkdownTheme {
+    MathBlock()
+        .fontSize(24)
+        .foregroundStyle(Color.brandNavy)
+        .background(Color.brandNavy.opacity(0.08))
+        .padding(20)
+        .marginBottom(24)
+        .textAlignment(.leading)
+
+    InlineMath()
+        .foregroundStyle(Color.brandNavy)
+}
+
+/// Leaves `MarkdownTheme.latexDefault` in effect.
+private let noOverrides = MarkdownTheme {}
+
 struct MathScreen: View {
+    @State private var usesCustomTheme: Bool = false
+
     var body: some View {
         ScrollView {
-            EnrichedMarkdownText(sampleMathMarkdown)
-                .markdownLaTeX()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 16)
+            VStack(alignment: .leading, spacing: 16) {
+                Toggle("Custom math theme", isOn: $usesCustomTheme)
+                    .accessibilityIdentifier("math-custom-theme-toggle")
+
+                EnrichedMarkdownText(sampleMathMarkdown)
+                    .markdownLaTeX()
+                    .markdownTheme(usesCustomTheme ? customMathTheme : noOverrides)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
         }
         .background(Color.white)
     }

--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -12,7 +12,7 @@ Standalone SwiftUI library for rendering enriched Markdown on iOS. This package 
 
 Add the package via [Swift Package Manager](https://docs.swift.org/latest/documentation/packagemanagerdocs/). The `Package.swift` lives at the repository root.
 
-**Xcode:** File → Add Package Dependencies… → enter `https://github.com/software-mansion-labs/enriched-markdown-ios`, then select the `EnrichedMarkdown` product.
+**Xcode:** File → Add Package Dependencies… → enter `https://github.com/software-mansion-labs/enriched-markdown-ios`, then select the `EnrichedMarkdown` product (and `EnrichedMarkdownLaTeX` for math, see [LaTeX math](#latex-math)).
 
 **Package.swift:**
 
@@ -154,6 +154,8 @@ The `MarkdownTheme` builder supports these elements:
 | `BlockImage()` | Block images |
 | `InlineImage()` | Inline images |
 | `ThematicBreak()` | Horizontal rules |
+| `MathBlock()` | Root-level `$$…$$` display math (`EnrichedMarkdownLaTeX`, see [LaTeX math](#latex-math)) |
+| `InlineMath()` | `$…$` math in running text (`EnrichedMarkdownLaTeX`) |
 
 Common modifiers (available on most elements): `.font`, `.fontFamily(_:size:)`, `.fontSize`, `.bold`, `.fontDesign`, `.foregroundStyle`, `.marginTop`, `.marginBottom`, `.lineHeight`, `.textAlignment`.
 
@@ -171,6 +173,8 @@ Element-specific modifiers include:
 - **BlockImage:** `.height`, `.borderRadius`
 - **InlineImage:** `.size`
 - **ThematicBreak:** `.color` / `.foregroundStyle`, `.height`
+- **MathBlock:** `.fontSize`, `.foregroundStyle`, `.background` / `.backgroundStyle`, `.padding`, `.marginTop`, `.marginBottom`, `.textAlignment` — the only modifiers; the face is always KaTeX's
+- **InlineMath:** `.foregroundStyle` — the only modifier; size follows the surrounding text
 
 ## API reference
 
@@ -360,6 +364,50 @@ Styling comes from the `Table()` theme element (header colors, row
 striping, borders, cell padding, alignment); the defaults adapt to light
 and dark mode.
 
+## LaTeX math
+
+Math rendering is an optional product so apps that never show formulas
+don't link the typesetting engine. Add `EnrichedMarkdownLaTeX` next to
+`EnrichedMarkdown` and enable it per view:
+
+```swift
+import EnrichedMarkdown
+import EnrichedMarkdownLaTeX
+
+EnrichedMarkdownText(content)
+  .markdownLaTeX()
+```
+
+`$…$` typesets inline at the surrounding text size, and a `$$…$$` block on
+its own line renders as a full-width panel. Source that fails to typeset
+falls back to the delimited text. Outside SwiftUI, `MarkdownRenderer.renderLaTeX`
+mirrors `MarkdownRenderer.render` with math enabled.
+
+Styling comes from two theme elements the product adds to the builder:
+
+```swift
+EnrichedMarkdownText(content)
+  .markdownLaTeX()
+  .markdownTheme {
+    MathBlock()
+      .fontSize(22)
+      .background(Color(red: 243 / 255, green: 244 / 255, blue: 246 / 255))
+      .padding(16)
+      .marginBottom(24)
+      .textAlignment(.leading)
+
+    InlineMath()
+      .foregroundStyle(.tint)
+  }
+```
+
+`.markdownLaTeX()` layers `MarkdownTheme.latexDefault` — 20pt formulas
+centered on a padded `.quaternary` panel — directly above `MarkdownTheme.default`,
+so your own themes still win whether they're applied on an ancestor or on the
+view itself. Font size and color left unset follow the paragraph. When
+resolving a `MarkdownStyleConfig` by hand for `renderLaTeX`, include that
+layer: `MarkdownStyleConfig.resolve(layers: [.default, .latexDefault, yours], traitCollection: …)`.
+
 ## Supported Markdown
 
 - Headings (`#`–`######`)
@@ -377,6 +425,7 @@ and dark mode.
 - Links and images (block and inline)
 - Autolinked bare URLs, `www.` links, and emails (`permissiveAutolinks`, on by default)
 - Thematic breaks (`---`)
+- LaTeX math (`$…$`, `$$…$$`) with the `EnrichedMarkdownLaTeX` product — see [LaTeX math](#latex-math)
 
 ## Development
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/AttributedRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/AttributedRenderer.swift
@@ -3,7 +3,8 @@ import UIKit
 final class AttributedRenderer {
     private let config: MarkdownStyleConfig
     private let factory: RendererFactory
-    private let rootBlockTypes: Set<NodeType>
+    /// Root-level plugin block node types and the margins each declares.
+    private let rootBlockMargins: [NodeType: BlockMargins]
 
     init(
         config: MarkdownStyleConfig,
@@ -16,7 +17,11 @@ final class AttributedRenderer {
             imageRequestHeaders: imageRequestHeaders,
             plugins: plugins
         )
-        self.rootBlockTypes = plugins.reduce(into: []) { $0.formUnion($1.rootBlockNodeTypes) }
+        self.rootBlockMargins = plugins.reduce(into: [:]) { margins, plugin in
+            for type in plugin.rootBlockNodeTypes where margins[type] == nil {
+                margins[type] = plugin.blockMargins(for: type, config: config)
+            }
+        }
     }
 
     func renderRoot(_ root: MarkdownASTNode) -> NSMutableAttributedString {
@@ -30,11 +35,11 @@ final class AttributedRenderer {
         for child in root.children {
             // A synthetic paragraph gives bare plugin block nodes their
             // block margins and alignment.
-            if rootBlockTypes.contains(child.type) {
-                context.rendersPluginBlock = true
+            if let margins = rootBlockMargins[child.type] {
+                context.pluginBlockMargins = margins
                 let paragraph = MarkdownASTNode(type: .paragraph, children: [child])
                 factory.renderer(for: .paragraph).render(node: paragraph, into: output, context: context)
-                context.rendersPluginBlock = false
+                context.pluginBlockMargins = nil
                 continue
             }
             factory.renderer(for: child.type).render(node: child, into: output, context: context)

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/MarkdownRenderPlugin.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/MarkdownRenderPlugin.swift
@@ -15,12 +15,35 @@ package protocol MarkdownRenderPlugin {
     /// display math, for instance) that should render wrapped in a synthetic
     /// paragraph; `RenderContext.rendersPluginBlock` is true while it renders.
     var rootBlockNodeTypes: Set<NodeType> { get }
+
+    /// Margins for a `rootBlockNodeTypes` member's synthetic paragraph; unset
+    /// ones keep the paragraph style's.
+    func blockMargins(for type: NodeType, config: MarkdownStyleConfig) -> BlockMargins
+
+    /// The plugin's element defaults, layered directly above
+    /// `MarkdownTheme.default` and below the app's themes.
+    var defaultTheme: MarkdownTheme? { get }
 }
 
 package extension MarkdownRenderPlugin {
     func adjustFlags(_ flags: inout Md4cFlags) {}
 
     var rootBlockNodeTypes: Set<NodeType> { [] }
+
+    func blockMargins(for type: NodeType, config: MarkdownStyleConfig) -> BlockMargins { BlockMargins() }
+
+    var defaultTheme: MarkdownTheme? { nil }
+}
+
+/// Block spacing overriding the paragraph style's, per set property.
+package struct BlockMargins: Equatable, Sendable {
+    package var marginTop: CGFloat?
+    package var marginBottom: CGFloat?
+
+    package init(marginTop: CGFloat? = nil, marginBottom: CGFloat? = nil) {
+        self.marginTop = marginTop
+        self.marginBottom = marginBottom
+    }
 }
 
 /// Adopted by plugin-created attachments so base components can handle them

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/RenderContext.swift
@@ -56,9 +56,10 @@ package final class RenderContext {
     var listItemNumber = 0
     var taskItemIndex = 0
     var rendersBlockImage = false
-    /// True while rendering the synthetic paragraph around a bare root-level
+    /// Set while rendering the synthetic paragraph around a bare root-level
     /// plugin block node (see `MarkdownRenderPlugin.rootBlockNodeTypes`).
-    package var rendersPluginBlock = false
+    var pluginBlockMargins: BlockMargins?
+    package var rendersPluginBlock: Bool { pluginBlockMargins != nil }
 
     private static let blockSpacerTemplate: NSParagraphStyle = {
         let style = NSMutableParagraphStyle()
@@ -76,7 +77,7 @@ package final class RenderContext {
         listItemNumber = 0
         taskItemIndex = 0
         rendersBlockImage = false
-        rendersPluginBlock = false
+        pluginBlockMargins = nil
     }
 
     func setBlockStyle(

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/ParagraphRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Rendering/Renderers/ParagraphRenderer.swift
@@ -22,10 +22,11 @@ final class ParagraphRenderer: NodeRenderer {
         let start = output.length
         let shouldApplyMargin = context.currentBlockType == .none || context.currentBlockType == .paragraph
         let isBlockImage = node.children.count == 1 && node.children[0].type == .image
-        let imageStyle = config.image
-        let marginTop = isBlockImage
-            ? (imageStyle.marginTop ?? paragraphStyle.marginTop ?? 0)
-            : (paragraphStyle.marginTop ?? 0)
+        let overrides = isBlockImage
+            ? BlockMargins(marginTop: config.image.marginTop, marginBottom: config.image.marginBottom)
+            : context.pluginBlockMargins ?? BlockMargins()
+        let marginTop = overrides.marginTop ?? paragraphStyle.marginTop ?? 0
+        let marginBottom = overrides.marginBottom ?? paragraphStyle.marginBottom
         var contentStart = start
 
         if shouldApplyMargin, start == 0, marginTop > 0 {
@@ -73,10 +74,6 @@ final class ParagraphRenderer: NodeRenderer {
                 marginTop: marginTop
             )
         }
-
-        let marginBottom = isBlockImage
-            ? (imageStyle.marginBottom ?? paragraphStyle.marginBottom)
-            : paragraphStyle.marginBottom
 
         if shouldApplyMargin, let marginBottom {
             ParagraphStyleHelpers.applyParagraphSpacingAfter(

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownStyleConfig.swift
@@ -416,6 +416,9 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
     public var list: ListStyle
     public var taskList: TaskListStyle
     public var table: TableStyle
+    /// Styles of optional modules' elements (`EnrichedMarkdownLaTeX`'s math
+    /// panel, say), keyed by the module's own record type.
+    package var pluginStyles = PluginStyleStorage()
 
     public init(
         paragraph: ElementStyle = ElementStyle(),
@@ -491,6 +494,7 @@ public struct MarkdownStyleConfig: Equatable, Sendable {
         list.merge(other.list)
         taskList.merge(other.taskList)
         table.merge(other.table)
+        pluginStyles.merge(other.pluginStyles)
     }
 
     public func headingStyle(for level: Int) -> ElementStyle {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownThemeElement.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/MarkdownThemeElement.swift
@@ -103,14 +103,16 @@ public extension MarkdownThemeElement {
         if let marginTop { style.marginTop = marginTop }
         if let marginBottom { style.marginBottom = marginBottom }
         if let lineHeight { style.lineHeight = lineHeight }
-        if let textAlignment { style.textAlignment = nsTextAlignment(from: textAlignment) }
+        if let textAlignment { style.textAlignment = NSTextAlignment(textAlignment) }
     }
+}
 
-    private func nsTextAlignment(from alignment: TextAlignment) -> NSTextAlignment {
+package extension NSTextAlignment {
+    init(_ alignment: TextAlignment) {
         switch alignment {
-        case .leading: return .left
-        case .center: return .center
-        case .trailing: return .right
+        case .leading: self = .left
+        case .center: self = .center
+        case .trailing: self = .right
         }
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/PluginStyleStorage.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/PluginStyleStorage.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// A style record an optional module keeps in `MarkdownStyleConfig.pluginStyles`,
+/// written by its theme elements and read by its renderers.
+package protocol PluginStyle: Equatable, Sendable {
+    /// Overlays `other`'s set properties, the way the built-in styles merge.
+    mutating func merge(_ other: Self)
+}
+
+/// `PluginStyle` records keyed by their type, one per module concern.
+package struct PluginStyleStorage: Equatable, Sendable {
+    private var values: [ObjectIdentifier: any PluginStyle] = [:]
+
+    package init() {}
+
+    package subscript<Style: PluginStyle>(_ type: Style.Type) -> Style? {
+        get { values[ObjectIdentifier(type)] as? Style }
+        set { values[ObjectIdentifier(type)] = newValue }
+    }
+
+    package mutating func merge(_ other: PluginStyleStorage) {
+        for (key, style) in other.values {
+            values[key] = values[key].map { $0.merged(with: style) } ?? style
+        }
+    }
+
+    package static func == (lhs: PluginStyleStorage, rhs: PluginStyleStorage) -> Bool {
+        guard lhs.values.count == rhs.values.count else { return false }
+        return lhs.values.allSatisfy { key, style in
+            rhs.values[key].map { style.isEqual(to: $0) } ?? false
+        }
+    }
+}
+
+private extension PluginStyle {
+    func isEqual(to other: any PluginStyle) -> Bool {
+        guard let other = other as? Self else { return false }
+        return self == other
+    }
+
+    /// A key holds one type, so the mismatch fallback is unreachable.
+    func merged(with other: any PluginStyle) -> any PluginStyle {
+        guard let other = other as? Self else { return other }
+        var copy = self
+        copy.merge(other)
+        return copy
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/ThemeColorModifiers.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/ThemeColorModifiers.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
-enum ThemeColorModifiers {
-    static func spec(from color: Color) -> ThemeColorSpec {
+package enum ThemeColorModifiers {
+    package static func spec(from color: Color) -> ThemeColorSpec {
         ThemeResolver.color(from: color, traitCollection: .current)
     }
 
-    static func spec(from semantic: ThemeColorSpec.SemanticColor) -> ThemeColorSpec {
+    package static func spec(from semantic: ThemeColorSpec.SemanticColor) -> ThemeColorSpec {
         .semantic(semantic)
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/ThemeResolver.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Theme/ThemeResolver.swift
@@ -46,7 +46,7 @@ public enum ThemeColorSpec: Equatable, Sendable {
         case quaternary
     }
 
-    func resolve(traitCollection: UITraitCollection) -> UIColor {
+    package func resolve(traitCollection: UITraitCollection) -> UIColor {
         switch self {
         case let .semantic(semantic):
             switch semantic {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -29,7 +29,11 @@ public struct EnrichedMarkdownText: View {
             colorScheme: colorScheme,
             dynamicTypeSize: dynamicTypeSize
         )
-        return MarkdownStyleConfig.resolve(layers: themeLayers, traitCollection: traitCollection)
+        // Plugin defaults go above `MarkdownTheme.default` (the environment's
+        // first layer) and below the app's themes.
+        var layers = themeLayers
+        layers.insert(contentsOf: renderPlugins.compactMap(\.defaultTheme), at: min(1, layers.count))
+        return MarkdownStyleConfig.resolve(layers: layers, traitCollection: traitCollection)
     }
 
     public var body: some View {

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/LaTeXRenderPlugin.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/LaTeXRenderPlugin.swift
@@ -19,11 +19,17 @@ package struct LaTeXRenderPlugin: MarkdownRenderPlugin {
     package func renderer(for type: NodeType, config: MarkdownStyleConfig) -> NodeRenderer? {
         switch type {
         case .latexMathInline, .latexMathDisplay:
-            return MathRenderer(typeset: typeset)
+            return MathRenderer(typeset: typeset, blockStyle: config.mathBlock, inlineStyle: config.inlineMath)
         default:
             return nil
         }
     }
+
+    package func blockMargins(for type: NodeType, config: MarkdownStyleConfig) -> BlockMargins {
+        BlockMargins(marginTop: config.mathBlock.marginTop, marginBottom: config.mathBlock.marginBottom)
+    }
+
+    package var defaultTheme: MarkdownTheme? { .latexDefault }
 
     package func adjustFlags(_ flags: inout Md4cFlags) {
         flags.latexMathEnabled = true
@@ -36,7 +42,8 @@ package struct LaTeXRenderPlugin: MarkdownRenderPlugin {
 
 public extension View {
     /// Parses and renders LaTeX math (`$…$` inline, `$$…$$` display) with
-    /// the bundled RaTeX engine.
+    /// the bundled RaTeX engine, styled by `MarkdownTheme.latexDefault`
+    /// underneath the themes applied around this view.
     func markdownLaTeX() -> some View {
         transformEnvironment(\.markdownRenderPlugins) { plugins in
             guard !plugins.contains(where: { $0 is LaTeXRenderPlugin }) else { return }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathAttachment.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathAttachment.swift
@@ -10,27 +10,56 @@ struct MathTypesetResult {
     let draw: (CGContext) -> Void
 }
 
+/// The full-width panel a root-level display formula sits in: the
+/// background fills the line, the formula is inset by `padding` and aligned
+/// inside; one wider than the panel starts at the left inset and clips.
+struct MathPanelStyle: Equatable {
+    var backgroundColor: UIColor?
+    var padding: CGFloat = 0
+    var textAlignment: NSTextAlignment = .natural
+
+    func contentOriginX(formulaWidth: CGFloat, panelWidth: CGFloat) -> CGFloat {
+        let available = panelWidth - padding * 2
+        guard formulaWidth < available else { return padding }
+        switch textAlignment {
+        case .center:
+            return padding + floor((available - formulaWidth) / 2)
+        case .right:
+            return padding + available - formulaWidth
+        default:
+            return padding
+        }
+    }
+}
+
 /// A typeset formula embedded in the text: the negative bounds origin sits
 /// it on the baseline, and the raster is drawn lazily via
-/// `image(forBounds:...)` and cached.
+/// `image(forBounds:...)`. The formula is rasterized once; a panel is
+/// re-composed around it whenever the line width changes.
 final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
     let latex: String
     /// `$$…$$` as opposed to `$…$`; picks the restored delimiters.
     let isDisplay: Bool
-    let isBlock: Bool
+    /// Set for root-level display math, which then spans the line.
+    let panel: MathPanelStyle?
 
     private let result: MathTypesetResult
-    private var cachedImage: UIImage?
+    private var panelImage: UIImage?
+
+    private lazy var formulaImage: UIImage? = {
+        guard formulaSize.width > 0, formulaSize.height > 0 else { return nil }
+        return UIGraphicsImageRenderer(size: formulaSize).image { result.draw($0.cgContext) }
+    }()
 
     static func delimiter(isDisplay: Bool) -> String {
         isDisplay ? "$$" : "$"
     }
 
-    init(latex: String, isDisplay: Bool, isBlock: Bool, result: MathTypesetResult) {
+    init(latex: String, isDisplay: Bool, result: MathTypesetResult, panel: MathPanelStyle? = nil) {
         self.latex = latex
         self.isDisplay = isDisplay
-        self.isBlock = isBlock
         self.result = result
+        self.panel = panel
         super.init(data: nil, ofType: nil)
         accessibilityLabel = latex
     }
@@ -44,6 +73,8 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         delimiter + latex + delimiter
     }
 
+    var isBlock: Bool { panel != nil }
+
     var literalText: String { latex }
 
     var sourceDelimiters: (opening: String, closing: String)? {
@@ -54,17 +85,26 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         Self.delimiter(isDisplay: isDisplay)
     }
 
+    private var formulaSize: CGSize {
+        CGSize(width: ceil(result.width), height: ceil(result.ascent) + ceil(result.descent))
+    }
+
     override func attachmentBounds(
         for textContainer: NSTextContainer?,
         proposedLineFragment lineFragmentRect: CGRect,
         glyphPosition position: CGPoint,
         characterIndex charIndex: Int
     ) -> CGRect {
-        CGRect(
+        let size = formulaSize
+        guard let panel else {
+            return CGRect(x: 0, y: -ceil(result.descent), width: size.width, height: size.height)
+        }
+        let inset = panel.padding * 2
+        return CGRect(
             x: 0,
-            y: -ceil(result.descent),
-            width: ceil(result.width),
-            height: ceil(result.ascent) + ceil(result.descent)
+            y: -(ceil(result.descent) + panel.padding),
+            width: max(lineFragmentRect.width, size.width + inset),
+            height: size.height + inset
         )
     }
 
@@ -73,16 +113,21 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         textContainer: NSTextContainer?,
         characterIndex charIndex: Int
     ) -> UIImage? {
-        if let cachedImage {
-            return cachedImage
+        guard let panel else { return formulaImage }
+        if let panelImage, panelImage.size == imageBounds.size {
+            return panelImage
         }
         guard imageBounds.width > 0, imageBounds.height > 0 else { return nil }
 
-        let renderer = UIGraphicsImageRenderer(size: imageBounds.size)
-        let rendered = renderer.image { rendererContext in
-            result.draw(rendererContext.cgContext)
+        let rendered = UIGraphicsImageRenderer(size: imageBounds.size).image { rendererContext in
+            if let backgroundColor = panel.backgroundColor {
+                backgroundColor.setFill()
+                rendererContext.fill(CGRect(origin: .zero, size: imageBounds.size))
+            }
+            let originX = panel.contentOriginX(formulaWidth: formulaSize.width, panelWidth: imageBounds.width)
+            formulaImage?.draw(at: CGPoint(x: originX, y: panel.padding))
         }
-        cachedImage = rendered
+        panelImage = rendered
         return rendered
     }
 }

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathRenderer.swift
@@ -1,9 +1,10 @@
 import EnrichedMarkdown
 import UIKit
 
-/// Renders math nodes as baseline-aligned image attachments inheriting the
-/// surrounding font size and color; typeset failures fall back to the
-/// delimited source text.
+/// Renders math nodes as baseline-aligned image attachments: inline math at
+/// the surrounding font size, root-level display math as a `MathBlock`
+/// panel; unset style values inherit from the surrounding text. Typeset
+/// failures fall back to the delimited source text.
 final class MathRenderer: NodeRenderer {
     typealias Typeset = (
         _ latex: String,
@@ -13,9 +14,19 @@ final class MathRenderer: NodeRenderer {
     ) -> MathTypesetResult?
 
     private let typeset: Typeset
+    private let blockStyle: MathBlockStyle
+    private let inlineStyle: InlineMathStyle
+    private let panel: MathPanelStyle
 
-    init(typeset: @escaping Typeset) {
+    init(typeset: @escaping Typeset, blockStyle: MathBlockStyle, inlineStyle: InlineMathStyle) {
         self.typeset = typeset
+        self.blockStyle = blockStyle
+        self.inlineStyle = inlineStyle
+        self.panel = MathPanelStyle(
+            backgroundColor: blockStyle.backgroundColor,
+            padding: blockStyle.padding ?? 0,
+            textAlignment: blockStyle.textAlignment ?? .natural
+        )
     }
 
     func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
@@ -23,12 +34,17 @@ final class MathRenderer: NodeRenderer {
         guard !latex.isEmpty else { return }
 
         let isDisplay = node.type == .latexMathDisplay
+        let isBlock = context.rendersPluginBlock
         var attributes = context.getTextAttributes()
         let font = attributes[.font] as? UIFont ?? UIFont.preferredFont(forTextStyle: .body)
-        let color = attributes[.foregroundColor] as? UIColor ?? UIColor.label
+        let fontSize = (isBlock ? blockStyle.fontSize : nil) ?? font.pointSize
+        let color = (isBlock ? blockStyle.foregroundColor : inlineStyle.foregroundColor)
+            ?? attributes[.foregroundColor] as? UIColor ?? UIColor.label
 
-        guard let result = typeset(latex, isDisplay, font.pointSize, color) else {
+        guard let result = typeset(latex, isDisplay, fontSize, color) else {
             let delimiter = MathAttachment.delimiter(isDisplay: isDisplay)
+            attributes[.font] = font.withSize(fontSize)
+            attributes[.foregroundColor] = color
             output.append(NSAttributedString(string: delimiter + latex + delimiter, attributes: attributes))
             return
         }
@@ -36,8 +52,8 @@ final class MathRenderer: NodeRenderer {
         attributes[.attachment] = MathAttachment(
             latex: latex,
             isDisplay: isDisplay,
-            isBlock: context.rendersPluginBlock,
-            result: result
+            result: result,
+            panel: isBlock ? panel : nil
         )
         SourceOffsetAnnotator.tagSourceRange(in: &attributes, of: node)
         output.append(NSAttributedString(string: "\u{FFFC}", attributes: attributes))

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathStyle.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathStyle.swift
@@ -1,0 +1,46 @@
+import EnrichedMarkdown
+import UIKit
+
+/// Resolved `MathBlock()` values for root-level display math; nil inherits
+/// from the surrounding paragraph (font size, color, margins) or means none
+/// (background, padding).
+struct MathBlockStyle: PluginStyle {
+    var fontSize: CGFloat?
+    var foregroundColor: UIColor?
+    var backgroundColor: UIColor?
+    var padding: CGFloat?
+    var marginTop: CGFloat?
+    var marginBottom: CGFloat?
+    var textAlignment: NSTextAlignment?
+
+    mutating func merge(_ other: MathBlockStyle) {
+        fontSize = other.fontSize ?? fontSize
+        foregroundColor = other.foregroundColor ?? foregroundColor
+        backgroundColor = other.backgroundColor ?? backgroundColor
+        padding = other.padding ?? padding
+        marginTop = other.marginTop ?? marginTop
+        marginBottom = other.marginBottom ?? marginBottom
+        textAlignment = other.textAlignment ?? textAlignment
+    }
+}
+
+/// Resolved `InlineMath()` values; nil inherits the surrounding text color.
+struct InlineMathStyle: PluginStyle {
+    var foregroundColor: UIColor?
+
+    mutating func merge(_ other: InlineMathStyle) {
+        foregroundColor = other.foregroundColor ?? foregroundColor
+    }
+}
+
+extension MarkdownStyleConfig {
+    var mathBlock: MathBlockStyle {
+        get { pluginStyles[MathBlockStyle.self] ?? MathBlockStyle() }
+        set { pluginStyles[MathBlockStyle.self] = newValue }
+    }
+
+    var inlineMath: InlineMathStyle {
+        get { pluginStyles[InlineMathStyle.self] ?? InlineMathStyle() }
+        set { pluginStyles[InlineMathStyle.self] = newValue }
+    }
+}

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathThemeElements.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathThemeElements.swift
@@ -1,0 +1,139 @@
+import EnrichedMarkdown
+import SwiftUI
+
+/// Root-level `$$…$$` blocks: a full-width panel with the formula aligned
+/// inside it. Unset font size and color follow the paragraph.
+public struct MathBlock: MarkdownThemeContent {
+    public var fontSize: CGFloat?
+    public var foregroundColorSpec: ThemeColorSpec?
+    public var backgroundColorSpec: ThemeColorSpec?
+    public var padding: CGFloat?
+    public var marginTop: CGFloat?
+    public var marginBottom: CGFloat?
+    public var textAlignment: TextAlignment?
+
+    public init() {}
+
+    /// Point size of the typeset formula; the face is always KaTeX's.
+    public func fontSize(_ size: CGFloat) -> Self {
+        var copy = self
+        copy.fontSize = size
+        return copy
+    }
+
+    public func foregroundStyle(_ color: Color) -> Self {
+        var copy = self
+        copy.foregroundColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func foregroundStyle(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.foregroundColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func backgroundStyle(_ color: Color) -> Self {
+        var copy = self
+        copy.backgroundColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func backgroundStyle(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.backgroundColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func background(_ color: Color) -> Self {
+        backgroundStyle(color)
+    }
+
+    public func background(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        backgroundStyle(semantic)
+    }
+
+    /// Inset between the panel edge and the formula, on every side.
+    public func padding(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.padding = value
+        return copy
+    }
+
+    public func marginTop(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.marginTop = value
+        return copy
+    }
+
+    public func marginBottom(_ value: CGFloat) -> Self {
+        var copy = self
+        copy.marginBottom = value
+        return copy
+    }
+
+    /// Where the formula sits inside the panel when narrower than it.
+    public func textAlignment(_ alignment: TextAlignment) -> Self {
+        var copy = self
+        copy.textAlignment = alignment
+        return copy
+    }
+
+    public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        var style = config.mathBlock
+        if let fontSize { style.fontSize = fontSize }
+        if let foregroundColorSpec {
+            style.foregroundColor = foregroundColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let backgroundColorSpec {
+            style.backgroundColor = backgroundColorSpec.resolve(traitCollection: traitCollection)
+        }
+        if let padding { style.padding = padding }
+        if let marginTop { style.marginTop = marginTop }
+        if let marginBottom { style.marginBottom = marginBottom }
+        if let textAlignment { style.textAlignment = NSTextAlignment(textAlignment) }
+        config.mathBlock = style
+    }
+}
+
+/// `$…$` in running text, and `$$…$$` inside a paragraph: typeset at the
+/// surrounding font size, in this color or the surrounding text's.
+public struct InlineMath: MarkdownThemeContent {
+    public var foregroundColorSpec: ThemeColorSpec?
+
+    public init() {}
+
+    public func foregroundStyle(_ color: Color) -> Self {
+        var copy = self
+        copy.foregroundColorSpec = ThemeColorModifiers.spec(from: color)
+        return copy
+    }
+
+    public func foregroundStyle(_ semantic: ThemeColorSpec.SemanticColor) -> Self {
+        var copy = self
+        copy.foregroundColorSpec = ThemeColorModifiers.spec(from: semantic)
+        return copy
+    }
+
+    public func apply(to config: inout MarkdownStyleConfig, traitCollection: UITraitCollection) {
+        guard let foregroundColorSpec else { return }
+        var style = config.inlineMath
+        style.foregroundColor = foregroundColorSpec.resolve(traitCollection: traitCollection)
+        config.inlineMath = style
+    }
+}
+
+public extension MarkdownTheme {
+    /// Math defaults matching the React Native package: 20pt display math
+    /// centered on a padded panel. `.markdownLaTeX()` layers it right above
+    /// `MarkdownTheme.default`; include it yourself when resolving a config
+    /// for `MarkdownRenderer.renderLaTeX`.
+    static let latexDefault = MarkdownTheme {
+        MathBlock()
+            .fontSize(20)
+            .background(ThemeColorSpec.SemanticColor.quaternary)
+            .padding(12)
+            .marginBottom(16)
+            .textAlignment(.center)
+    }
+}

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXRenderingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXRenderingTests.swift
@@ -31,23 +31,6 @@ final class LaTeXRenderingTests: XCTestCase {
         )
     }
 
-    private func stubResult() -> MathTypesetResult {
-        MathTypesetResult(width: 40, ascent: 12, descent: 4) { _ in }
-    }
-
-    private func mathAttachments(in rendered: NSAttributedString) -> [MathAttachment] {
-        var found: [MathAttachment] = []
-        rendered.enumerateAttribute(
-            .attachment,
-            in: NSRange(location: 0, length: rendered.length)
-        ) { value, _, _ in
-            if let math = value as? MathAttachment {
-                found.append(math)
-            }
-        }
-        return found
-    }
-
     /// Copy as Markdown for the rendered selection matching `substring`,
     /// rendered with stub typesetting.
     private func copyMarkdown(
@@ -228,24 +211,5 @@ final class LaTeXRenderingTests: XCTestCase {
             )?.trimmingCharacters(in: .whitespacesAndNewlines),
             "before\n\n$$E=mc^2$$\n\nafter"
         )
-    }
-
-    /// True when every pixel is fully transparent.
-    private func isBlank(_ image: UIImage) -> Bool {
-        guard let cgImage = image.cgImage else { return true }
-        let width = cgImage.width
-        let height = cgImage.height
-        var pixels = [UInt8](repeating: 0, count: width * height)
-        guard let context = CGContext(
-            data: &pixels,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: width,
-            space: CGColorSpaceCreateDeviceGray(),
-            bitmapInfo: CGImageAlphaInfo.alphaOnly.rawValue
-        ) else { return true }
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
-        return !pixels.contains { $0 > 0 }
     }
 }

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathTestSupport.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathTestSupport.swift
@@ -1,0 +1,42 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdownLaTeX
+
+extension XCTestCase {
+    /// Deterministic typeset metrics standing in for RaTeX.
+    func stubResult() -> MathTypesetResult {
+        MathTypesetResult(width: 40, ascent: 12, descent: 4) { _ in }
+    }
+
+    func mathAttachments(in rendered: NSAttributedString) -> [MathAttachment] {
+        var found: [MathAttachment] = []
+        rendered.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: rendered.length)
+        ) { value, _, _ in
+            if let math = value as? MathAttachment {
+                found.append(math)
+            }
+        }
+        return found
+    }
+
+    /// True when every pixel is fully transparent.
+    func isBlank(_ image: UIImage) -> Bool {
+        guard let cgImage = image.cgImage else { return true }
+        let width = cgImage.width
+        let height = cgImage.height
+        var pixels = [UInt8](repeating: 0, count: width * height)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGImageAlphaInfo.alphaOnly.rawValue
+        ) else { return true }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return !pixels.contains { $0 > 0 }
+    }
+}

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathThemingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathThemingTests.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+@testable import EnrichedMarkdownLaTeX
+
+final class MathThemingTests: XCTestCase {
+    /// Typeset inputs captured from the last `render`.
+    private struct TypesetCall: Equatable {
+        var fontSize: CGFloat
+        var color: UIColor
+    }
+
+    private var typesetCalls: [TypesetCall] = []
+
+    override func setUp() {
+        super.setUp()
+        typesetCalls = []
+    }
+
+    // MARK: - Helpers
+
+    private func config(@MarkdownThemeBuilder _ content: () -> MarkdownThemeGroup) -> MarkdownStyleConfig {
+        MarkdownStyleConfig.resolve(layers: [.default, MarkdownTheme(content)], traitCollection: .current)
+    }
+
+    private func render(_ markdown: String, config: MarkdownStyleConfig, typesets: Bool = true) -> NSAttributedString {
+        MarkdownRenderer.render(
+            markdown,
+            config: config,
+            flags: .commonMark,
+            imageRequestHeaders: [:],
+            plugins: [LaTeXRenderPlugin(typeset: { _, _, fontSize, color in
+                self.typesetCalls.append(TypesetCall(fontSize: fontSize, color: color))
+                return typesets ? self.stubResult() : nil
+            })]
+        )
+    }
+
+    private func paragraphFontSize(in config: MarkdownStyleConfig) -> CGFloat {
+        (config.paragraph.font ?? UIFont.preferredFont(forTextStyle: .body)).pointSize
+    }
+
+    private func bounds(of attachment: MathAttachment, lineWidth: CGFloat) -> CGRect {
+        attachment.attachmentBounds(
+            for: nil,
+            proposedLineFragment: CGRect(x: 0, y: 0, width: lineWidth, height: 20),
+            glyphPosition: .zero,
+            characterIndex: 0
+        )
+    }
+
+    // MARK: - Theme elements
+
+    func testMathBlockThemeElementAppliesToConfig() {
+        var config = MarkdownStyleConfig()
+        MathBlock()
+            .fontSize(24)
+            .foregroundStyle(Color(UIColor.systemRed))
+            .background(Color(UIColor.systemBlue))
+            .padding(10)
+            .marginTop(4)
+            .marginBottom(20)
+            .textAlignment(.trailing)
+            .apply(to: &config, traitCollection: .current)
+
+        XCTAssertEqual(config.mathBlock.fontSize, 24)
+        XCTAssertNotNil(config.mathBlock.foregroundColor)
+        XCTAssertNotNil(config.mathBlock.backgroundColor)
+        XCTAssertEqual(config.mathBlock.padding, 10)
+        XCTAssertEqual(config.mathBlock.marginTop, 4)
+        XCTAssertEqual(config.mathBlock.marginBottom, 20)
+        XCTAssertEqual(config.mathBlock.textAlignment, .right)
+    }
+
+    func testInlineMathThemeElementAppliesToConfig() {
+        var config = MarkdownStyleConfig()
+        XCTAssertNil(config.inlineMath.foregroundColor)
+
+        InlineMath().foregroundStyle(.tint).apply(to: &config, traitCollection: .current)
+        XCTAssertNotNil(config.inlineMath.foregroundColor)
+    }
+
+    func testLatexDefaultMatchesReactNativeDefaults() {
+        let config = MarkdownStyleConfig.resolve(layers: [.default, .latexDefault], traitCollection: .current)
+
+        XCTAssertEqual(config.mathBlock.fontSize, 20)
+        XCTAssertNil(config.mathBlock.foregroundColor, "block color inherits the paragraph's")
+        XCTAssertNotNil(config.mathBlock.backgroundColor)
+        XCTAssertEqual(config.mathBlock.padding, 12)
+        XCTAssertNil(config.mathBlock.marginTop)
+        XCTAssertEqual(config.mathBlock.marginBottom, 16)
+        XCTAssertEqual(config.mathBlock.textAlignment, .center)
+        XCTAssertNil(config.inlineMath.foregroundColor)
+    }
+
+    func testLaterThemeLayersOverrideOnlySetMathProperties() {
+        let config = MarkdownStyleConfig.resolve(
+            layers: [.default, .latexDefault, MarkdownTheme { MathBlock().padding(4).textAlignment(.leading) }],
+            traitCollection: .current
+        )
+
+        XCTAssertEqual(config.mathBlock.fontSize, 20)
+        XCTAssertEqual(config.mathBlock.padding, 4)
+        XCTAssertEqual(config.mathBlock.textAlignment, .left)
+        XCTAssertEqual(config.mathBlock.marginBottom, 16)
+    }
+
+    // MARK: - Rendering
+
+    func testBlockMathTypesetsWithBlockStyle() {
+        let config = config {
+            MathBlock().fontSize(24).foregroundStyle(Color(UIColor.systemRed)).background(.quaternary).padding(6)
+        }
+        let rendered = render("$$E=mc^2$$", config: config)
+
+        XCTAssertEqual(typesetCalls, [TypesetCall(fontSize: 24, color: config.mathBlock.foregroundColor!)])
+        let attachment = mathAttachments(in: rendered).first
+        XCTAssertEqual(attachment?.isBlock, true)
+        XCTAssertEqual(attachment?.panel?.padding, 6)
+        XCTAssertEqual(attachment?.panel?.backgroundColor, config.mathBlock.backgroundColor)
+    }
+
+    func testBlockMathWithoutThemeInheritsParagraph() {
+        let config = MarkdownStyleConfig.baseline()
+        let rendered = render("$$E=mc^2$$", config: config)
+
+        XCTAssertEqual(typesetCalls, [TypesetCall(fontSize: paragraphFontSize(in: config), color: config.paragraph.foregroundColor!)])
+        XCTAssertEqual(mathAttachments(in: rendered).first?.panel, MathPanelStyle())
+    }
+
+    func testInlineMathKeepsParagraphSizeAndUsesInlineColor() {
+        let config = config {
+            MathBlock().fontSize(24).foregroundStyle(Color(UIColor.systemRed))
+            InlineMath().foregroundStyle(Color(UIColor.systemBlue))
+        }
+        let rendered = render("a $x$ and $$y$$ b", config: config)
+
+        let expected = TypesetCall(fontSize: paragraphFontSize(in: config), color: config.inlineMath.foregroundColor!)
+        XCTAssertEqual(typesetCalls, [expected, expected])
+        XCTAssertNil(mathAttachments(in: rendered).first?.panel, "display math inside a paragraph is not a block")
+    }
+
+    func testBlockMathMarginsComeFromTheme() {
+        var config = config { MathBlock().marginTop(7).marginBottom(9) }
+        config.paragraph.marginTop = 3
+        config.paragraph.marginBottom = 5
+        let rendered = render("before\n\n$$x$$\n\nafter", config: config)
+
+        let index = (rendered.string as NSString).range(of: "\u{FFFC}").location
+        let before = rendered.attribute(.paragraphStyle, at: index - 1, effectiveRange: nil) as? NSParagraphStyle
+        let block = rendered.attribute(.paragraphStyle, at: index, effectiveRange: nil) as? NSParagraphStyle
+        XCTAssertEqual(before?.paragraphSpacingBefore, 7)
+        XCTAssertEqual(block?.paragraphSpacing, 9)
+    }
+
+    func testTypesetFailureInBlockUsesBlockStyle() {
+        let config = config { MathBlock().fontSize(24).foregroundStyle(Color(UIColor.systemRed)) }
+        let rendered = render("$$\\frac{1}{$$", config: config, typesets: false)
+
+        let index = (rendered.string as NSString).range(of: "$$").location
+        XCTAssertEqual((rendered.attribute(.font, at: index, effectiveRange: nil) as? UIFont)?.pointSize, 24)
+        XCTAssertEqual(rendered.attribute(.foregroundColor, at: index, effectiveRange: nil) as? UIColor, config.mathBlock.foregroundColor)
+    }
+
+    // MARK: - Panel attachment
+
+    func testPanelAttachmentSpansLineAndInsetsFormula() {
+        let attachment = MathAttachment(
+            latex: "x",
+            isDisplay: true,
+            result: stubResult(),
+            panel: MathPanelStyle(padding: 12, textAlignment: .center)
+        )
+
+        XCTAssertEqual(bounds(of: attachment, lineWidth: 300), CGRect(x: 0, y: -16, width: 300, height: 40))
+        XCTAssertEqual(bounds(of: attachment, lineWidth: 50).width, 64, "a wide formula keeps its padded width")
+    }
+
+    func testPanelAlignsFormulaInsideInsets() {
+        func originX(_ alignment: NSTextAlignment, panelWidth: CGFloat = 300) -> CGFloat {
+            MathPanelStyle(padding: 12, textAlignment: alignment).contentOriginX(formulaWidth: 40, panelWidth: panelWidth)
+        }
+
+        XCTAssertEqual(originX(.left), 12)
+        XCTAssertEqual(originX(.natural), 12)
+        XCTAssertEqual(originX(.center), 130)
+        XCTAssertEqual(originX(.right), 248)
+        XCTAssertEqual(originX(.center, panelWidth: 50), 12, "an overflowing formula starts at the inset")
+    }
+
+    func testPanelImageFillsBackgroundAndRerendersPerSize() {
+        func image(background: UIColor?, width: CGFloat) -> UIImage? {
+            let attachment = MathAttachment(
+                latex: "x",
+                isDisplay: true,
+                result: stubResult(),
+                panel: MathPanelStyle(backgroundColor: background, padding: 12)
+            )
+            let size = CGSize(width: width, height: 40)
+            return attachment.image(forBounds: CGRect(origin: .zero, size: size), textContainer: nil, characterIndex: 0)
+        }
+
+        XCTAssertEqual(image(background: nil, width: 300).map(isBlank), true)
+        XCTAssertEqual(image(background: .systemRed, width: 300).map(isBlank), false)
+
+        let attachment = MathAttachment(latex: "x", isDisplay: true, result: stubResult(), panel: MathPanelStyle())
+        let narrow = attachment.image(forBounds: CGRect(x: 0, y: 0, width: 100, height: 16), textContainer: nil, characterIndex: 0)
+        let wide = attachment.image(forBounds: CGRect(x: 0, y: 0, width: 200, height: 16), textContainer: nil, characterIndex: 0)
+        XCTAssertEqual(narrow?.size.width, 100)
+        XCTAssertEqual(wide?.size.width, 200)
+    }
+}

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/PluginStyleTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/PluginStyleTests.swift
@@ -1,0 +1,163 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+
+private struct RecordStyle: PluginStyle {
+    var size: CGFloat?
+    var name: String?
+
+    mutating func merge(_ other: RecordStyle) {
+        size = other.size ?? size
+        name = other.name ?? name
+    }
+}
+
+private struct FlagStyle: PluginStyle {
+    var enabled: Bool?
+
+    mutating func merge(_ other: FlagStyle) {
+        enabled = other.enabled ?? enabled
+    }
+}
+
+/// Renders the node as a placeholder character; the margin tests only
+/// read the paragraph style around it.
+private final class PlaceholderRenderer: NodeRenderer {
+    func render(node: MarkdownASTNode, into output: NSMutableAttributedString, context: RenderContext) {
+        output.append(NSAttributedString(string: "\u{FFFC}", attributes: context.getTextAttributes()))
+    }
+}
+
+/// Claims display math as a root block with `margins`.
+private struct BlockMarginsPlugin: MarkdownRenderPlugin {
+    let margins: BlockMargins
+
+    func renderer(for type: NodeType, config: MarkdownStyleConfig) -> NodeRenderer? {
+        type == .latexMathDisplay ? PlaceholderRenderer() : nil
+    }
+
+    func adjustFlags(_ flags: inout Md4cFlags) {
+        flags.latexMathEnabled = true
+    }
+
+    var rootBlockNodeTypes: Set<NodeType> { [.latexMathDisplay] }
+
+    func blockMargins(for type: NodeType, config: MarkdownStyleConfig) -> BlockMargins { margins }
+}
+
+final class PluginStyleTests: XCTestCase {
+    // MARK: - Storage
+
+    func testSubscriptStoresRecordsByType() {
+        var storage = PluginStyleStorage()
+        XCTAssertNil(storage[RecordStyle.self])
+
+        storage[RecordStyle.self] = RecordStyle(size: 3, name: "a")
+        storage[FlagStyle.self] = FlagStyle(enabled: true)
+
+        XCTAssertEqual(storage[RecordStyle.self], RecordStyle(size: 3, name: "a"))
+        XCTAssertEqual(storage[FlagStyle.self], FlagStyle(enabled: true))
+
+        storage[FlagStyle.self] = nil
+        XCTAssertNil(storage[FlagStyle.self])
+        XCTAssertNotNil(storage[RecordStyle.self])
+    }
+
+    func testEqualityComparesRecords() {
+        var lhs = PluginStyleStorage()
+        var rhs = PluginStyleStorage()
+        XCTAssertEqual(lhs, rhs)
+
+        lhs[RecordStyle.self] = RecordStyle(size: 3)
+        XCTAssertNotEqual(lhs, rhs)
+
+        rhs[RecordStyle.self] = RecordStyle(size: 3)
+        XCTAssertEqual(lhs, rhs)
+
+        rhs[RecordStyle.self] = RecordStyle(size: 4)
+        XCTAssertNotEqual(lhs, rhs)
+
+        rhs[RecordStyle.self] = RecordStyle(size: 3)
+        rhs[FlagStyle.self] = FlagStyle()
+        XCTAssertNotEqual(lhs, rhs)
+    }
+
+    func testMergeOverlaysSetPropertiesOnly() {
+        var base = PluginStyleStorage()
+        base[RecordStyle.self] = RecordStyle(size: 3, name: "a")
+
+        var overlay = PluginStyleStorage()
+        overlay[RecordStyle.self] = RecordStyle(size: 5)
+        overlay[FlagStyle.self] = FlagStyle(enabled: false)
+
+        base.merge(overlay)
+
+        XCTAssertEqual(base[RecordStyle.self], RecordStyle(size: 5, name: "a"))
+        XCTAssertEqual(base[FlagStyle.self], FlagStyle(enabled: false))
+    }
+
+    func testConfigEqualityAndMergeCoverPluginStyles() {
+        var lhs = MarkdownStyleConfig.baseline()
+        let rhs = MarkdownStyleConfig.baseline()
+        XCTAssertEqual(lhs, rhs)
+
+        lhs.pluginStyles[RecordStyle.self] = RecordStyle(size: 3)
+        XCTAssertNotEqual(lhs, rhs)
+
+        var merged = rhs
+        merged.merge(lhs)
+        XCTAssertEqual(merged.pluginStyles[RecordStyle.self], RecordStyle(size: 3))
+    }
+
+    // MARK: - Block margins
+
+    private func render(_ markdown: String, config: MarkdownStyleConfig, margins: BlockMargins) -> NSAttributedString {
+        MarkdownRenderer.render(
+            markdown,
+            config: config,
+            flags: .commonMark,
+            imageRequestHeaders: [:],
+            plugins: [BlockMarginsPlugin(margins: margins)]
+        )
+    }
+
+    /// `paragraphSpacingBefore` of the spacer line ahead of the block and
+    /// `paragraphSpacing` of the block itself.
+    private func blockSpacing(in rendered: NSAttributedString) -> (before: CGFloat?, after: CGFloat?) {
+        let index = (rendered.string as NSString).range(of: "\u{FFFC}").location
+        guard index != NSNotFound, index > 0 else {
+            XCTFail("block attachment not rendered")
+            return (nil, nil)
+        }
+        let before = rendered.attribute(.paragraphStyle, at: index - 1, effectiveRange: nil) as? NSParagraphStyle
+        let block = rendered.attribute(.paragraphStyle, at: index, effectiveRange: nil) as? NSParagraphStyle
+        return (before?.paragraphSpacingBefore, block?.paragraphSpacing)
+    }
+
+    private var marginConfig: MarkdownStyleConfig {
+        var config = MarkdownStyleConfig.baseline()
+        config.paragraph.marginTop = 3
+        config.paragraph.marginBottom = 5
+        return config
+    }
+
+    private let source = "before\n\n$$x$$\n\nafter"
+
+    func testPluginBlockMarginsReplaceParagraphMargins() {
+        let rendered = render(source, config: marginConfig, margins: BlockMargins(marginTop: 7, marginBottom: 9))
+
+        let spacing = blockSpacing(in: rendered)
+        XCTAssertEqual(spacing.before, 7)
+        XCTAssertEqual(spacing.after, 9)
+    }
+
+    func testUnsetPluginBlockMarginsFallBackToParagraph() {
+        let partial = blockSpacing(in: render(source, config: marginConfig, margins: BlockMargins(marginBottom: 9)))
+        XCTAssertEqual(partial.before, 3)
+        XCTAssertEqual(partial.after, 9)
+
+        let none = blockSpacing(in: render(source, config: marginConfig, margins: BlockMargins()))
+        XCTAssertEqual(none.before, 3)
+        XCTAssertEqual(none.after, 5)
+    }
+}


### PR DESCRIPTION
Mirror the React Native package's `math` / `inlineMath` styles in the EnrichedMarkdownLaTeX product. `MathBlock()` styles root-level `$$…$$` (font size, color, background, padding, margins, alignment) and `InlineMath()` colors `$…$`; `MarkdownTheme.latexDefault` carries the RN defaults and is layered above `MarkdownTheme.default` by `.markdownLaTeX()`. Root display math renders as a full-width panel drawn by the attachment.

The base module only gains generic package-level seams: a type-keyed `pluginStyles` slot on `MarkdownStyleConfig`, and `blockMargins` / `defaultTheme` on `MarkdownRenderPlugin`.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

