### PR TITLE
perf(ios): reuse LaTeX rasters across renders

### DIFF
--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathAttachment.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathAttachment.swift
@@ -8,7 +8,18 @@ struct MathTypesetResult {
     let width: CGFloat
     let ascent: CGFloat
     let descent: CGFloat
+    /// Pre-rasterized off the main thread; nil draws lazily.
+    var image: UIImage?
     let draw: (CGContext) -> Void
+
+    var size: CGSize {
+        CGSize(width: ceil(width), height: ceil(ascent) + ceil(descent))
+    }
+
+    func rasterize() -> UIImage? {
+        guard size.width > 0, size.height > 0 else { return nil }
+        return UIGraphicsImageRenderer(size: size).image { draw($0.cgContext) }
+    }
 }
 
 /// The full-width panel a root-level display formula sits in: the
@@ -39,7 +50,7 @@ struct MathPanelStyle: Equatable {
 }
 
 /// A typeset formula embedded in the text, sat on the baseline by its
-/// negative bounds origin. Inline math draws as a lazily rasterized image;
+/// negative bounds origin. Inline math draws as a rasterized image;
 /// root-level display math (`panel != nil`) is hosted in a scrolling
 /// `MathBlockView`, or under TextKit 1, which installs no view, drawn as a
 /// panel image that clips the overflow.
@@ -72,10 +83,7 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
     private var panelImage: UIImage?
 
     /// The formula rasterized once at its natural size.
-    private(set) lazy var formulaImage: UIImage? = {
-        guard formulaSize.width > 0, formulaSize.height > 0 else { return nil }
-        return UIGraphicsImageRenderer(size: formulaSize).image { result.draw($0.cgContext) }
-    }()
+    private(set) lazy var formulaImage: UIImage? = result.image ?? result.rasterize()
 
     static func delimiter(isDisplay: Bool) -> String {
         isDisplay ? "$$" : "$"
@@ -92,6 +100,8 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
             super.init(data: Data("math".utf8), ofType: Self.fileType)
         } else {
             super.init(data: nil, ofType: nil)
+            // Else TextKit 2 hosts each inline formula in an image view, rebuilt per layout pass.
+            allowsTextAttachmentView = false
         }
         accessibilityLabel = latex
     }
@@ -117,9 +127,7 @@ final class MathAttachment: NSTextAttachment, MarkdownPluginAttachment {
         Self.delimiter(isDisplay: isDisplay)
     }
 
-    var formulaSize: CGSize {
-        CGSize(width: ceil(result.width), height: ceil(result.ascent) + ceil(result.descent))
-    }
+    var formulaSize: CGSize { result.size }
 
     /// TextKit 2 sizes the hosted view from this too; overriding its own
     /// bounds method instead stops UIKit from installing the view.

--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathRenderer.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdownLaTeX/MathRenderer.swift
@@ -59,8 +59,9 @@ final class MathRenderer: NodeRenderer {
         output.append(NSAttributedString(string: "\u{FFFC}", attributes: attributes))
     }
 
