### PR TITLE
feat: add macOS video playback support

### DIFF
--- a/apps/react-native-macos-example/src/sampleMarkdown.ts
+++ b/apps/react-native-macos-example/src/sampleMarkdown.ts
@@ -7,6 +7,12 @@ Forests cover approximately **31% of the Earth's land surface**, providing habit
 
 ![Misty forest at sunrise](https://images.unsplash.com/photo-1448375240586-882707db888b?w=800)
 
+## Forest in Motion
+
+A short nature clip — press play to watch:
+
+<video src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"></video>
+
 ## Why Forests Matter
 
 Forests are often called the *lungs of the Earth*. They absorb **carbon dioxide** and release oxygen through photosynthesis — a process essential for all life on our planet. A single mature tree can absorb up to \`48 pounds\` of CO₂ per year.

--- a/docs/MACOS.md
+++ b/docs/MACOS.md
@@ -2,13 +2,12 @@
 
 `react-native-enriched-markdown` supports macOS via [react-native-macos](https://github.com/microsoft/react-native-macos). The native layer shares code with iOS through a platform abstraction header (`ENRMUIKit.h`), with macOS-specific implementations for context menus, text selection, and clipboard handling.
 
-The macOS implementation supports the same rendering elements as iOS — CommonMark, GitHub Flavored Markdown (tables, task lists, strikethrough), images, code blocks, blockquotes, and all other supported elements. `EnrichedMarkdownTextInput` is also available on macOS with full support for inline styles, links, and the native context menu.
+The macOS implementation supports the same rendering elements as iOS — CommonMark, GitHub Flavored Markdown (tables, task lists, strikethrough), images, code blocks, blockquotes, video playback, and all other supported elements. `EnrichedMarkdownTextInput` is also available on macOS with full support for inline styles, links, and the native context menu.
 
 ## Known limitations
 
 These will be addressed in upcoming releases:
 
-- **Video playback** is not yet available on macOS. The native `AVPlayerView` integration will be added in a future release.
 - **LaTeX math** (both inline and block) is not available on macOS. The math engine (RaTeX) is distributed as a Swift Package, which requires `use_frameworks!` in CocoaPods. `react-native-macos` does not currently support `use_frameworks!` due to circular dependencies between `React-Core` and `React-RCTText` ([microsoft/react-native-macos#1969](https://github.com/microsoft/react-native-macos/issues/1969)). Math will be enabled once this upstream issue is resolved.
 - **Tail fade-in animation** falls back to instant reveal (no `CADisplayLink` on macOS)
 - **VoiceOver** accessibility is stubbed (pending `NSAccessibility` implementation)

--- a/packages/react-native-enriched-markdown/ios/segments/ENRMVideoContainerView.m
+++ b/packages/react-native-enriched-markdown/ios/segments/ENRMVideoContainerView.m
@@ -6,6 +6,9 @@
 #import "MarkdownASTNode.h"
 #import "PasteboardUtils.h"
 #import <AVKit/AVKit.h>
+#if TARGET_OS_OSX
+#import "ENRMMenuAction.h"
+#endif
 
 static const CGFloat kDefaultVideoAspectRatio = 16.0 / 9.0;
 
@@ -14,6 +17,8 @@ static inline CGFloat ENRMVideoAspectRatio(StyleConfig *config)
   CGFloat aspectRatio = [config videoAspectRatio];
   return aspectRatio > 0 ? aspectRatio : kDefaultVideoAspectRatio;
 }
+
+#if !TARGET_OS_OSX
 
 // A thin wrapper VC that hosts AVPlayerViewController as a child with correct
 // containment. RNSScreen (react-native-screens) overrides
@@ -57,9 +62,43 @@ static inline CGFloat ENRMVideoAspectRatio(StyleConfig *config)
 
 @end
 
+#endif // !TARGET_OS_OSX
+
+// ===== iOS implementation =====
+
+#if !TARGET_OS_OSX
+
+static RCTUIView *ENRMCreatePlayIconOverlay(void)
+{
+  CGFloat size = 52;
+  RCTUIView *circle = [[RCTUIView alloc] initWithFrame:CGRectMake(0, 0, size, size)];
+  circle.userInteractionEnabled = NO;
+  circle.layer.backgroundColor = [RCTUIColor colorWithWhite:0 alpha:0.5].CGColor;
+  circle.layer.cornerRadius = size / 2.0;
+
+  CGFloat inset = size * 0.3;
+  CGFloat triLeft = inset + size * 0.04;
+  CGFloat triTop = inset - size * 0.04;
+  CGFloat triRight = size - inset + size * 0.04;
+  CGFloat triMid = size / 2.0;
+
+  UIBezierPath *triangle = [UIBezierPath bezierPath];
+  [triangle moveToPoint:CGPointMake(triLeft, triTop)];
+  BezierPathAddLine(triangle, CGPointMake(triRight, triMid));
+  BezierPathAddLine(triangle, CGPointMake(triLeft, size - triTop));
+  [triangle closePath];
+
+  CAShapeLayer *triLayer = [CAShapeLayer layer];
+  triLayer.path = triangle.CGPath;
+  triLayer.fillColor = [RCTUIColor whiteColor].CGColor;
+  [circle.layer addSublayer:triLayer];
+
+  return circle;
+}
+
 @implementation ENRMVideoContainerView {
   ENRMVideoHostController *_hostController;
-  UIView *_playIconOverlay;
+  RCTUIView *_playIconOverlay;
   NSString *_currentURL;
   BOOL _hostInstalled;
   BOOL _hasBeenTapped;
@@ -77,44 +116,14 @@ static inline CGFloat ENRMVideoAspectRatio(StyleConfig *config)
     [_hostController applyCornerRadius:[config videoBorderRadius] backgroundColor:[config videoBackgroundColor]];
     [self addSubview:_hostController.view];
 
-    _playIconOverlay = [ENRMVideoContainerView createPlayIconOverlay];
+    _playIconOverlay = ENRMCreatePlayIconOverlay();
     _playIconOverlay.userInteractionEnabled = NO;
     [self addSubview:_playIconOverlay];
 
-#if !TARGET_OS_OSX
     UIContextMenuInteraction *contextMenu = [[UIContextMenuInteraction alloc] initWithDelegate:self];
     [_hostController.view addInteraction:contextMenu];
-#endif
   }
   return self;
-}
-
-+ (UIView *)createPlayIconOverlay
-{
-  CGFloat size = 52;
-  UIView *circle = [[UIView alloc] initWithFrame:CGRectMake(0, 0, size, size)];
-  circle.backgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
-  circle.layer.cornerRadius = size / 2.0;
-  circle.userInteractionEnabled = NO;
-
-  CGFloat inset = size * 0.3;
-  CGFloat triLeft = inset + size * 0.04;
-  CGFloat triTop = inset - size * 0.04;
-  CGFloat triRight = size - inset + size * 0.04;
-  CGFloat triMid = size / 2.0;
-
-  UIBezierPath *triangle = [UIBezierPath bezierPath];
-  [triangle moveToPoint:CGPointMake(triLeft, triTop)];
-  [triangle addLineToPoint:CGPointMake(triRight, triMid)];
-  [triangle addLineToPoint:CGPointMake(triLeft, size - triTop)];
-  [triangle closePath];
-
-  CAShapeLayer *triLayer = [CAShapeLayer layer];
-  triLayer.path = triangle.CGPath;
-  triLayer.fillColor = [UIColor whiteColor].CGColor;
-  [circle.layer addSublayer:triLayer];
-
-  return circle;
 }
 
 #pragma mark - Touch Forwarding
@@ -243,7 +252,6 @@ static inline CGFloat ENRMVideoAspectRatio(StyleConfig *config)
   }
 }
 
-#if !TARGET_OS_OSX
 - (UIContextMenuConfiguration *)contextMenuInteraction:(UIContextMenuInteraction *)interaction
                         configurationForMenuAtLocation:(CGPoint)location
 {
@@ -269,7 +277,6 @@ static inline CGFloat ENRMVideoAspectRatio(StyleConfig *config)
                      return [UIMenu menuWithTitle:@"" children:@[ copyURL, copyMarkdown ]];
                    }];
 }
-#endif
 
 #pragma mark - Cleanup
 
@@ -285,4 +292,130 @@ static inline CGFloat ENRMVideoAspectRatio(StyleConfig *config)
 
 @end
 
-#endif
+#else // TARGET_OS_OSX
+
+// ===== macOS implementation =====
+
+@implementation ENRMVideoContainerView {
+  AVPlayerView *_playerView;
+  NSString *_currentURL;
+}
+
+- (instancetype)initWithConfig:(StyleConfig *)config
+{
+  if (self = [super init]) {
+    _config = config;
+    _enableBlockContextMenu = YES;
+    self.wantsLayer = YES;
+
+    _playerView = [[AVPlayerView alloc] init];
+    _playerView.controlsStyle = AVPlayerViewControlsStyleInline;
+    _playerView.wantsLayer = YES;
+    _playerView.layer.masksToBounds = YES;
+    _playerView.layer.cornerRadius = [config videoBorderRadius];
+    _playerView.layer.backgroundColor = ([config videoBackgroundColor] ?: [NSColor blackColor]).CGColor;
+    [self addSubview:_playerView];
+  }
+  return self;
+}
+
+- (BOOL)isFlipped
+{
+  return YES;
+}
+
+#pragma mark - Style Updates
+
+- (void)reapplyStyle
+{
+  _playerView.layer.cornerRadius = [_config videoBorderRadius];
+  _playerView.layer.backgroundColor = ([_config videoBackgroundColor] ?: [NSColor blackColor]).CGColor;
+}
+
+#pragma mark - Video Loading
+
+- (void)applyVideoNode:(MarkdownASTNode *)node
+{
+  NSString *url = [node.attributes objectForKey:@"url"];
+  if (!url || [url isEqualToString:_currentURL]) {
+    return;
+  }
+  _currentURL = [url copy];
+
+  [_playerView.player pause];
+
+  NSURL *videoURL = [NSURL URLWithString:url];
+  if (!videoURL) {
+    _playerView.player = nil;
+    return;
+  }
+
+  _playerView.player = [AVPlayer playerWithURL:videoURL];
+}
+
+#pragma mark - Layout & Measurement
+
+- (void)layout
+{
+  [super layout];
+  _playerView.frame = self.bounds;
+}
+
+- (CGFloat)measureHeight:(CGFloat)maxWidth
+{
+  return maxWidth / ENRMVideoAspectRatio(_config);
+}
+
++ (CGFloat)measureHeightForVideoNode:(__unused MarkdownASTNode *)node
+                              config:(StyleConfig *)config
+                            maxWidth:(CGFloat)maxWidth
+{
+  return maxWidth / ENRMVideoAspectRatio(config);
+}
+
+#pragma mark - Context Menu
+
+- (void)copyURLToPasteboard
+{
+  if (_currentURL.length > 0) {
+    copyStringToPasteboard(_currentURL);
+  }
+}
+
+- (void)copyMarkdownToPasteboard
+{
+  if (_currentURL.length > 0) {
+    NSString *markdown;
+    if ([_currentURL containsString:@"\""]) {
+      markdown = [NSString stringWithFormat:@"<video src='%@' />", _currentURL];
+    } else {
+      markdown = [NSString stringWithFormat:@"<video src=\"%@\" />", _currentURL];
+    }
+    copyStringToPasteboard(markdown);
+  }
+}
+
+- (NSMenu *)menuForEvent:(NSEvent *)event
+{
+  if (!_enableBlockContextMenu || _currentURL.length == 0) {
+    return [super menuForEvent:event];
+  }
+  NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
+  [menu addItem:ENRMCreateMenuItem(self.copyLabel, ^{ [self copyURLToPasteboard]; })];
+  [menu addItem:ENRMCreateMenuItem(self.copyAsMarkdownLabel, ^{ [self copyMarkdownToPasteboard]; })];
+  return menu;
+}
+
+#pragma mark - Cleanup
+
+- (void)dealloc
+{
+  [_playerView.player pause];
+  _playerView.player = nil;
+}
+
+@end
+
+#endif // TARGET_OS_OSX
+
+#endif // ENRICHED_MARKDOWN_VIDEO

--- a/packages/react-native-enriched-markdown/ios/utils/ENRMFeatureFlags.h
+++ b/packages/react-native-enriched-markdown/ios/utils/ENRMFeatureFlags.h
@@ -18,13 +18,8 @@
 #define ENRICHED_MARKDOWN_CODE_HIGHLIGHT 0
 #endif
 
-// Video playback support. Uses AVKit (built into iOS — no external framework),
-// so the flag gates only the container view code itself.
-// Not yet supported on macOS — force off regardless of podspec.
+// Video playback support. Uses AVKit (built into both iOS and macOS — no
+// external framework), so the flag gates only the container view code itself.
 #if !defined(ENRICHED_MARKDOWN_VIDEO)
-#define ENRICHED_MARKDOWN_VIDEO 0
-#endif
-#if ENRICHED_MARKDOWN_VIDEO && TARGET_OS_OSX
-#undef ENRICHED_MARKDOWN_VIDEO
 #define ENRICHED_MARKDOWN_VIDEO 0
 #endif


### PR DESCRIPTION
## Summary

Adds native video playback support on macOS, closing the last major feature gap documented in `MACOS.md`.

## Changes

### `ENRMVideoContainerView.m`
- **macOS implementation** using `AVPlayerView` with `AVPlayerViewControlsStyleInline` (persistent play/pause/scrubber bar)
- **iOS implementation** unchanged in behavior — only reorganized into a dedicated `#if !TARGET_OS_OSX` block
- Play icon overlay moved into the iOS-only block (macOS uses native `AVPlayerView` controls)
- Overlay refactored to use cross-platform `BezierPathAddLine()` helper and layer-based APIs
- macOS right-click context menu via `menuForEvent:` + `ENRMCreateMenuItem` (same pattern as blockquote, math, and table views)
- `isFlipped` returns `YES` for React Native coordinate system compatibility

### `ENRMFeatureFlags.h`
- Removed the `TARGET_OS_OSX` force-disable guard that prevented video compilation on macOS

### `MACOS.md`
- Added "video playback" to the supported features list
- Removed "Video playback is not yet available" from Known limitations

### `sampleMarkdown.ts` (macOS example app)
- Added a "Forest in Motion" section with a `<video>` tag for testing

## Architecture notes

The iOS and macOS implementations use **separate `@implementation` blocks** rather than inline `#if` guards. This is intentional — the two platforms share almost no structural code:
- iOS: `AVPlayerViewController` + `ENRMVideoHostController` containment + custom `hitTest:` forwarding + play icon overlay
- macOS: `AVPlayerView` directly as subview — no VC containment, no overlay, no hit-test override

No changes were needed in `EnrichedMarkdown.mm`, `ENRMBlockquoteContainerView.mm`, `ENRMSegmentHeightMeasurer.mm`, or any other propagation files — all video call sites were already gated by `#if ENRICHED_MARKDOWN_VIDEO` (not `!TARGET_OS_OSX`).

## Test plan
- [x] macOS example app renders video with inline controls (play/pause/scrubber visible)
- [x] Right-click context menu shows "Copy URL" and "Copy as Markdown"
- [x] iOS example app unchanged — play icon overlay, context menu, VC containment all work as before

Made with [Cursor](https://cursor.com)