### PR TITLE
perf(ios): stop re-assigning and re-measuring unchanged text

### DIFF
--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/EnrichedMarkdownText.swift
@@ -37,10 +37,13 @@ public struct EnrichedMarkdownText: View {
     }
 
     public var body: some View {
-        MarkdownTextViewRepresentable(
+        // Resolved once: `styleConfig` rebuilds the whole config on each read,
+        // and the representable and every `onChange` below read it.
+        let config = styleConfig
+        return MarkdownTextViewRepresentable(
             attributedText: renderStore.attributedText,
             source: renderStore.source,
-            styleConfig: styleConfig,
+            styleConfig: config,
             onLinkPress: onLinkPress,
             onLinkLongPress: onLinkLongPress,
             selectionMenuConfig: selectionMenuConfig,
@@ -48,7 +51,7 @@ public struct EnrichedMarkdownText: View {
             selectionColor: selectionColor,
             onTaskListItemTap: isTaskListToggleEnabled ? { hit in
                 let checked = !hit.checked
-                renderStore.applyTaskListToggle(index: hit.index, checked: checked, config: styleConfig)
+                renderStore.applyTaskListToggle(index: hit.index, checked: checked, config: config)
                 onTaskListItemPress?(
                     TaskListItemPressEvent(index: hit.index, checked: checked, text: hit.itemText)
                 )
@@ -58,7 +61,7 @@ public struct EnrichedMarkdownText: View {
         .onAppear {
             renderStore.schedule(
                 markdown: markdown,
-                config: styleConfig,
+                config: config,
                 flags: flags,
                 imageRequestHeaders: imageRequestHeaders,
                 plugins: renderPlugins
@@ -70,13 +73,13 @@ public struct EnrichedMarkdownText: View {
         .onChange(of: markdown) { newValue in
             renderStore.schedule(
                 markdown: newValue,
-                config: styleConfig,
+                config: config,
                 flags: flags,
                 imageRequestHeaders: imageRequestHeaders,
                 plugins: renderPlugins
             )
         }
-        .onChange(of: styleConfig) { newValue in
+        .onChange(of: config) { newValue in
             renderStore.schedule(
                 markdown: markdown,
                 config: newValue,
@@ -88,7 +91,7 @@ public struct EnrichedMarkdownText: View {
         .onChange(of: flags) { newValue in
             renderStore.schedule(
                 markdown: markdown,
-                config: styleConfig,
+                config: config,
                 flags: newValue,
                 imageRequestHeaders: imageRequestHeaders,
                 plugins: renderPlugins
@@ -97,7 +100,7 @@ public struct EnrichedMarkdownText: View {
         .onChange(of: imageRequestHeaders) { newValue in
             renderStore.schedule(
                 markdown: markdown,
-                config: styleConfig,
+                config: config,
                 flags: flags,
                 imageRequestHeaders: newValue,
                 plugins: renderPlugins

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -212,8 +212,23 @@ final class MarkdownTextView: UITextView {
     var styleConfig: MarkdownStyleConfig = .baseline() {
         didSet {
             updateDecorationStyleConfig()
+            // `updateUIView` assigns this on every pass, so only a real change
+            // may drop the measurement — clearing it unconditionally would
+            // re-measure the document every frame, which is the whole point.
+            if styleConfig != oldValue { cachedFit = nil }
         }
     }
+
+    /// The exact instance last handed to `attributedText`.
+    ///
+    /// `UITextView.attributedText` is `@NSCopying`, so its getter cannot serve
+    /// as an identity token — reading it to compare would copy the whole
+    /// document. This can.
+    private var renderedText: NSAttributedString?
+
+    /// Measuring lays out the whole document, and SwiftUI asks for it on every
+    /// update pass — and again through `intrinsicContentSize`.
+    private var cachedFit: (width: CGFloat, text: NSAttributedString, height: CGFloat)?
 
     /// Mirrored from the representable so VoiceOver link elements can invoke
     /// the press handler via accessibilityActivate.
@@ -381,11 +396,30 @@ final class MarkdownTextView: UITextView {
     }
 
     func setMarkdownAttributedText(_ attributedText: NSAttributedString) {
+        // Identity first, and not as an optimization: the round trip through
+        // `attributedText` does not compare equal to what was set, so the
+        // guard below lets every update through and re-assigns the whole
+        // document — measured at 30 re-assignments a second under a parent
+        // that re-evaluates at frame rate.
+        if let renderedText, renderedText === attributedText { return }
         guard !(self.attributedText?.isEqual(to: attributedText) ?? false) else { return }
+        renderedText = attributedText
+        cachedFit = nil
         self.attributedText = attributedText
         invalidateIntrinsicContentSize()
         setDecorationNeedsDisplay()
         rebuildAccessibilityElements()
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        if let cachedFit, cachedFit.width == size.width, cachedFit.text === renderedText {
+            return CGSize(width: size.width, height: cachedFit.height)
+        }
+        let fitted = super.sizeThatFits(size)
+        if let renderedText {
+            cachedFit = (size.width, renderedText, fitted.height)
+        }
+        return fitted
     }
 
     private func rebuildAccessibilityElements() {

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownTextViewTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownTests/MarkdownTextViewTests.swift
@@ -57,4 +57,70 @@ final class MarkdownTextViewTests: XCTestCase {
         XCTAssertTrue(environment.markdownSelectable)
         XCTAssertNil(environment.markdownSelectionColor)
     }
+
+    // MARK: - Measurement cache
+
+    // Measuring lays out the whole document, so the result is cached against
+    // the width and the text it was measured for. These cover the
+    // invalidation: a stale height is a misdrawn page, not a slow one.
+
+    private func attributed(_ string: String, size: CGFloat = 17) -> NSAttributedString {
+        NSAttributedString(string: string, attributes: [.font: UIFont.systemFont(ofSize: size)])
+    }
+
+    private static let measureWidth: CGFloat = 200
+
+    private func height(of textView: MarkdownTextView, width: CGFloat = measureWidth) -> CGFloat {
+        textView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude)).height
+    }
+
+    func testRepeatedMeasurementsAgree() {
+        let textView = MarkdownTextView()
+        textView.setMarkdownAttributedText(attributed("One line of text"))
+
+        XCTAssertEqual(height(of: textView), height(of: textView))
+    }
+
+    func testLongerTextMeasuresTaller() {
+        let textView = MarkdownTextView()
+        textView.setMarkdownAttributedText(attributed("Short"))
+        let short = height(of: textView)
+
+        textView.setMarkdownAttributedText(attributed(String(repeating: "Much longer body copy. ", count: 20)))
+
+        XCTAssertGreaterThan(height(of: textView), short)
+    }
+
+    func testNarrowerWidthMeasuresTaller() {
+        let textView = MarkdownTextView()
+        textView.setMarkdownAttributedText(attributed(String(repeating: "Wrapping body copy. ", count: 10)))
+        let wide = height(of: textView, width: 400)
+
+        XCTAssertGreaterThan(height(of: textView, width: 120), wide)
+    }
+
+    /// Growing the font changes the height without changing the string, so the
+    /// cache must key on the instance and not on its text.
+    func testLargerFontMeasuresTallerForTheSameString() {
+        let textView = MarkdownTextView()
+        textView.setMarkdownAttributedText(attributed("Same string", size: 12))
+        let small = height(of: textView)
+
+        textView.setMarkdownAttributedText(attributed("Same string", size: 40))
+
+        XCTAssertGreaterThan(height(of: textView), small)
+    }
+
+    /// A distinct instance holding equal content is not a re-render: the text
+    /// view keeps what it has, and the measurement stays valid.
+    func testEqualReplacementKeepsMeasurement() {
+        let textView = MarkdownTextView()
+        textView.setMarkdownAttributedText(attributed("Stable content"))
+        let before = height(of: textView)
+
+        textView.setMarkdownAttributedText(attributed("Stable content"))
+
+        XCTAssertEqual(height(of: textView), before)
+        XCTAssertEqual(textView.attributedText.string, "Stable content")
+    }
 }


### PR DESCRIPTION
### What/Why?

Two costs on every `updateUIView`, both paid on a document that had not changed.

**1. The whole document was re-assigned on every pass.** `setMarkdownAttributedText` guards on `self.attributedText?.isEqual(to:)`, but `UITextView.attributedText` is `@NSCopying` and the round trip does not compare equal to what was set. The guard lets every update through. Instrumented at **30 re-assignments a second** under a parent re-evaluating at frame rate. Keeping the instance that was last set gives the guard something that does compare — by identity.

**2. The whole document was then re-measured.** `UITextView.sizeThatFits` lays out everything, and SwiftUI asks for it on every update pass and again through `intrinsicContentSize` — **4.4 ms a call, 36 calls a second**. With the text no longer churning, a height keyed on `(width, text)` answers all of them.

The two are linked: without the identity check the text is re-assigned constantly, which invalidates any measurement cache, so neither fix works without the other.

Also in here:

- `updateUIView` assigns `styleConfig` on every pass, so only a real change drops the measurement. Decoration updates are untouched.
- `EnrichedMarkdownText` binds `styleConfig` once per evaluation rather than rebuilding the config for the representable and again for `onChange(of:)`.

### Testing

Example app's article screen, parent re-evaluating the markdown subtree at 60 Hz. **One clean build**, toggled at runtime so both arms share a binary:

| | CPU |
| - | - |
| Before | **99.6%**, **100.0%** |
| After | **32.1%**, **32.4%** |

Counters confirm the mechanism rather than inferring it from CPU:

| | before | after |
| - | - | - |
| Text re-assignments/sec | 30 | **0** |
| `sizeThatFits` hit rate | 0 / 37 | **36 / 36** |

New `MarkdownTextViewTests` cases cover invalidation on text, width and font change. Full suite: 386 + 31 LaTeX, passing.

**Cache safety:** attachment heights are fixed when the string is built — `MarkdownImageAttachment.cachedHeight` is a `let` and math is typeset synchronously — so nothing resizes underneath a cached measurement, including when a remote image finishes loading.

**Scope note:** this PR originally also memoized theme resolution behind `Equatable` conformances on every theme element (27 files). A theme resolve is ~57 µs against `sizeThatFits`'s 4.4 ms, so that was dropped; the numbers above are this 3-file version.

### PR Checklist

- [x] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android — iOS-only change
- [ ] Updated documentation/README if applicable — no API change
- [x] Ran example app to verify changes
- [ ] E2E tests are passing — not run locally
- [ ] Required E2E tests have been added (if applicable) — unit tests added instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kiX4Fujou7PvbUxoSvaxu