-    /// Synchronous and thread-safe, so it runs on the render queue; layouts are
-    /// cached because every re-render (each streamed token) would repeat the FFI parse.
+    /// Synchronous and thread-safe, so it runs on the render queue; layouts and
+    /// rasters are cached because every re-render (each streamed token) would
+    /// otherwise repeat the FFI parse and redraw every formula.
     static func raTeXTypeset(
         _ latex: String,
         displayMode: Bool,
@@ -74,13 +75,15 @@ final class MathRenderer: NodeRenderer {
         }
 
         let renderer = RaTeXRenderer(displayList: displayList, fontSize: fontSize)
-        return MathTypesetResult(
+        var result = MathTypesetResult(
             width: renderer.width,
             ascent: renderer.height,
             descent: renderer.depth
         ) { context in
             renderer.draw(in: context)
         }
+        result.image = raster(for: result, key: "\(fontSize)|\(layoutKey(latex, displayMode: displayMode, color: color))")
+        return result
     }
 
     private static let displayListCache: NSCache<NSString, DisplayListBox> = {
@@ -89,11 +92,31 @@ final class MathRenderer: NodeRenderer {
         return cache
     }()
 
+    private static let rasterCache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.countLimit = 300
+        cache.totalCostLimit = 24 * 1024 * 1024
+        return cache
+    }()
+
+    private static func raster(for result: MathTypesetResult, key: String) -> UIImage? {
+        if let cached = rasterCache.object(forKey: key as NSString) {
+            return cached
+        }
+        guard let image = result.rasterize(), let cgImage = image.cgImage else { return nil }
+        rasterCache.setObject(image, forKey: key as NSString, cost: cgImage.bytesPerRow * cgImage.height)
+        return image
+    }
+
     /// The layout is font-size independent (em units) but bakes in the
     /// color, so the color joins the key.
-    private static func displayList(for latex: String, displayMode: Bool, color: UIColor) -> DisplayList? {
+    private static func layoutKey(_ latex: String, displayMode: Bool, color: UIColor) -> String {
         let colorKey = color.cgColor.components?.map { "\($0)" }.joined(separator: ",") ?? "?"
-        let key = "\(displayMode)|\(colorKey)|\(latex)" as NSString
+        return "\(displayMode)|\(colorKey)|\(latex)"
+    }
+
+    private static func displayList(for latex: String, displayMode: Bool, color: UIColor) -> DisplayList? {
+        let key = layoutKey(latex, displayMode: displayMode, color: color) as NSString
         if let cached = displayListCache.object(forKey: key) {
             return cached.displayList
         }

--- a/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXRenderingTests.swift
+++ b/packages/enriched-markdown-ios/Tests/EnrichedMarkdownLaTeXTests/LaTeXRenderingTests.swift
@@ -88,6 +88,39 @@ final class LaTeXRenderingTests: XCTestCase {
         XCTAssertFalse(isBlank(image))
     }
 
+    /// Streaming re-renders the document per token; the same formula must
+    /// not be redrawn each time.
+    func testRepeatedRendersShareOneRaster() {
+        let config = MarkdownStyleConfig.baseline()
+        let first = mathAttachments(in: MarkdownRenderer.renderLaTeX("$x^2$", config: config))
+        let second = mathAttachments(in: MarkdownRenderer.renderLaTeX("$x^2$", config: config))
+        guard let firstImage = first.first?.formulaImage, let secondImage = second.first?.formulaImage else {
+            return XCTFail("expected rasterized formulas")
+        }
+        XCTAssertTrue(firstImage === secondImage)
+    }
+
+    func testDifferentFontSizesDoNotShareARaster() {
+        let config = MarkdownStyleConfig.baseline()
+        let body = mathAttachments(in: MarkdownRenderer.renderLaTeX("$x^2$", config: config))
+        let heading = mathAttachments(in: MarkdownRenderer.renderLaTeX("# $x^2$", config: config))
+        guard let bodyImage = body.first?.formulaImage, let headingImage = heading.first?.formulaImage else {
+            return XCTFail("expected rasterized formulas")
+        }
+        XCTAssertFalse(bodyImage === headingImage)
+        XCTAssertNotEqual(bodyImage.size, headingImage.size)
+    }
+
+    func testStubbedTypesetNeverSharesARaster() {
+        let first = renderWithStub("$x^2$") { _, _, _, _ in self.stubResult() }
+        let second = renderWithStub("$x^2$") { _, _, _, _ in self.stubResult() }
+        guard let firstImage = mathAttachments(in: first).first?.formulaImage,
+              let secondImage = mathAttachments(in: second).first?.formulaImage else {
+            return XCTFail("expected rasterized formulas")
+        }
+        XCTAssertFalse(firstImage === secondImage)
+    }
+
     func testRenderLaTeXProducesMathAttachmentWithoutFlagSetup() {
         let rendered = MarkdownRenderer.renderLaTeX("inline $x^2$ math", config: config)
 


### PR DESCRIPTION
Every re-render (each streamed token) built fresh MathAttachments, and each formula was rasterized on the main thread at first draw. TextKit 2 also hosted every inline formula in its own image view, rebuilt on each layout pass.

Rasterize in raTeXTypeset on the render queue, cached next to the display lists, and draw inline math directly instead of through attachment views. Per re-render main-thread cost on a 70-formula document: 38 ms -> 15 ms.

### What/Why?
<!-- Context is helpful. What does the PR do? Why is this change needed? -->



### Testing
<!-- How to test changed code? What testing has been done? -->



<!-- #### Screenshots -->
<!-- If you attach screenshots, please use <img src="" width=200/> -->

<!-- Table for side-by-side comparison (iOS/Android or Before/After)
| iOS | Android |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |

| Before | After |
| - | - |
| <img src="" width=300 /> | <img src="" width=300 /> |
-->

### PR Checklist

- [ ] Code compiles and runs on iOS
- [ ] Code compiles and runs on Android
- [ ] Updated documentation/README if applicable
- [ ] Ran example app to verify changes
- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)

