### PR TITLE
fix(macos): use UIFontLineHeight for code block line height calculation

### DIFF
--- a/packages/react-native-enriched-markdown/ios/segments/ENRMCodeBlockContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/segments/ENRMCodeBlockContainerView.m
@@ -43,7 +43,7 @@ static UIFont *ENRMCodeBlockHeaderFont(StyleConfig *config)
 
 static CGFloat ENRMCodeBlockHeaderLabelLineHeight(UIFont *headerFont)
 {
-  return ceil(headerFont.lineHeight);
+  return ceil(UIFontLineHeight(headerFont));
 }
 #else
 static NSFont *ENRMCodeBlockHeaderFont(StyleConfig *config)
@@ -53,7 +53,7 @@ static NSFont *ENRMCodeBlockHeaderFont(StyleConfig *config)
 
 static CGFloat ENRMCodeBlockHeaderLabelLineHeight(NSFont *headerFont)
 {
-  return ceil(headerFont.ascender - headerFont.descender);
+  return ceil(UIFontLineHeight(headerFont));
 }
 #endif
 
@@ -73,7 +73,7 @@ static NSAttributedString *ENRMCodeBlockPlainAttributedCode(NSString *code, Styl
 static CGFloat ENRMCodeBlockPerLineHeight(StyleConfig *config)
 {
   CGFloat lineHeight = [config codeBlockLineHeight];
-  return lineHeight > 0 ? lineHeight : ceil([config codeBlockFont].lineHeight);
+  return lineHeight > 0 ? lineHeight : ceil(UIFontLineHeight([config codeBlockFont]));
 }
 
 // Analytic code height: lines never wrap and each fragment is a fixed height, so


### PR DESCRIPTION
## Summary

`ENRMCodeBlockPerLineHeight` called `.lineHeight` on the font object, which does not exist on `NSFont` (macOS), breaking the macOS build with:

> Property 'lineHeight' not found on object of type 'NSFont *'

## Fix

Replace raw `.lineHeight` / manual `ascender - descender` with `UIFontLineHeight()` which is already defined cross-platform:
- **iOS** (`ENRMUIKit.h`): returns `font.lineHeight`
- **macOS** (`RCTUIKit.h`): returns `ascender + |descender| + leading`

Also unifies the existing `ENRMCodeBlockHeaderLabelLineHeight` to use the same helper, removing duplicated platform-specific logic.

## Changes

- `ENRMCodeBlockContainerView.m`: 3 call sites updated to use `UIFontLineHeight()`

## No iOS regressions

On iOS, `UIFontLineHeight(font)` is a trivial inline that returns `font.lineHeight` — identical to the previous code.

Made with [Cursor](https://cursor.com)