### PR TITLE
fix: input default values serialization

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputRemend.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputRemend.kt
@@ -68,9 +68,12 @@ object InputRemend {
           if (substring == pair.open) {
             if (stack.isNotEmpty() && stack.last() == pair.open) {
               stack.removeAt(stack.lastIndex)
-            } else {
+            } else if (isLeftFlankingOpener(markdown, i, openLen)) {
               stack.add(pair.open)
             }
+            // A delimiter that neither closes an open run nor opens a new one is a
+            // lone literal (e.g. the trailing "*" of "control*"): consume it without
+            // stacking so no spurious closer is appended at end-of-input.
             i += openLen
             matched = true
             break
@@ -118,4 +121,19 @@ object InputRemend {
   }
 
   private fun closingFor(entry: String): String = DELIMITER_PAIRS.firstOrNull { it.open == entry }?.close ?: entry
+
+  /**
+   * A symmetric delimiter can only start (and thus later need auto-closing) if it is
+   * left-flanking: immediately followed by a non-whitespace character. A delimiter at
+   * end-of-input or followed by whitespace cannot open emphasis in CommonMark, so
+   * completing it would fabricate a marker md4c would never have produced.
+   */
+  private fun isLeftFlankingOpener(
+    markdown: String,
+    start: Int,
+    openLen: Int,
+  ): Boolean {
+    val after = start + openLen
+    return after < markdown.length && !markdown[after].isWhitespace()
+  }
 }

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputRemend.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputRemend.kt
@@ -71,9 +71,6 @@ object InputRemend {
             } else if (isLeftFlankingOpener(markdown, i, openLen)) {
               stack.add(pair.open)
             }
-            // A delimiter that neither closes an open run nor opens a new one is a
-            // lone literal (e.g. the trailing "*" of "control*"): consume it without
-            // stacking so no spurious closer is appended at end-of-input.
             i += openLen
             matched = true
             break

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputRemend.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/input/formatting/InputRemend.kt
@@ -5,15 +5,18 @@ object InputRemend {
     val open: String,
     val close: String,
     val symmetric: Boolean,
+    // Emphasis-family delimiters (*, _, ~~) only open when left-flanking; code spans
+    // and spoilers open regardless of surrounding whitespace, so they skip the check.
+    val flanking: Boolean = false,
   )
 
   private val DELIMITER_PAIRS =
     arrayOf(
-      DelimiterPair("***", "***", true),
-      DelimiterPair("**", "**", true),
-      DelimiterPair("*", "*", true),
-      DelimiterPair("_", "_", true),
-      DelimiterPair("~~", "~~", true),
+      DelimiterPair("***", "***", true, flanking = true),
+      DelimiterPair("**", "**", true, flanking = true),
+      DelimiterPair("*", "*", true, flanking = true),
+      DelimiterPair("_", "_", true, flanking = true),
+      DelimiterPair("~~", "~~", true, flanking = true),
       DelimiterPair("||", "||", true),
       DelimiterPair("`", "`", true),
       DelimiterPair("[", "]", false),
@@ -68,7 +71,7 @@ object InputRemend {
           if (substring == pair.open) {
             if (stack.isNotEmpty() && stack.last() == pair.open) {
               stack.removeAt(stack.lastIndex)
-            } else if (isLeftFlankingOpener(markdown, i, openLen)) {
+            } else if (!pair.flanking || isEmphasisOpener(markdown, i, pair.open)) {
               stack.add(pair.open)
             }
             i += openLen
@@ -120,17 +123,37 @@ object InputRemend {
   private fun closingFor(entry: String): String = DELIMITER_PAIRS.firstOrNull { it.open == entry }?.close ?: entry
 
   /**
-   * A symmetric delimiter can only start (and thus later need auto-closing) if it is
-   * left-flanking: immediately followed by a non-whitespace character. A delimiter at
-   * end-of-input or followed by whitespace cannot open emphasis in CommonMark, so
-   * completing it would fabricate a marker md4c would never have produced.
+   * Mirrors md4c's emphasis opener test so completion only closes a delimiter md4c
+   * would actually treat as an opener: the run is a potential opener when its right
+   * side is "stronger" than its left (rightLevel > 0 and rightLevel >= leftLevel),
+   * where each side is scored 0 = whitespace/boundary, 1 = punctuation, 2 = other.
+   * Intraword underscore (both sides "other") never opens. This rejects lone or
+   * whitespace/punctuation-flanked delimiters (`control*`, `2 * 3`, `a*.`, `a_b`)
+   * that would otherwise fabricate a marker. Intraword `*` (`a*b`) is a genuine md4c
+   * opener, so it is not (and cannot be) rejected here.
    */
-  private fun isLeftFlankingOpener(
+  private fun isEmphasisOpener(
     markdown: String,
     start: Int,
-    openLen: Int,
+    open: String,
   ): Boolean {
-    val after = start + openLen
-    return after < markdown.length && !markdown[after].isWhitespace()
+    val leftLevel = flankingLevelAt(markdown, start - 1)
+    val rightLevel = flankingLevelAt(markdown, start + open.length)
+    if (open == "_" && leftLevel == 2 && rightLevel == 2) return false
+    return rightLevel > 0 && rightLevel >= leftLevel
+  }
+
+  /** 0 = whitespace or out-of-bounds boundary, 1 = punctuation, 2 = letter/digit. */
+  private fun flankingLevelAt(
+    markdown: String,
+    index: Int,
+  ): Int {
+    if (index !in markdown.indices) return 0
+    val c = markdown[index]
+    return when {
+      c.isWhitespace() -> 0
+      c.isLetterOrDigit() -> 2
+      else -> 1
+    }
   }
 }

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
@@ -106,6 +106,10 @@ struct ParseContext {
   std::vector<BlockInfo> openBlockStack;
   std::vector<BlockInfo> resolvedBlocks;
   std::vector<size_t> textStartOffsets;
+  // Byte offsets of backslashes that md4c resolved as escape sequences (e.g. the
+  // '\' of "\*"). md4c never reports these as syntax, so they are collected in
+  // onText and stripped from the plain text alongside inline/block delimiters.
+  std::vector<size_t> escapeByteOffsets;
   size_t lastTextEnd = 0;
   // Open list containers, innermost last (true = ordered). An item's depth is
   // the stack size - 1 and its type the innermost container's; md4c carries no
@@ -315,6 +319,16 @@ static int onText(MD_TEXTTYPE, const MD_CHAR *text, MD_SIZE size, void *userdata
   size_t textEnd = textStart + size;
   context->textStartOffsets.push_back(textStart);
 
+  // md4c resolves a backslash escape by dropping the backslash and emitting the
+  // escaped character as its own text run that points into the buffer; the
+  // backslash byte is left in the gap, covered by no run. Flag it when the byte
+  // right before this run is a backslash sitting at or after the previous run's
+  // end. A backslash that is real content (not a valid escape, or inside a code
+  // span) stays within a text run, so its preceding-byte check never matches.
+  if (textStart > 0 && context->buffer[textStart - 1] == '\\' && (textStart - 1) >= context->lastTextEnd) {
+    context->escapeByteOffsets.push_back(textStart - 1);
+  }
+
   for (auto &openSpan : context->openStack) {
     if (openSpan.contentStartByteOffset == kByteOffsetUnset) {
       openSpan.contentStartByteOffset = textStart;
@@ -492,10 +506,17 @@ static NSArray<ENRMBlockRange *> *blockRangesFromContext(const ParseContext &con
   ParseContext context;
   NSArray<ENRMInputStyledRange *> *styledRanges = @[];
   NSArray<ENRMBlockRange *> *rawBlockRanges = @[];
+  NSMutableIndexSet *escapeIndexes = [NSMutableIndexSet indexSet];
   if (runMd4cParse(markdown, context)) {
     auto byteMap = buildByteToUTF16Map(context.buffer, context.bufferLength);
     styledRanges = styledRangesFromContext(context, byteMap);
     rawBlockRanges = blockRangesFromContext(context, byteMap, markdown);
+    for (size_t escapeByte : context.escapeByteOffsets) {
+      NSUInteger escapeIndex = mapByteOffset(byteMap, escapeByte, context.bufferLength);
+      if (escapeIndex < markdown.length) {
+        [escapeIndexes addIndex:escapeIndex];
+      }
+    }
   }
 
   NSUInteger rawLength = markdown.length;
@@ -534,6 +555,12 @@ static NSArray<ENRMBlockRange *> *blockRangesFromContext(const ParseContext &con
       [syntaxIndexes addIndexesInRange:NSMakeRange(lineStart, contentStart - lineStart)];
     }
   }
+
+  // Hide the backslash of every resolved escape sequence ("\*" -> "*"), matching
+  // the read-only renderer and the Android input, which both build display text
+  // from md4c's resolved output. Only the backslash is treated as syntax; the
+  // escaped character stays visible.
+  [syntaxIndexes addIndexes:escapeIndexes];
 
   // Strip \n/\r from syntax ranges — newlines are structural content, not
   // markdown syntax, and must survive into the plain text.

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputParser.mm
@@ -106,9 +106,8 @@ struct ParseContext {
   std::vector<BlockInfo> openBlockStack;
   std::vector<BlockInfo> resolvedBlocks;
   std::vector<size_t> textStartOffsets;
-  // Byte offsets of backslashes that md4c resolved as escape sequences (e.g. the
-  // '\' of "\*"). md4c never reports these as syntax, so they are collected in
-  // onText and stripped from the plain text alongside inline/block delimiters.
+  // Byte offsets of backslashes md4c resolved as escape sequences (the '\' of "\*"),
+  // stripped from the plain text alongside inline/block delimiters.
   std::vector<size_t> escapeByteOffsets;
   size_t lastTextEnd = 0;
   // Open list containers, innermost last (true = ordered). An item's depth is
@@ -319,12 +318,6 @@ static int onText(MD_TEXTTYPE, const MD_CHAR *text, MD_SIZE size, void *userdata
   size_t textEnd = textStart + size;
   context->textStartOffsets.push_back(textStart);
 
-  // md4c resolves a backslash escape by dropping the backslash and emitting the
-  // escaped character as its own text run that points into the buffer; the
-  // backslash byte is left in the gap, covered by no run. Flag it when the byte
-  // right before this run is a backslash sitting at or after the previous run's
-  // end. A backslash that is real content (not a valid escape, or inside a code
-  // span) stays within a text run, so its preceding-byte check never matches.
   if (textStart > 0 && context->buffer[textStart - 1] == '\\' && (textStart - 1) >= context->lastTextEnd) {
     context->escapeByteOffsets.push_back(textStart - 1);
   }
@@ -556,10 +549,6 @@ static NSArray<ENRMBlockRange *> *blockRangesFromContext(const ParseContext &con
     }
   }
 
-  // Hide the backslash of every resolved escape sequence ("\*" -> "*"), matching
-  // the read-only renderer and the Android input, which both build display text
-  // from md4c's resolved output. Only the backslash is treated as syntax; the
-  // escaped character stays visible.
   [syntaxIndexes addIndexes:escapeIndexes];
 
   // Strip \n/\r from syntax ranges — newlines are structural content, not

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputRemend.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputRemend.mm
@@ -22,6 +22,19 @@ static NSString *closingForStackEntry(NSString *entry)
   return entry;
 }
 
+// A symmetric delimiter can only start (and thus later need auto-closing) if it is
+// left-flanking: immediately followed by a non-whitespace character. A delimiter at
+// end-of-input or followed by whitespace cannot open emphasis in CommonMark, so
+// completing it would fabricate a marker md4c would never have produced.
+static BOOL isLeftFlankingOpener(NSString *markdown, NSUInteger start, NSUInteger openLen)
+{
+  NSUInteger after = start + openLen;
+  if (after >= markdown.length) {
+    return NO;
+  }
+  return ![[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[markdown characterAtIndex:after]];
+}
+
 NSString *ENRMInputRemendComplete(NSString *markdown)
 {
   if (markdown.length == 0) {
@@ -84,9 +97,12 @@ NSString *ENRMInputRemendComplete(NSString *markdown)
         if ([substring isEqualToString:pair.open]) {
           if (stack.count > 0 && [stack.lastObject isEqualToString:pair.open]) {
             [stack removeLastObject];
-          } else {
+          } else if (isLeftFlankingOpener(markdown, i, openLen)) {
             [stack addObject:pair.open];
           }
+          // A delimiter that neither closes an open run nor opens a new one is a
+          // lone literal (e.g. the trailing "*" of "control*"): consume it without
+          // stacking so no spurious closer is appended at end-of-input.
           i += openLen;
           matched = YES;
           break;

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputRemend.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputRemend.mm
@@ -4,11 +4,14 @@ typedef struct {
   NSString *__unsafe_unretained open;
   NSString *__unsafe_unretained close;
   BOOL symmetric;
+  // Emphasis-family delimiters (*, _, ~~) only open when left-flanking; code spans
+  // and spoilers open regardless of surrounding whitespace, so they skip the check.
+  BOOL flanking;
 } ENRMDelimiterPair;
 
 static const ENRMDelimiterPair kDelimiterPairs[] = {
-    {@"***", @"***", YES}, {@"**", @"**", YES}, {@"*", @"*", YES}, {@"_", @"_", YES},
-    {@"~~", @"~~", YES},   {@"||", @"||", YES}, {@"`", @"`", YES}, {@"[", @"]", NO},
+    {@"***", @"***", YES, YES}, {@"**", @"**", YES, YES}, {@"*", @"*", YES, YES}, {@"_", @"_", YES, YES},
+    {@"~~", @"~~", YES, YES},   {@"||", @"||", YES, NO},  {@"`", @"`", YES, NO},  {@"[", @"]", NO, NO},
 };
 static const NSUInteger kDelimiterPairCount = sizeof(kDelimiterPairs) / sizeof(kDelimiterPairs[0]);
 
@@ -22,17 +25,38 @@ static NSString *closingForStackEntry(NSString *entry)
   return entry;
 }
 
-// A symmetric delimiter can only start (and thus later need auto-closing) if it is
-// left-flanking: immediately followed by a non-whitespace character. A delimiter at
-// end-of-input or followed by whitespace cannot open emphasis in CommonMark, so
-// completing it would fabricate a marker md4c would never have produced.
-static BOOL isLeftFlankingOpener(NSString *markdown, NSUInteger start, NSUInteger openLen)
+// 0 = whitespace or out-of-bounds boundary, 1 = punctuation, 2 = letter/digit.
+static int flankingLevelAt(NSString *markdown, NSInteger index)
 {
-  NSUInteger after = start + openLen;
-  if (after >= markdown.length) {
+  if (index < 0 || index >= (NSInteger)markdown.length) {
+    return 0;
+  }
+  unichar c = [markdown characterAtIndex:(NSUInteger)index];
+  if ([[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:c]) {
+    return 0;
+  }
+  if ([[NSCharacterSet alphanumericCharacterSet] characterIsMember:c]) {
+    return 2;
+  }
+  return 1;
+}
+
+// Mirrors md4c's emphasis opener test so completion only closes a delimiter md4c
+// would actually treat as an opener: the run is a potential opener when its right
+// side is "stronger" than its left (rightLevel > 0 and rightLevel >= leftLevel),
+// where each side is scored 0 = whitespace/boundary, 1 = punctuation, 2 = other.
+// Intraword underscore (both sides "other") never opens. This rejects lone or
+// whitespace/punctuation-flanked delimiters (control*, 2 * 3, a*., a_b) that would
+// otherwise fabricate a marker. Intraword * (a*b) is a genuine md4c opener, so it is
+// not (and cannot be) rejected here.
+static BOOL isEmphasisOpener(NSString *markdown, NSUInteger start, NSString *open)
+{
+  int leftLevel = flankingLevelAt(markdown, (NSInteger)start - 1);
+  int rightLevel = flankingLevelAt(markdown, (NSInteger)start + (NSInteger)open.length);
+  if ([open isEqualToString:@"_"] && leftLevel == 2 && rightLevel == 2) {
     return NO;
   }
-  return ![[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:[markdown characterAtIndex:after]];
+  return rightLevel > 0 && rightLevel >= leftLevel;
 }
 
 NSString *ENRMInputRemendComplete(NSString *markdown)
@@ -97,7 +121,7 @@ NSString *ENRMInputRemendComplete(NSString *markdown)
         if ([substring isEqualToString:pair.open]) {
           if (stack.count > 0 && [stack.lastObject isEqualToString:pair.open]) {
             [stack removeLastObject];
-          } else if (isLeftFlankingOpener(markdown, i, openLen)) {
+          } else if (!pair.flanking || isEmphasisOpener(markdown, i, pair.open)) {
             [stack addObject:pair.open];
           }
           i += openLen;

--- a/packages/react-native-enriched-markdown/ios/input/ENRMInputRemend.mm
+++ b/packages/react-native-enriched-markdown/ios/input/ENRMInputRemend.mm
@@ -100,9 +100,6 @@ NSString *ENRMInputRemendComplete(NSString *markdown)
           } else if (isLeftFlankingOpener(markdown, i, openLen)) {
             [stack addObject:pair.open];
           }
-          // A delimiter that neither closes an open run nor opens a new one is a
-          // lone literal (e.g. the trailing "*" of "control*"): consume it without
-          // stacking so no spurious closer is appended at end-of-input.
           i += openLen;
           matched = YES;
           break;


### PR DESCRIPTION
### What/Why?

Closes #792 

Fixes two input-side bugs surfaced by #792, both around `defaultValue` / pasted markdown.

**1. iOS input displayed the backslash of escape sequences literally.** `a \* b` rendered as `a \* b` instead of `a * b`. Per CommonMark, `\*` is syntax that resolves to a literal `*` - the backslash is not content. iOS was the only affected path: it builds the display text by copying the raw markdown minus known syntax offsets, and md4c never reports the escape backslash as syntax, so it survived. Android input and both read-only renderers already build from md4c's resolved output and were unaffected. Fix: `ENRMInputParser` now flags the backslash of every resolved escape (detected from md4c's own text runs) and strips it from the display, the same way an emphasis delimiter is hidden. The escaped character stays visible.

**2. The remend/completion step fabricated a trailing marker.** A lone unmatched delimiter, e.g. `defaultValue="a\*b control*"` (or plain `xyz control*`), had a closing `*` appended at end-of-input and leaked into the text, showing `a*b control**`. Root cause: `InputRemend` treated any unmatched symmetric delimiter as a dangling opener, even a lone literal that CommonMark/md4c keep as plain text. This was cross-platform in behaviour but only visible on Android (iOS rebuilds display from the original string and discards remend's appended tail). Fix: a delimiter is only completed when md4c would actually treat it as an opener. The check is delimiter-specific - emphasis-family delimiters (`*`, `_`, `~~`) mirror md4c's left-flanking rule (`rightLevel > 0 && rightLevel >= leftLevel`, with intraword `_` excluded), while code spans and spoilers open regardless of surrounding whitespace and skip the check. Applied to both platforms.

Verified against md4c's own opener rules (`cpp/md4c/md4c.c`): emphasis/underscore at ~3285, strikethrough at ~3638, spoiler at ~3535. Genuine completions still work (`**bold` -> `**bold**`, `*italic`, `` `code ``, `` ` code ``, `|| secret`, `~~strike`, `[link` -> `[link]`); fabricated markers for lone/whitespace/punctuation-flanked delimiters (`control*`, `2 * 3`, `a*.`, `a_b`) are gone.

### Testing

- iOS/Android: set `defaultValue` to `a\*b control*` and confirm the editor shows `a*b control*` (no visible backslash, no doubled trailing star).
- Regression check that normal formatting still round-trips: `**bold**`, `*italic*`, `[text](url)`, lists, strikethrough, spoilers, code spans.
- remend opener/closer behaviour verified across a range of inputs (dangling openers still complete; lone, whitespace-flanked and punctuation-flanked literals no longer do).

### Known limitations / follow-ups

- **Intraword `*`** (e.g. `a*b`) is a genuine md4c opener, so it still completes to `a*b*`. No flanking rule can distinguish "literal `*`" from "unclosed emphasis" here - this is inherent heuristic ambiguity.
- **Android reconstruction** (#799): Android leaks remend's completion characters into the display where iOS discards them; the remend heuristic is a workaround. Aligning Android's display reconstruction with iOS would fix this structurally and let us delete the heuristic (and also fixes the `[link` -> `[link]` leak).
- **Serializer re-escaping**: paired escaped delimiters (`\*x\*`) can still change meaning on round-trip because the serializer does not re-escape literal markers on save - tracked separately.
- **Escaped hard-break** (`a\` + newline): md4c sets a hard-break flag and does not emit `onText` for the escaped newline, so the iOS escape detector misses it and the backslash stays visible. Pre-existing; not addressed here.

The fixes live in native ObjC/Kotlin, so they are not covered by the Jest suite; behavioural coverage would need native test targets.

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
