### PR TITLE
fix(ios): replace 3-member tuple with struct to fix large_tuple lint violation

### DIFF
--- a/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
+++ b/packages/enriched-markdown-ios/Sources/EnrichedMarkdown/Views/MarkdownTextViewRepresentable.swift
@@ -228,9 +228,15 @@ final class MarkdownTextView: UITextView {
     /// document. This can.
     private var renderedText: NSAttributedString?
 
+    private struct CachedFit {
+        let width: CGFloat
+        let text: NSAttributedString
+        let height: CGFloat
+    }
+
     /// Measuring lays out the whole document, and SwiftUI asks for it on every
     /// update pass — and again through `intrinsicContentSize`.
-    private var cachedFit: (width: CGFloat, text: NSAttributedString, height: CGFloat)?
+    private var cachedFit: CachedFit?
 
     /// Mirrored from the representable so VoiceOver link elements can invoke
     /// the press handler via accessibilityActivate.
@@ -439,7 +445,7 @@ final class MarkdownTextView: UITextView {
         }
         let fitted = super.sizeThatFits(size)
         if let renderedText {
-            cachedFit = (size.width, renderedText, fitted.height)
+            cachedFit = CachedFit(width: size.width, text: renderedText, height: fitted.height)
         }
         return fitted
     }


### PR DESCRIPTION
## Summary

SwiftLint's `large_tuple` rule (max 2 members) flagged the `cachedFit` tuple in `MarkdownTextViewRepresentable.swift:233`.

## Fix

Replace the 3-member tuple with a private `CachedFit` struct nested inside `MarkdownTextView` — same fields, same semantics, zero behavioral change.

## Verification

- ✅ `xcodebuild build` succeeds (iOS Simulator)
- ✅ All read/write/invalidation sites use identical logic

Made with [Cursor](https://cursor.com)