### PR TITLE
feat(ios): scroll block LaTeX math horizontally

### DIFF
--- a/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Math/MathScreen.swift
+++ b/apps/ios-example/EnrichedMarkdownExample/EnrichedMarkdownExample/Views/Math/MathScreen.swift
@@ -16,6 +16,10 @@ Sums work too:
 
 $$\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}$$
 
+A block wider than the line scrolls horizontally:
+
+$$f(x) = a_0 + \sum_{n=1}^{\infty} \left( a_n \cos\frac{n\pi x}{L} + b_n \sin\frac{n\pi x}{L} \right) + \int_0^1 \frac{\partial^2 u}{\partial t^2}\,dt$$
+
 ## Inside other blocks
 
 > Blockquotes can carry $E = mc^2$ inline.

--- a/packages/enriched-markdown-ios/README.md
+++ b/packages/enriched-markdown-ios/README.md
@@ -379,8 +379,9 @@ EnrichedMarkdownText(content)
 ```
 
 `$…$` typesets inline at the surrounding text size, and a `$$…$$` block on
-its own line renders as a full-width panel. Source that fails to typeset
-falls back to the delimited text. Outside SwiftUI, `MarkdownRenderer.renderLaTeX`
+its own line renders as a full-width panel that scrolls horizontally when
+the formula is wider than the line. Source that fails to typeset falls back
+to the delimited text. Outside SwiftUI, `MarkdownRenderer.renderLaTeX`
 mirrors `MarkdownRenderer.render` with math enabled.
 
 Styling comes from two theme elements the product adds to the builder:

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathAttachment.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathAttachment.swift
@@ -1,5 +1,6 @@
 import EnrichedMarkdown
 import UIKit
+import UniformTypeIdentifiers
 
 /// Metrics and drawing for one typeset formula, in points. The closure
 /// receives a top-left-origin context; the baseline sits at `y == ascent`.
@@ -12,11 +13,16 @@ struct MathTypesetResult {
 
 /// The full-width panel a root-level display formula sits in: the
 /// background fills the line, the formula is inset by `padding` and aligned
-/// inside; one wider than the panel starts at the left inset and clips.
+/// inside; one wider than the panel starts at the left inset and scrolls.
 struct MathPanelStyle: Equatable {
     var backgroundColor: UIColor?
     var padding: CGFloat = 0
     var textAlignment: NSTextAlignment = .natural
+
+    /// The formula plus its inset on every side.
+    func contentSize(formulaSize: CGSize) -> CGSize {
+        CGSize(width: formulaSize.width + padding * 2, height: formulaSize.height + padding * 2)
+    }
 
     func contentOriginX(formulaWidth: CGFloat, panelWidth: CGFloat) -> CGFloat {
         let available = panelWidth - padding * 2
@@ -32,21 +38,41 @@ struct MathPanelStyle: Equatable {
     }
 }
 
-/// A typeset formula embedded in the text: the negative bounds origin sits
-/// it on the baseline, and the raster is drawn lazily via
-/// `image(forBounds:...)`. The formula is rasterized once; a panel is
-/// re-composed around it whenever the line width changes.
+/// A typeset formula embedded in the text, sat on the baseline by its
+/// negative bounds origin. Inline math draws as a lazily rasterized image;
+/// root-level display math (`panel != nil`) is hosted in a scrolling
+/// `MathBlockView`, or under TextKit 1, which installs no view, drawn as a
+/// panel image that clips the overflow.
 final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
+    /// Must be a resolvable UTI, or NSTextAttachment silently drops it.
+    static let fileType: String = UTType(
+        filenameExtension: "enriched-markdown-math"
+    )?.identifier ?? "public.data"
+
+    /// The only way UIKit installs the view; overriding `viewProvider(for:)`
+    /// on the attachment breaks it.
+    private static let providerRegistration: Void = {
+        NSTextAttachment.registerViewProviderClass(
+            MathAttachmentViewProvider.self,
+            forFileType: MathAttachment.fileType
+        )
+    }()
+
     let latex: String
     /// `$$…$$` as opposed to `$…$`; picks the restored delimiters.
     let isDisplay: Bool
     /// Set for root-level display math, which then spans the line.
     let panel: MathPanelStyle?
 
+    /// TextKit 2 recreates the provider view whenever the block re-enters
+    /// the viewport; the horizontal scroll position survives here.
+    var preservedContentOffset: CGPoint = .zero
+
     private let result: MathTypesetResult
     private var panelImage: UIImage?
 
-    private lazy var formulaImage: UIImage? = {
+    /// The formula rasterized once at its natural size.
+    private(set) lazy var formulaImage: UIImage? = {
         guard formulaSize.width > 0, formulaSize.height > 0 else { return nil }
         return UIGraphicsImageRenderer(size: formulaSize).image { result.draw($0.cgContext) }
     }()
@@ -60,7 +86,13 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         self.isDisplay = isDisplay
         self.result = result
         self.panel = panel
-        super.init(data: nil, ofType: nil)
+        if panel != nil {
+            _ = Self.providerRegistration
+            // fileType only persists with non-nil contents; the data is never read.
+            super.init(data: Data("math".utf8), ofType: Self.fileType)
+        } else {
+            super.init(data: nil, ofType: nil)
+        }
         accessibilityLabel = latex
     }
 
@@ -85,10 +117,12 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         Self.delimiter(isDisplay: isDisplay)
     }
 
-    private var formulaSize: CGSize {
+    var formulaSize: CGSize {
         CGSize(width: ceil(result.width), height: ceil(result.ascent) + ceil(result.descent))
     }
 
+    /// TextKit 2 sizes the hosted view from this too; overriding its own
+    /// bounds method instead stops UIKit from installing the view.
     override func attachmentBounds(
         for textContainer: NSTextContainer?,
         proposedLineFragment lineFragmentRect: CGRect,
@@ -99,12 +133,11 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         guard let panel else {
             return CGRect(x: 0, y: -ceil(result.descent), width: size.width, height: size.height)
         }
-        let inset = panel.padding * 2
         return CGRect(
             x: 0,
             y: -(ceil(result.descent) + panel.padding),
-            width: max(lineFragmentRect.width, size.width + inset),
-            height: size.height + inset
+            width: lineFragmentRect.width,
+            height: panel.contentSize(formulaSize: size).height
         )
     }
 

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathBlockView.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathBlockView.swift
@@ -1,0 +1,116 @@
+import UIKit
+
+/// TextKit 2 creates and destroys providers with viewport layout, so all
+/// state lives on the attachment, whose bounds override also sizes the view.
+final class MathAttachmentViewProvider: NSTextAttachmentViewProvider {
+    override init(
+        textAttachment: NSTextAttachment,
+        parentView: UIView?,
+        textLayoutManager: NSTextLayoutManager?,
+        location: NSTextLocation
+    ) {
+        super.init(
+            textAttachment: textAttachment,
+            parentView: parentView,
+            textLayoutManager: textLayoutManager,
+            location: location
+        )
+        // Without this UIKit never installs the view.
+        tracksTextAttachmentViewBounds = true
+    }
+
+    override func loadView() {
+        guard let attachment = textAttachment as? MathAttachment, let panel = attachment.panel else {
+            view = UIView()
+            return
+        }
+        view = MathBlockView(attachment: attachment, panel: panel)
+    }
+}
+
+/// The line-wide panel hosting a root-level display formula, inset and
+/// aligned inside it and scrolling horizontally when wider than the line.
+final class MathBlockView: UIView, UIScrollViewDelegate, UIContextMenuInteractionDelegate {
+    let scrollView = UIScrollView()
+    let formulaView = UIImageView()
+    private let attachment: MathAttachment
+    private let panel: MathPanelStyle
+    private var didRestoreOffset = false
+
+    init(attachment: MathAttachment, panel: MathPanelStyle) {
+        self.attachment = attachment
+        self.panel = panel
+        super.init(frame: .zero)
+
+        backgroundColor = panel.backgroundColor
+
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = true
+        scrollView.alwaysBounceVertical = false
+        scrollView.delegate = self
+        addSubview(scrollView)
+
+        formulaView.image = attachment.formulaImage
+        scrollView.addSubview(formulaView)
+
+        addInteraction(UIContextMenuInteraction(delegate: self))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        scrollView.frame = bounds
+
+        let formulaSize = attachment.formulaSize
+        let contentWidth = panel.contentSize(formulaSize: formulaSize).width
+        let overflow = max(contentWidth - bounds.width, 0)
+
+        formulaView.frame = CGRect(
+            origin: CGPoint(
+                x: panel.contentOriginX(formulaWidth: formulaSize.width, panelWidth: bounds.width),
+                y: panel.padding
+            ),
+            size: formulaSize
+        )
+        scrollView.contentSize = CGSize(width: bounds.width + overflow, height: bounds.height)
+        scrollView.isScrollEnabled = overflow > 0
+
+        if !didRestoreOffset, bounds.width > 0 {
+            didRestoreOffset = true
+            scrollView.contentOffset.x = min(max(attachment.preservedContentOffset.x, 0), overflow)
+        }
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard didRestoreOffset else { return }
+        attachment.preservedContentOffset = scrollView.contentOffset
+    }
+
+    // MARK: - Copy menu
+
+    func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation location: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        let attachment = self.attachment
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+            let copy = UIAction(
+                title: "Copy",
+                image: UIImage(systemName: "doc.on.doc")
+            ) { _ in
+                UIPasteboard.general.string = attachment.latex
+            }
+            let copyMarkdown = UIAction(
+                title: "Copy as Markdown",
+                image: UIImage(systemName: "doc.text")
+            ) { _ in
+                UIPasteboard.general.string = attachment.markdownText()
+            }
+            return UIMenu(children: [copy, copyMarkdown])
+        }
+    }
+}

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathBlockViewTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathBlockViewTests.swift
@@ -1,0 +1,114 @@
+import UIKit
+import XCTest
+@testable import EnrichedMarkdown
+@testable import EnrichedMarkdownLaTeX
+
+@MainActor
+final class MathBlockViewTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func blockAttachment(
+        padding: CGFloat = 12,
+        alignment: NSTextAlignment = .center,
+        background: UIColor? = nil
+    ) -> MathAttachment {
+        MathAttachment(
+            latex: "x",
+            isDisplay: true,
+            result: stubResult(),
+            panel: MathPanelStyle(backgroundColor: background, padding: padding, textAlignment: alignment)
+        )
+    }
+
+    /// A laid-out block view `width` points wide for the stub formula
+    /// (40 × 16, so 64 wide with the default padding).
+    private func layoutView(_ attachment: MathAttachment, width: CGFloat) -> MathBlockView {
+        let view = MathBlockView(attachment: attachment, panel: attachment.panel ?? MathPanelStyle())
+        view.frame = CGRect(x: 0, y: 0, width: width, height: 40)
+        view.layoutIfNeeded()
+        return view
+    }
+
+    private func findBlockView(in view: UIView) -> MathBlockView? {
+        if let block = view as? MathBlockView { return block }
+        for subview in view.subviews {
+            if let found = findBlockView(in: subview) { return found }
+        }
+        return nil
+    }
+
+    // MARK: - Attachment
+
+    func testOnlyBlockMathDeclaresTheProviderFileType() {
+        XCTAssertEqual(blockAttachment().fileType, MathAttachment.fileType)
+        XCTAssertNil(MathAttachment(latex: "x", isDisplay: false, result: stubResult()).fileType)
+    }
+
+    // MARK: - Layout
+
+    func testFittingFormulaIsAlignedAndDoesNotScroll() {
+        let view = layoutView(blockAttachment(alignment: .center, background: .systemRed), width: 300)
+
+        XCTAssertFalse(view.scrollView.isScrollEnabled)
+        XCTAssertEqual(view.scrollView.contentSize, CGSize(width: 300, height: 40))
+        XCTAssertEqual(view.formulaView.frame, CGRect(x: 130, y: 12, width: 40, height: 16))
+        XCTAssertEqual(view.backgroundColor, .systemRed)
+    }
+
+    func testOverflowingFormulaScrollsHorizontally() {
+        let view = layoutView(blockAttachment(alignment: .center), width: 50)
+
+        XCTAssertTrue(view.scrollView.isScrollEnabled)
+        XCTAssertEqual(view.scrollView.contentSize, CGSize(width: 64, height: 40))
+        XCTAssertEqual(view.formulaView.frame.origin, CGPoint(x: 12, y: 12), "starts at the inset")
+    }
+
+    func testScrollOffsetSurvivesViewRecreation() {
+        let attachment = blockAttachment()
+        let first = layoutView(attachment, width: 50)
+        first.scrollView.contentOffset = CGPoint(x: 10, y: 0)
+        XCTAssertEqual(attachment.preservedContentOffset.x, 10)
+
+        XCTAssertEqual(layoutView(attachment, width: 50).scrollView.contentOffset.x, 10)
+
+        attachment.preservedContentOffset = CGPoint(x: 100, y: 0)
+        XCTAssertEqual(layoutView(attachment, width: 50).scrollView.contentOffset.x, 14, "clamped to the overflow")
+        XCTAssertEqual(layoutView(attachment, width: 300).scrollView.contentOffset.x, 0, "a fitting formula does not scroll")
+    }
+
+    // MARK: - Text view integration
+
+    /// Breaks silently with an undeclared UTI, nil contents, or an
+    /// attachment-side viewProvider override. The formula is wider than the
+    /// text view, so the block must stay line-wide rather than widen with it.
+    func testProviderViewIsInstalledInTextView() {
+        let config = MarkdownStyleConfig.baseline()
+        let wide = MathTypesetResult(width: 1000, ascent: 12, descent: 4) { _ in }
+        let rendered = MarkdownRenderer.render(
+            "before\n\n$$E=mc^2$$\n\nafter",
+            config: config,
+            flags: .commonMark,
+            imageRequestHeaders: [:],
+            plugins: [LaTeXRenderPlugin(typeset: { _, _, _, _ in wide })]
+        )
+
+        let textView = MarkdownTextView()
+        textView.styleConfig = config
+        textView.frame = CGRect(x: 0, y: 0, width: 380, height: 10)
+        textView.setMarkdownAttributedText(rendered)
+
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 380, height: 1000))
+        window.addSubview(textView)
+        window.makeKeyAndVisible()
+        let fitted = textView.sizeThatFits(CGSize(width: 380, height: CGFloat.greatestFiniteMagnitude))
+        textView.frame.size.height = fitted.height
+        textView.layoutIfNeeded()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.3))
+        textView.layoutIfNeeded()
+
+        let blockView = findBlockView(in: textView)
+        XCTAssertNotNil(blockView)
+        XCTAssertEqual(blockView?.bounds.width, textView.textContainer.size.width - textView.textContainer.lineFragmentPadding * 2)
+        window.isHidden = true
+    }
+}

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathThemingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/MathThemingTests.swift
@@ -174,7 +174,7 @@ final class MathThemingTests: XCTestCase {
         )
 
         XCTAssertEqual(bounds(of: attachment, lineWidth: 300), CGRect(x: 0, y: -16, width: 300, height: 40))
-        XCTAssertEqual(bounds(of: attachment, lineWidth: 50).width, 64, "a wide formula keeps its padded width")
+        XCTAssertEqual(bounds(of: attachment, lineWidth: 50).width, 50, "a wide formula scrolls (or clips) inside the line")
     }
 
     func testPanelAlignsFormulaInsideInsets() {


### PR DESCRIPTION
Host root-level `$$…$$` math in a `MathBlockView` (a scroll view around the rasterized formula) through a TextKit 2 view provider, the same mechanism GFM tables use, so a formula wider than the line scrolls instead of clipping — matching the React Native container. The panel keeps its background, padding and alignment, preserves its scroll offset across viewport re-entry, and offers Copy / Copy as Markdown on long-press. Inline math still draws as an image; TextKit 1 hosts of `renderLaTeX` output keep the panel image, now clipped to the line.

The attachment's legacy `attachmentBounds` override is what TextKit 2 sizes the view from — an attachment-side TextKit 2 override, like a `viewProvider(for:)` override, stops UIKit installing the view at all.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

