### PR TITLE
fix(android): containerStyle border and clamped numberOfLines box

### DIFF
--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -84,9 +84,7 @@ class EnrichedMarkdownManager :
     view.commitProps()
   }
 
-  // BaseViewManagerDelegate does not apply borderWidth / borderColor / borderRadius
-  // to a SimpleViewManager (see applyReactBorderProps), so `containerStyle` borders
-  // are dropped on Android. Replay them after the delegate has run.
+  // Replay containerStyle border props the delegate drops (see applyReactBorderProps).
   override fun updateProperties(
     view: EnrichedMarkdown,
     props: ReactStylesDiffMap,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownManager.kt
@@ -16,6 +16,7 @@ import com.facebook.yoga.YogaMeasureMode
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
 import com.swmansion.enriched.markdown.utils.common.CodeBlockStreamingMode
 import com.swmansion.enriched.markdown.utils.common.TableStreamingMode
+import com.swmansion.enriched.markdown.utils.common.applyReactBorderProps
 import com.swmansion.enriched.markdown.utils.common.emitCodeBlockPress
 import com.swmansion.enriched.markdown.utils.common.emitContextMenuItemPress
 import com.swmansion.enriched.markdown.utils.common.emitCopyPress
@@ -81,6 +82,17 @@ class EnrichedMarkdownManager :
   override fun onAfterUpdateTransaction(view: EnrichedMarkdown) {
     super.onAfterUpdateTransaction(view)
     view.commitProps()
+  }
+
+  // BaseViewManagerDelegate does not apply borderWidth / borderColor / borderRadius
+  // to a SimpleViewManager (see applyReactBorderProps), so `containerStyle` borders
+  // are dropped on Android. Replay them after the delegate has run.
+  override fun updateProperties(
+    view: EnrichedMarkdown,
+    props: ReactStylesDiffMap,
+  ) {
+    super.updateProperties(view, props)
+    applyReactBorderProps(view, props)
   }
 
   override fun updateState(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -83,9 +83,7 @@ class EnrichedMarkdownTextManager :
     view.commitProps()
   }
 
-  // BaseViewManagerDelegate does not apply borderWidth / borderColor / borderRadius
-  // to a SimpleViewManager (see applyReactBorderProps), so `containerStyle` borders
-  // are dropped on Android. Replay them after the delegate has run.
+  // Replay containerStyle border props the delegate drops (see applyReactBorderProps).
   override fun updateProperties(
     view: EnrichedMarkdownText,
     props: ReactStylesDiffMap,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/EnrichedMarkdownTextManager.kt
@@ -14,6 +14,7 @@ import com.facebook.react.viewmanagers.EnrichedMarkdownTextManagerDelegate
 import com.facebook.react.viewmanagers.EnrichedMarkdownTextManagerInterface
 import com.facebook.yoga.YogaMeasureMode
 import com.swmansion.enriched.markdown.spoiler.SpoilerOverlay
+import com.swmansion.enriched.markdown.utils.common.applyReactBorderProps
 import com.swmansion.enriched.markdown.utils.common.emitContextMenuItemPress
 import com.swmansion.enriched.markdown.utils.common.emitLatexError
 import com.swmansion.enriched.markdown.utils.common.emitLinkLongPress
@@ -80,6 +81,17 @@ class EnrichedMarkdownTextManager :
   override fun onAfterUpdateTransaction(view: EnrichedMarkdownText) {
     super.onAfterUpdateTransaction(view)
     view.commitProps()
+  }
+
+  // BaseViewManagerDelegate does not apply borderWidth / borderColor / borderRadius
+  // to a SimpleViewManager (see applyReactBorderProps), so `containerStyle` borders
+  // are dropped on Android. Replay them after the delegate has run.
+  override fun updateProperties(
+    view: EnrichedMarkdownText,
+    props: ReactStylesDiffMap,
+  ) {
+    super.updateProperties(view, props)
+    applyReactBorderProps(view, props)
   }
 
   override fun updateState(

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -764,22 +764,12 @@ object MeasurementStore {
     if (visibleLineCount <= 0) return 0f
     val lastLine = visibleLineCount - 1
     val bottom = layout.getLineBottom(lastLine).toFloat()
-    return (bottom - leakedTrailingMargin(layout, lastLine, text)).coerceAtLeast(0f)
+    return (bottom - measureLeakedTrailingMargin(layout, lastLine, text)).coerceAtLeast(0f)
   }
 
-  /**
-   * When a clamp truncates mid-paragraph, Android extends the last visible line to
-   * absorb the rest of that paragraph, including its trailing MarginBottomSpan spacer
-   * (paragraph spacing rides on the '\n' that terminates the paragraph). That block
-   * marginBottom is then baked into the truncated line's descent, leaving a phantom
-   * gap below the text - iOS never reaches a truncated paragraph's trailing spacing.
-   * This returns the margin that leaked onto [lastLine] so callers can subtract it.
-   * Only the spacer at the very end of the line whose paragraph still has content
-   * after it counts (mirrors MarginBottomSpan's own rule); the final block's spacer
-   * has no content after and never contributes, so a non-truncated last line is
-   * unaffected.
-   */
-  private fun leakedTrailingMargin(
+  // When we clamp the text mid-paragraph, drop the trailing block margin that Android
+  // bakes into the truncated last line (only when content follows, like MarginBottomSpan).
+  private fun measureLeakedTrailingMargin(
     layout: StaticLayout,
     lastLine: Int,
     text: CharSequence,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/MeasurementStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Typeface
 import android.os.Build
 import android.text.SpannableString
+import android.text.Spanned
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.text.TextUtils.TruncateAt
@@ -21,6 +22,7 @@ import com.swmansion.enriched.markdown.segments.MarkdownSegmentRenderer
 import com.swmansion.enriched.markdown.segments.RenderedSegment
 import com.swmansion.enriched.markdown.segments.TableContainerView
 import com.swmansion.enriched.markdown.segments.splitASTIntoSegments
+import com.swmansion.enriched.markdown.spans.MarginBottomSpan
 import com.swmansion.enriched.markdown.spans.MathMeasureRequest
 import com.swmansion.enriched.markdown.spans.MathMetrics
 import com.swmansion.enriched.markdown.spans.MathRenderMode
@@ -723,7 +725,7 @@ object MeasurementStore {
 
     val layout = builder.build()
     val visibleLineCount = visibleLineCount(layout, viewId)
-    val measuredHeight = truncatedHeight(layout, visibleLineCount)
+    val measuredHeight = truncatedHeight(layout, visibleLineCount, content)
 
     // Calculate actual content width (widest visible line)
     val measuredWidth = (0 until visibleLineCount).maxOfOrNull { layout.getLineWidth(it) } ?: 0f
@@ -757,7 +759,55 @@ object MeasurementStore {
   private fun truncatedHeight(
     layout: StaticLayout,
     visibleLineCount: Int,
-  ): Float = if (visibleLineCount <= 0) 0f else layout.getLineBottom(visibleLineCount - 1).toFloat()
+    text: CharSequence,
+  ): Float {
+    if (visibleLineCount <= 0) return 0f
+    val lastLine = visibleLineCount - 1
+    val bottom = layout.getLineBottom(lastLine).toFloat()
+    return (bottom - leakedTrailingMargin(layout, lastLine, text)).coerceAtLeast(0f)
+  }
+
+  /**
+   * When a clamp truncates mid-paragraph, Android extends the last visible line to
+   * absorb the rest of that paragraph, including its trailing MarginBottomSpan spacer
+   * (paragraph spacing rides on the '\n' that terminates the paragraph). That block
+   * marginBottom is then baked into the truncated line's descent, leaving a phantom
+   * gap below the text - iOS never reaches a truncated paragraph's trailing spacing.
+   * This returns the margin that leaked onto [lastLine] so callers can subtract it.
+   * Only the spacer at the very end of the line whose paragraph still has content
+   * after it counts (mirrors MarginBottomSpan's own rule); the final block's spacer
+   * has no content after and never contributes, so a non-truncated last line is
+   * unaffected.
+   */
+  private fun leakedTrailingMargin(
+    layout: StaticLayout,
+    lastLine: Int,
+    text: CharSequence,
+  ): Float {
+    val spanned = text as? Spanned ?: return 0f
+    val lineStart = layout.getLineStart(lastLine)
+    val lineEnd = layout.getLineEnd(lastLine)
+    if (lineEnd <= lineStart || lineEnd < 1 || text[lineEnd - 1] != '\n') return 0f
+    if (!hasContentAfter(text, lineEnd)) return 0f
+    val trailing =
+      spanned
+        .getSpans(lineStart, lineEnd, MarginBottomSpan::class.java)
+        .firstOrNull { spanned.getSpanEnd(it) == lineEnd } ?: return 0f
+    return trailing.marginBottom.toInt().toFloat()
+  }
+
+  private fun hasContentAfter(
+    text: CharSequence,
+    pos: Int,
+  ): Boolean {
+    if (pos >= text.length) return false
+    if (text[pos] == '\n') {
+      val nextPos = pos + 1
+      if (nextPos >= text.length) return false
+      return text[nextPos] != '\n'
+    }
+    return true
+  }
 
   /**
    * Measures text and returns both the size and the layout for calculating last line descent.
@@ -798,7 +848,7 @@ object MeasurementStore {
     val size =
       YogaMeasureOutput.make(
         PixelUtil.toDIPFromPixel(ceil(maxLineWidth)),
-        PixelUtil.toDIPFromPixel(truncatedHeight(layout, visibleLineCount)),
+        PixelUtil.toDIPFromPixel(truncatedHeight(layout, visibleLineCount, content)),
       )
 
     return size to layout

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/BorderStyleUtils.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/BorderStyleUtils.kt
@@ -1,0 +1,91 @@
+package com.swmansion.enriched.markdown.utils.common
+
+import android.view.View
+import com.facebook.react.bridge.ColorPropConverter
+import com.facebook.react.uimanager.BackgroundStyleApplicator
+import com.facebook.react.uimanager.LengthPercentage
+import com.facebook.react.uimanager.ReactStylesDiffMap
+import com.facebook.react.uimanager.style.BorderRadiusProp
+import com.facebook.react.uimanager.style.BorderStyle
+import com.facebook.react.uimanager.style.LogicalEdge
+
+// The markdown view managers are SimpleViewManagers, so the codegen
+// ViewManagerDelegate routes every prop through BaseViewManagerDelegate. That
+// delegate has no case for borderWidth / borderColor / borderStyle, and its
+// borderRadius case forwards to BaseViewManager.setBorderRadius - a no-op that only
+// logs an "unsupported property" warning. Those props are implemented only on
+// ReactViewManager / ReactTextViewManager. So a `containerStyle` border was
+// dropped entirely on Android (no stroke, square corners) while iOS rendered it.
+// applyReactBorderProps replays those props onto the view via
+// BackgroundStyleApplicator, exactly the way ReactViewManager /
+// ReactTextViewManager do. Call it after super.updateProperties so the delegate
+// has already created the composite background drawable.
+fun applyReactBorderProps(
+  view: View,
+  props: ReactStylesDiffMap,
+) {
+  for ((name, edge) in BORDER_WIDTH_EDGES) {
+    if (!props.hasKey(name)) continue
+    val width = if (props.isNull(name)) null else props.getFloat(name, Float.NaN).takeUnless { it.isNaN() }
+    BackgroundStyleApplicator.setBorderWidth(view, edge, width)
+  }
+
+  if (BORDER_COLOR_EDGES.keys.any { props.hasKey(it) }) {
+    val rawProps = props.toMap()
+    for ((name, edge) in BORDER_COLOR_EDGES) {
+      if (!props.hasKey(name)) continue
+      val color = if (props.isNull(name)) null else ColorPropConverter.getColor(rawProps[name], view.context)
+      BackgroundStyleApplicator.setBorderColor(view, edge, color)
+    }
+  }
+
+  if (props.hasKey("borderStyle")) {
+    val style = if (props.isNull("borderStyle")) null else BorderStyle.fromString(props.getString("borderStyle") ?: "")
+    BackgroundStyleApplicator.setBorderStyle(view, style)
+  }
+
+  // Radius last, so the border drawable created above already exists and picks
+  // up the rounded corners.
+  for ((name, corner) in BORDER_RADIUS_PROPS) {
+    if (!props.hasKey(name)) continue
+    val radius = if (props.isNull(name)) null else LengthPercentage.setFromDynamic(props.getDynamic(name))
+    BackgroundStyleApplicator.setBorderRadius(view, corner, radius)
+  }
+}
+
+private val BORDER_WIDTH_EDGES =
+  linkedMapOf(
+    "borderWidth" to LogicalEdge.ALL,
+    "borderLeftWidth" to LogicalEdge.LEFT,
+    "borderRightWidth" to LogicalEdge.RIGHT,
+    "borderTopWidth" to LogicalEdge.TOP,
+    "borderBottomWidth" to LogicalEdge.BOTTOM,
+    "borderStartWidth" to LogicalEdge.START,
+    "borderEndWidth" to LogicalEdge.END,
+  )
+
+private val BORDER_COLOR_EDGES =
+  linkedMapOf(
+    "borderColor" to LogicalEdge.ALL,
+    "borderLeftColor" to LogicalEdge.LEFT,
+    "borderRightColor" to LogicalEdge.RIGHT,
+    "borderTopColor" to LogicalEdge.TOP,
+    "borderBottomColor" to LogicalEdge.BOTTOM,
+  )
+
+private val BORDER_RADIUS_PROPS =
+  linkedMapOf(
+    "borderRadius" to BorderRadiusProp.BORDER_RADIUS,
+    "borderTopLeftRadius" to BorderRadiusProp.BORDER_TOP_LEFT_RADIUS,
+    "borderTopRightRadius" to BorderRadiusProp.BORDER_TOP_RIGHT_RADIUS,
+    "borderBottomRightRadius" to BorderRadiusProp.BORDER_BOTTOM_RIGHT_RADIUS,
+    "borderBottomLeftRadius" to BorderRadiusProp.BORDER_BOTTOM_LEFT_RADIUS,
+    "borderTopStartRadius" to BorderRadiusProp.BORDER_TOP_START_RADIUS,
+    "borderTopEndRadius" to BorderRadiusProp.BORDER_TOP_END_RADIUS,
+    "borderBottomStartRadius" to BorderRadiusProp.BORDER_BOTTOM_START_RADIUS,
+    "borderBottomEndRadius" to BorderRadiusProp.BORDER_BOTTOM_END_RADIUS,
+    "borderEndEndRadius" to BorderRadiusProp.BORDER_END_END_RADIUS,
+    "borderEndStartRadius" to BorderRadiusProp.BORDER_END_START_RADIUS,
+    "borderStartEndRadius" to BorderRadiusProp.BORDER_START_END_RADIUS,
+    "borderStartStartRadius" to BorderRadiusProp.BORDER_START_START_RADIUS,
+  )

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/BorderStyleUtils.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/BorderStyleUtils.kt
@@ -9,17 +9,10 @@ import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.uimanager.style.BorderStyle
 import com.facebook.react.uimanager.style.LogicalEdge
 
-// The markdown view managers are SimpleViewManagers, so the codegen
-// ViewManagerDelegate routes every prop through BaseViewManagerDelegate. That
-// delegate has no case for borderWidth / borderColor / borderStyle, and its
-// borderRadius case forwards to BaseViewManager.setBorderRadius - a no-op that only
-// logs an "unsupported property" warning. Those props are implemented only on
-// ReactViewManager / ReactTextViewManager. So a `containerStyle` border was
-// dropped entirely on Android (no stroke, square corners) while iOS rendered it.
-// applyReactBorderProps replays those props onto the view via
-// BackgroundStyleApplicator, exactly the way ReactViewManager /
-// ReactTextViewManager do. Call it after super.updateProperties so the delegate
-// has already created the composite background drawable.
+// BaseViewManagerDelegate (used by our SimpleViewManagers) ignores border
+// width/color/style and no-ops borderRadius, so `containerStyle` borders vanish on
+// Android. Replay them via BackgroundStyleApplicator like ReactViewManager does.
+// Call after super.updateProperties so the composite background drawable exists.
 fun applyReactBorderProps(
   view: View,
   props: ReactStylesDiffMap,

--- a/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/BorderStyleUtils.kt
+++ b/packages/react-native-enriched-markdown/android/src/main/java/com/swmansion/enriched/markdown/utils/common/BorderStyleUtils.kt
@@ -64,6 +64,8 @@ private val BORDER_COLOR_EDGES =
     "borderRightColor" to LogicalEdge.RIGHT,
     "borderTopColor" to LogicalEdge.TOP,
     "borderBottomColor" to LogicalEdge.BOTTOM,
+    "borderStartColor" to LogicalEdge.START,
+    "borderEndColor" to LogicalEdge.END,
   )
 
 private val BORDER_RADIUS_PROPS =


### PR DESCRIPTION
### What/Why?

Two Android-only fixes for the `numberOfLines` container, both of which iOS already got right:

1. **`containerStyle` border was invisible.** `EnrichedMarkdownText` / `EnrichedMarkdown` are `SimpleViewManager`s, so `BaseViewManagerDelegate` never applies `borderWidth` / `borderColor` / `borderStyle` and no-ops `borderRadius`. A shared `applyReactBorderProps` helper now replays them via `BackgroundStyleApplicator` (used by both the CommonMark and GFM managers).
2. **Clamped box had a phantom bottom gap.** When `numberOfLines` truncates mid-paragraph, Android bakes the paragraph's trailing `marginBottom` into the clamped last line. We now strip that leaked margin so the box hugs its content.

### Testing

Example app -> `EnrichedMarkdownText/Props/Number Of Lines`. Verified on Android (API 36) across numberOfLines 0/1/2/4/5: the border + rounded corners render, and the clamped box has no trailing gap.

| Before | After |
| - | - |
| <video src="https://github.com/user-attachments/assets/f9898bd0-fcd0-48a1-9db8-afba4aeb2855" width=300 /> | <video src="https://github.com/user-attachments/assets/4877ba29-6c1c-41a4-9dd0-e81f3f1cfd25" width=300 /> |

### PR Checklist

- [x] Code compiles and runs on iOS
- [x] Code compiles and runs on Android
- [x] Updated documentation/README if applicable
- [x] Ran example app to verify changes
- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
